### PR TITLE
feat(form): Add PageTwo and refactor layout structure

### DIFF
--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -1,0 +1,39 @@
+name: Flutter Build
+
+on:
+  push:
+    branches: [ main, master ] # or your main branch
+  pull_request:
+    branches: [ main, master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.22.0' # or whatever version you're using
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Analyze project
+        run: flutter analyze
+
+      - name: Run tests
+        run: flutter test
+
+      - name: Build APK
+        run: flutter build apk --release
+
+      # Optional: Upload the APK as an artifact
+      - name: Upload APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-apk
+          path: build/app/outputs/flutter-apk/app-release.apk

--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.22.0' # or whatever version you're using
+          flutter-version: '3.29.3' # or whatever version you're using
 
       - name: Install dependencies
         run: flutter pub get

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 android {
     namespace = "com.example.form_app"
     compileSdk = flutter.compileSdkVersion
-    ndkVersion = flutter.ndkVersion
+    ndkVersion = "27.0.12077973"
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:form_app/pages/page_one.dart';
+import 'package:form_app/widgets/common_layout.dart'; // Import the new layout
 
 
 void main() {
@@ -17,7 +18,9 @@ class FormApp extends StatelessWidget {
       theme: ThemeData(),
 
       debugShowCheckedModeBanner: false,
-      home: PageOne(),
+      // Wrap PageOne with CommonLayout
+      // You can optionally pass a title here if needed for PageOne's AppBar
+      home: const CommonLayout(child: PageOne()),
     );
   }
 }

--- a/lib/pages/page_one.dart
+++ b/lib/pages/page_one.dart
@@ -1,5 +1,7 @@
+// page_one.dart
 import 'package:flutter/material.dart';
 import 'package:form_app/pages/page_two.dart';
+import 'package:form_app/widgets/common_layout.dart'; // Import CommonLayout
 import 'package:form_app/widgets/footer.dart';
 import 'package:form_app/widgets/labeled_date_field.dart';
 import 'package:form_app/widgets/navigation_button_row.dart';
@@ -19,82 +21,75 @@ class _PageOneState extends State<PageOne> {
   DateTime? _selectedDate;
 
   moveToNextPage() {
+    // Wrap the next page with CommonLayout as well
     Navigator.push(
       context,
       MaterialPageRoute(
-        builder: (context) => const PageTwo(), // Replace with your next page
+        builder: (context) => const CommonLayout(child: PageTwo()), // Wrap PageTwo
       ),
     );
   }
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: () {
-        FocusScope.of(
-          context,
-        ).unfocus(); // Dismiss the keyboard when tapping outside
-      },
-      child: Scaffold(
-        backgroundColor: Colors.white,
-        body: SafeArea(
-          // Main Column to structure the page with a sticky footer
-          child: Column(
-            children: [
-              // Expanded takes up available space, pushing footer down
-              Expanded(
-                child: Container(
-                  margin: const EdgeInsets.all(16), // Keep the overall margin
-                  child: SingleChildScrollView(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        PageNumber(data: '1/9'),
-                        const SizedBox(height: 8.0),
-                        PageTitle(data: 'Identitas'),
-                        const SizedBox(height: 24.0),
-                        LabeledTextField(
-                          label: 'Nama Inspektor',
-                          hintText: 'Masukkan nama inspektor',
-                        ),
-                        const SizedBox(height: 16.0),
-                        LabeledTextField(
-                          label: 'Nama Customer',
-                          hintText: 'Masukkan nama customer',
-                        ),
-                        const SizedBox(height: 16.0),
-                        LabeledTextField(
-                          label: 'Cabang Inspeksi',
-                          hintText: 'Contoh: Yogyakarta / Semarang',
-                        ),
-                        const SizedBox(height: 16.0),
-                        LabeledDateField(
-                          label: 'Tanggal Inspeksi',
-                          hintText: 'Pilih tanggal inspeksi',
-                          initialDate: _selectedDate,
-                          onChanged: (date) {
-                            setState(() {
-                              _selectedDate = date;
-                            });
-                          },
-                        ),
-                        const SizedBox(height: 32.0),
-                        NavigationButtonRow(onNextPressed: moveToNextPage),
-                        // Removed Spacer() here
-                      ],
-                    ),
-                  ),
+    // Return the core content Column directly. Scaffold/SafeArea are in CommonLayout.
+    // The GestureDetector for unfocus is removed; can be added to CommonLayout if needed globally.
+    return Column( // This Column is now the root widget returned by PageOne's build method
+      children: [
+        // Expanded takes up available space, pushing footer down
+        Expanded(
+          // Removed the Container with margin, CommonLayout handles padding
+          child: SingleChildScrollView(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                PageNumber(data: '1/9'),
+                const SizedBox(height: 8.0),
+                PageTitle(data: 'Identitas'),
+                const SizedBox(height: 24.0), // Keep internal spacing
+                LabeledTextField(
+                  label: 'Nama Inspektor',
+                  hintText: 'Masukkan nama inspektor',
                 ),
-              ),
-              // Footer is placed outside Expanded, at the bottom of the main Column
-              Footer(),
-              // Add some padding below the footer if needed, e.g.,
-              // const SizedBox(height: 16.0),
-            ],
+                const SizedBox(height: 16.0), // Keep internal spacing
+                LabeledTextField(
+                  label: 'Nama Customer',
+                  hintText: 'Masukkan nama customer',
+                ),
+                const SizedBox(height: 16.0), // Keep internal spacing
+                LabeledTextField(
+                  label: 'Cabang Inspeksi',
+                  hintText: 'Contoh: Yogyakarta / Semarang',
+                ),
+                const SizedBox(height: 16.0), // Keep internal spacing
+                LabeledDateField(
+                  label: 'Tanggal Inspeksi',
+                  hintText: 'Pilih tanggal inspeksi',
+                  initialDate: _selectedDate,
+                  onChanged: (date) {
+                    setState(() {
+                      _selectedDate = date;
+                    });
+                  },
+                ),
+                const SizedBox(height: 32.0), // Keep internal spacing
+                // Pass isBackButtonEnabled: false for PageOne
+                NavigationButtonRow(
+                  onNextPressed: moveToNextPage,
+                  isBackButtonEnabled: false, // Hide back button on page 1
+                  // Add onBackPressed: null explicitly if needed, though it won't be used when hidden
+                  // onBackPressed: null,
+                ),
+              ],
+            ),
           ),
         ),
-      ),
+        SizedBox(height: 16.0), // Optional padding between content and footer
+        // Footer is placed outside Expanded, at the bottom of the main Column
+        Footer(),
+        // Add some padding below the footer if needed, e.g.,
+        // const SizedBox(height: 16.0),
+      ],
     );
   }
 }
-

--- a/lib/pages/page_three.dart
+++ b/lib/pages/page_three.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:form_app/widgets/navigation_button_row.dart';
+import 'package:form_app/widgets/page_number.dart';
+import 'package:form_app/widgets/page_title.dart';
+import 'package:form_app/widgets/footer.dart';
+// Import other necessary widgets like CommonLayout if you plan to use it here
+
+// Placeholder for Page Three
+class PageThree extends StatelessWidget {
+  const PageThree({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    // Basic structure, replace with actual content later
+    return Column(
+      children: [
+        Expanded(
+          child: SingleChildScrollView(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                PageNumber(data: '3/9'),
+                const SizedBox(height: 8.0),
+                PageTitle(data: 'Page Three Title'), // Placeholder Title
+                const SizedBox(height: 24.0),
+                const Center(child: Text('Page Three Content Goes Here')),
+                const SizedBox(height: 32.0),
+                NavigationButtonRow(
+                  onBackPressed: () => Navigator.pop(context),
+                  onNextPressed: () {
+                    // TODO: Implement navigation to Page Four
+                  },
+                ),
+              ],
+            ),
+          ),
+        ),
+        Footer(),
+      ],
+    );
+  }
+}

--- a/lib/pages/page_two.dart
+++ b/lib/pages/page_two.dart
@@ -1,4 +1,12 @@
 import 'package:flutter/material.dart';
+import 'package:form_app/pages/page_three.dart'; // Assuming PageThree exists or will be created
+import 'package:form_app/widgets/common_layout.dart';
+import 'package:form_app/widgets/footer.dart';
+import 'package:form_app/widgets/labeled_date_field.dart';
+import 'package:form_app/widgets/labeled_text_field.dart';
+import 'package:form_app/widgets/navigation_button_row.dart';
+import 'package:form_app/widgets/page_number.dart';
+import 'package:form_app/widgets/page_title.dart';
 
 class PageTwo extends StatefulWidget {
   const PageTwo({super.key});
@@ -8,8 +16,125 @@ class PageTwo extends StatefulWidget {
 }
 
 class _PageTwoState extends State<PageTwo> {
+  DateTime? _pajak1TahunDate;
+  DateTime? _pajak5TahunDate;
+
+  void moveToNextPage() {
+    // Navigate to Page Three, wrapped in CommonLayout
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (context) => const CommonLayout(child: PageThree()), // Wrap PageThree
+      ),
+    );
+  }
+
+  void moveToPreviousPage() {
+    Navigator.pop(context); // Simple pop to go back to the previous page (PageOne)
+  }
+
   @override
   Widget build(BuildContext context) {
-    return const Placeholder();
+    // Return the core content Column directly. Scaffold/SafeArea are in CommonLayout.
+    return Column(
+      children: [
+        Expanded(
+          child: SingleChildScrollView(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                PageNumber(data: '2/9'), // Updated Page Number
+                const SizedBox(height: 8.0),
+                PageTitle(data: 'Data Kendaraan'), // Updated Title
+                const SizedBox(height: 24.0),
+
+                // Input Fields based on user request
+                LabeledTextField(
+                  label: 'Merek Kendaraan',
+                  hintText: 'Masukkan merek kendaraan',
+                ),
+                const SizedBox(height: 16.0),
+                LabeledTextField(
+                  label: 'Tipe Kendaraan',
+                  hintText: 'Masukkan tipe kendaraan',
+                ),
+                const SizedBox(height: 16.0),
+                 LabeledTextField(
+                  label: 'Tahun',
+                  hintText: 'Masukkan tahun pembuatan',
+                  keyboardType: TextInputType.number, // Use number keyboard
+                ),
+                const SizedBox(height: 16.0),
+                LabeledTextField(
+                  label: 'Transmisi',
+                  hintText: 'Contoh: Otomatis / Manual',
+                ),
+                 const SizedBox(height: 16.0),
+                LabeledTextField(
+                  label: 'Warna Kendaraan',
+                  hintText: 'Masukkan warna kendaraan',
+                ),
+                const SizedBox(height: 16.0),
+                 LabeledTextField(
+                  label: 'Odometer',
+                  hintText: 'Masukkan angka odometer (km)',
+                   keyboardType: TextInputType.number, // Use number keyboard
+                ),
+                const SizedBox(height: 16.0),
+                 LabeledTextField(
+                  label: 'Kepemilikan',
+                  hintText: 'Contoh: Pribadi / Perusahaan',
+                ),
+                const SizedBox(height: 16.0),
+                 LabeledTextField(
+                  label: 'Plat Nomor',
+                  hintText: 'Masukkan plat nomor',
+                ),
+                const SizedBox(height: 16.0),
+                LabeledDateField(
+                  label: 'Pajak 1 Tahun s.d.',
+                  hintText: 'Pilih tanggal',
+                  initialDate: _pajak1TahunDate,
+                  onChanged: (date) {
+                    setState(() {
+                      _pajak1TahunDate = date;
+                    });
+                  },
+                ),
+                 const SizedBox(height: 16.0),
+                 LabeledDateField(
+                  label: 'Pajak 5 Tahun s.d.',
+                  hintText: 'Pilih tanggal',
+                  initialDate: _pajak5TahunDate,
+                  onChanged: (date) {
+                    setState(() {
+                      _pajak5TahunDate = date;
+                    });
+                  },
+                ),
+                const SizedBox(height: 16.0),
+                 LabeledTextField(
+                  label: 'Biaya Pajak',
+                  hintText: 'Masukkan biaya pajak (Rp)',
+                  keyboardType: TextInputType.number, // Use number keyboard
+                ),
+
+                const SizedBox(height: 32.0), // Spacing before buttons
+
+                // Navigation Row - Back button is enabled here
+                NavigationButtonRow(
+                  onBackPressed: moveToPreviousPage, // Enable back navigation
+                  onNextPressed: moveToNextPage,
+                  // isBackButtonEnabled: true, // Default is true, so can be omitted
+                ),
+              ],
+            ),
+          ),
+        ),
+        SizedBox(height: 16.0), // Optional spacing below the content
+        // Footer
+        Footer(),
+      ],
+    );
   }
 }

--- a/lib/widgets/common_layout.dart
+++ b/lib/widgets/common_layout.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+
+class CommonLayout extends StatelessWidget {
+  final Widget child;
+  final String? title; // Optional title for the AppBar
+
+  const CommonLayout({
+    super.key,
+    required this.child,
+    this.title,
+  });
+
+  // Define standard padding
+  static const EdgeInsets pagePadding = EdgeInsets.symmetric(horizontal: 24.0, vertical: 16.0);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.white,
+      body: SafeArea(
+        child: Padding(
+          padding: pagePadding, // Apply standard padding
+          child: child, // Display the page-specific content
+        ),
+      ),
+      // You can add other Scaffold elements here if needed globally,
+      // like a FloatingActionButton, BottomNavigationBar, Drawer, etc.
+    );
+  }
+}

--- a/lib/widgets/labeled_date_field.dart
+++ b/lib/widgets/labeled_date_field.dart
@@ -11,12 +11,12 @@ class LabeledDateField extends StatefulWidget {
   // --- Define Styles and Colors here for consistency ---
   static const Color borderColor = Color(0xFFC28CFF); // Purple from LabeledTextField
   static const Color labelTextColor = Colors.black87;
-  static const Color hintTextColor = Colors.grey;
+  static const Color hintTextColor = Color(0xFFCBCBCB);
   static const Color selectedDateColor = Color(0xFF4C1C82); // Specific selected date color
   static const Color iconColor = Colors.grey; // Color for the dropdown icon
 
   static final TextStyle labelStyle = GoogleFonts.rubik(
-    fontSize: 16.0,
+    fontSize:20.0,
     fontWeight: FontWeight.w500,
     color: labelTextColor,
   );
@@ -24,11 +24,13 @@ class LabeledDateField extends StatefulWidget {
   static final TextStyle hintTextStyle = GoogleFonts.rubik(
     fontSize: 16.0,
     color: hintTextColor,
+    fontWeight: FontWeight.w400,
   );
 
   static final TextStyle selectedDateTextStyle = GoogleFonts.rubik(
     fontSize: 16.0,
     color: selectedDateColor, // Use the specific purple
+    fontWeight: FontWeight.w400,
   );
   // --- End Styles ---
 
@@ -58,7 +60,7 @@ class _LabeledDateFieldState extends State<LabeledDateField> {
   InputDecoration _buildInputDecoration() {
     return InputDecoration(
       // No hintText here, handled by the Text widget logic
-      contentPadding: const EdgeInsets.symmetric(vertical: 12.0, horizontal: 16.0),
+      contentPadding: const EdgeInsets.symmetric(vertical: 12.0, horizontal: 20.0),
       border: OutlineInputBorder(
         borderRadius: BorderRadius.circular(8.0),
         borderSide: const BorderSide(color: LabeledDateField.borderColor, width: 1.5),
@@ -88,8 +90,17 @@ class _LabeledDateFieldState extends State<LabeledDateField> {
       // Add theme customization here if needed
     );
 
+    // Check if the widget is still mounted before interacting with context or state
+    if (!mounted) return; // Exit if the widget was removed during the await
+
+    // Unfocus again after the picker is closed to prevent keyboard reappearing
+    // on the previously focused text field.
+    FocusScope.of(context).unfocus();
+
     // Check if a date was actually picked and it's different
     if (picked != null && picked != _selectedDate) {
+      // No need for another mounted check here as setState does it internally,
+      // but it's good practice to be aware.
       setState(() {
         _selectedDate = picked; // Update local state to refresh UI
       });

--- a/lib/widgets/labeled_text_field.dart
+++ b/lib/widgets/labeled_text_field.dart
@@ -17,7 +17,7 @@ class LabeledTextField extends StatelessWidget {
   static const Color hintTextColor = Color(0xFFCBCBCB);
 
   static final TextStyle labelStyle = GoogleFonts.rubik(
-    fontSize: 16.0,
+    fontSize: 20.0,
     fontWeight: FontWeight.w300,
     color: labelTextColor,
   );
@@ -25,11 +25,13 @@ class LabeledTextField extends StatelessWidget {
   static final TextStyle inputTextStyling = GoogleFonts.rubik(
     fontSize: 16.0,
     color: Colors.black,
+    fontWeight: FontWeight.w400,
   );
 
    static final TextStyle hintTextStyling = GoogleFonts.rubik(
     fontSize: 16.0,
     color: hintTextColor,
+    fontWeight: FontWeight.w400,
   );
 
   const LabeledTextField({

--- a/lib/widgets/navigation_button_row.dart
+++ b/lib/widgets/navigation_button_row.dart
@@ -84,9 +84,8 @@ class NavigationButtonRow extends StatelessWidget {
           const SizedBox(width: 10),
 
         // --- Next/Submit Button ---
-        // Use Expanded to make the Next button take remaining space if Back is hidden
-        Expanded(
-          child: ElevatedButton(
+        // Removed Expanded wrapper to keep button's natural width
+        ElevatedButton(
           onPressed: onNextPressed, // Always use the provided callback
           // Apply base style and override background/foreground explicitly for clarity
           style: _baseButtonStyle.copyWith(
@@ -105,7 +104,6 @@ class NavigationButtonRow extends StatelessWidget {
           //       )
           //     : Text(nextButtonText, style: buttonTextStyle),
             child: Text(nextButtonText, style: buttonTextStyle),
-          ),
         ),
       ],
     );

--- a/lib/widgets/navigation_button_row.dart
+++ b/lib/widgets/navigation_button_row.dart
@@ -45,13 +45,14 @@ class NavigationButtonRow extends StatelessWidget {
     return Row(
       mainAxisAlignment: MainAxisAlignment.start,
       children: [
-        // --- Back Button ---
-        ElevatedButton(
-          // Use the provided callback if enabled, otherwise null to disable
-          onPressed: isBackButtonEnabled ? onBackPressed : null,
-          style: _baseButtonStyle.copyWith(
-            // Override specific properties for enabled/disabled state
-            backgroundColor: WidgetStateProperty.resolveWith<Color>(
+        // --- Back Button (Conditionally Rendered) ---
+        if (isBackButtonEnabled) // Only render if enabled
+          ElevatedButton(
+            // Use the provided callback
+            onPressed: onBackPressed, // No need for ternary here as it won't render if disabled
+            style: _baseButtonStyle.copyWith(
+              // Override specific properties for enabled/disabled state
+              backgroundColor: WidgetStateProperty.resolveWith<Color>(
               (Set<WidgetState> states) {
                 if (states.contains(WidgetState.disabled)) {
                   return disabledButtonColor; // Disabled color
@@ -78,10 +79,14 @@ class NavigationButtonRow extends StatelessWidget {
           child: Text('Back', style: buttonTextStyle),
         ),
 
-        SizedBox(width: 10,),
+        // --- Spacer (Conditionally Rendered with Back Button) ---
+        if (isBackButtonEnabled) // Only render spacer if back button is rendered
+          const SizedBox(width: 10),
 
         // --- Next/Submit Button ---
-        ElevatedButton(
+        // Use Expanded to make the Next button take remaining space if Back is hidden
+        Expanded(
+          child: ElevatedButton(
           onPressed: onNextPressed, // Always use the provided callback
           // Apply base style and override background/foreground explicitly for clarity
           style: _baseButtonStyle.copyWith(
@@ -99,7 +104,8 @@ class NavigationButtonRow extends StatelessWidget {
           //         ),
           //       )
           //     : Text(nextButtonText, style: buttonTextStyle),
-           child: Text(nextButtonText, style: buttonTextStyle),
+            child: Text(nextButtonText, style: buttonTextStyle),
+          ),
         ),
       ],
     );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -264,7 +264,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.20.2"
-
   leak_tracker:
     dependency: transitive
     description:


### PR DESCRIPTION
- Implement PageTwo ("Data Kendaraan") with required input fields (text and date pickers).
- Create CommonLayout widget to centralize Scaffold, SafeArea, and padding for consistent page structure.
- Refactor PageOne and main.dart to use CommonLayout.
- Update NavigationButtonRow to conditionally hide the back button (used on PageOne).
- Fix bug in LabeledDateField causing keyboard to reappear after date selection.
- Address lint warning (use_build_context_synchronously) in LabeledDateField.
- Add placeholder PageThree to resolve build errors.