### PR TITLE
feat: Refactor expandable text field state management in Penilaian pages and add PageFiveFour

### DIFF
--- a/lib/models/form_data.dart
+++ b/lib/models/form_data.dart
@@ -63,7 +63,7 @@ class FormData {
   bool? powerWindowIsEnabled;
   int? sistemAcSelectedIndex;
   bool? sistemAcIsEnabled;
-  String? fiturCatatan;
+  List<String> fiturCatatanList;
 
   // New fields for Page Five Two
   int? getaranMesinSelectedIndex;
@@ -291,8 +291,8 @@ class FormData {
     this.powerWindowIsEnabled,
     this.sistemAcSelectedIndex,
     this.sistemAcIsEnabled,
-    this.fiturCatatan,
     this.getaranMesinSelectedIndex,
+    this.fiturCatatanList = const [],
     this.getaranMesinIsEnabled,
     this.suaraMesinSelectedIndex,
     this.suaraMesinIsEnabled,

--- a/lib/models/form_data.dart
+++ b/lib/models/form_data.dart
@@ -173,6 +173,69 @@ class FormData {
   bool? plafonIsEnabled;
   String? interiorCatatan;
 
+  // New fields for Page Five Four
+  int? bumperDepanSelectedIndex;
+  bool? bumperDepanIsEnabled;
+  int? kapMesinSelectedIndex;
+  bool? kapMesinIsEnabled;
+  int? lampuUtamaSelectedIndex;
+  bool? lampuUtamaIsEnabled;
+  int? panelAtapSelectedIndex;
+  bool? panelAtapIsEnabled;
+  int? grillSelectedIndex;
+  bool? grillIsEnabled;
+  int? lampuFoglampSelectedIndex;
+  bool? lampuFoglampIsEnabled;
+  int? kacaBeningSelectedIndex;
+  bool? kacaBeningIsEnabled;
+  int? wiperBelakangSelectedIndex;
+  bool? wiperBelakangIsEnabled;
+  int? bumperBelakangSelectedIndex;
+  bool? bumperBelakangIsEnabled;
+  int? lampuBelakangSelectedIndex;
+  bool? lampuBelakangIsEnabled;
+  int? trunklidSelectedIndex;
+  bool? trunklidIsEnabled;
+  int? kacaDepanSelectedIndex;
+  bool? kacaDepanIsEnabled;
+  int? fenderKananSelectedIndex;
+  bool? fenderKananIsEnabled;
+  int? quarterPanelKananSelectedIndex;
+  bool? quarterPanelKananIsEnabled;
+  int? pintuBelakangKananSelectedIndex;
+  bool? pintuBelakangKananIsEnabled;
+  int? spionKananSelectedIndex;
+  bool? spionKananIsEnabled;
+  int? lisplangKananSelectedIndex;
+  bool? lisplangKananIsEnabled;
+  int? sideSkirtKananSelectedIndex;
+  bool? sideSkirtKananIsEnabled;
+  int? daunWiperSelectedIndex;
+  bool? daunWiperIsEnabled;
+  int? pintuBelakangSelectedIndex;
+  bool? pintuBelakangIsEnabled;
+  int? fenderKiriSelectedIndex;
+  bool? fenderKiriIsEnabled;
+  int? quarterPanelKiriSelectedIndex;
+  bool? quarterPanelKiriIsEnabled;
+  int? pintuDepanSelectedIndex;
+  bool? pintuDepanIsEnabled;
+  int? kacaJendelaKananSelectedIndex;
+  bool? kacaJendelaKananIsEnabled;
+  int? pintuBelakangKiriSelectedIndex;
+  bool? pintuBelakangKiriIsEnabled;
+  int? spionKiriSelectedIndex;
+  bool? spionKiriIsEnabled;
+  int? pintuDepanKiriSelectedIndex;
+  bool? pintuDepanKiriIsEnabled;
+  int? kacaJendelaKiriSelectedIndex;
+  bool? kacaJendelaKiriIsEnabled;
+  int? lisplangKiriSelectedIndex;
+  bool? lisplangKiriIsEnabled;
+  int? sideSkirtKiriSelectedIndex;
+  bool? sideSkirtKiriIsEnabled;
+  String? eksteriorCatatan;
+
 
   // New field for repair estimations
   List<Map<String, String>> repairEstimations;
@@ -333,6 +396,67 @@ class FormData {
     this.plafonSelectedIndex,
     this.plafonIsEnabled,
     this.interiorCatatan,
+    this.bumperDepanSelectedIndex,
+    this.bumperDepanIsEnabled,
+    this.kapMesinSelectedIndex,
+    this.kapMesinIsEnabled,
+    this.lampuUtamaSelectedIndex,
+    this.lampuUtamaIsEnabled,
+    this.panelAtapSelectedIndex,
+    this.panelAtapIsEnabled,
+    this.grillSelectedIndex,
+    this.grillIsEnabled,
+    this.lampuFoglampSelectedIndex,
+    this.lampuFoglampIsEnabled,
+    this.kacaBeningSelectedIndex,
+    this.kacaBeningIsEnabled,
+    this.wiperBelakangSelectedIndex,
+    this.wiperBelakangIsEnabled,
+    this.bumperBelakangSelectedIndex,
+    this.bumperBelakangIsEnabled,
+    this.lampuBelakangSelectedIndex,
+    this.lampuBelakangIsEnabled,
+    this.trunklidSelectedIndex,
+    this.trunklidIsEnabled,
+    this.kacaDepanSelectedIndex,
+    this.kacaDepanIsEnabled,
+    this.fenderKananSelectedIndex,
+    this.fenderKananIsEnabled,
+    this.quarterPanelKananSelectedIndex,
+    this.quarterPanelKananIsEnabled,
+    this.pintuBelakangKananSelectedIndex,
+    this.pintuBelakangKananIsEnabled,
+    this.spionKananSelectedIndex,
+    this.spionKananIsEnabled,
+    this.lisplangKananSelectedIndex,
+    this.lisplangKananIsEnabled,
+    this.sideSkirtKananSelectedIndex,
+    this.sideSkirtKananIsEnabled,
+    this.daunWiperSelectedIndex,
+    this.daunWiperIsEnabled,
+    this.pintuBelakangSelectedIndex,
+    this.pintuBelakangIsEnabled,
+    this.fenderKiriSelectedIndex,
+    this.fenderKiriIsEnabled,
+    this.quarterPanelKiriSelectedIndex,
+    this.quarterPanelKiriIsEnabled,
+    this.pintuDepanSelectedIndex,
+    this.pintuDepanIsEnabled,
+    this.kacaJendelaKananSelectedIndex,
+    this.kacaJendelaKananIsEnabled,
+    this.pintuBelakangKiriSelectedIndex,
+    this.pintuBelakangKiriIsEnabled,
+    this.spionKiriSelectedIndex,
+    this.spionKiriIsEnabled,
+    this.pintuDepanKiriSelectedIndex,
+    this.pintuDepanKiriIsEnabled,
+    this.kacaJendelaKiriSelectedIndex,
+    this.kacaJendelaKiriIsEnabled,
+    this.lisplangKiriSelectedIndex,
+    this.lisplangKiriIsEnabled,
+    this.sideSkirtKiriSelectedIndex,
+    this.sideSkirtKiriIsEnabled,
+    this.eksteriorCatatan,
 
   }) : keteranganEksterior = keteranganEksterior ?? [],
        keteranganInterior = keteranganInterior ?? [],

--- a/lib/models/form_data.dart
+++ b/lib/models/form_data.dart
@@ -120,7 +120,7 @@ class FormData {
   bool? bushingKecilIsEnabled;
   int? tutupRadiatorSelectedIndex;
   bool? tutupRadiatorIsEnabled;
-  String? mesinCatatan;
+  List<String> mesinCatatanList;
 
   // New fields for Page Five Three
   int? stirSelectedIndex;
@@ -171,7 +171,7 @@ class FormData {
   bool? trimInteriorIsEnabled;
   int? plafonSelectedIndex;
   bool? plafonIsEnabled;
-  String? interiorCatatan;
+  List<String> interiorCatatanList;
 
   // New fields for Page Five Four
   int? bumperDepanSelectedIndex;
@@ -234,7 +234,7 @@ class FormData {
   bool? lisplangKiriIsEnabled;
   int? sideSkirtKiriSelectedIndex;
   bool? sideSkirtKiriIsEnabled;
-  String? eksteriorCatatan;
+  List<String> eksteriorCatatanList;
 
 
   // New field for repair estimations
@@ -346,7 +346,7 @@ class FormData {
     this.bushingKecilIsEnabled,
     this.tutupRadiatorSelectedIndex,
     this.tutupRadiatorIsEnabled,
-    this.mesinCatatan,
+    List<String>? mesinCatatanList,
     this.stirSelectedIndex,
     this.stirIsEnabled,
     this.remTonganSelectedIndex,
@@ -395,7 +395,7 @@ class FormData {
     this.trimInteriorIsEnabled,
     this.plafonSelectedIndex,
     this.plafonIsEnabled,
-    this.interiorCatatan,
+    List<String>? interiorCatatanList,
     this.bumperDepanSelectedIndex,
     this.bumperDepanIsEnabled,
     this.kapMesinSelectedIndex,
@@ -456,14 +456,17 @@ class FormData {
     this.lisplangKiriIsEnabled,
     this.sideSkirtKiriSelectedIndex,
     this.sideSkirtKiriIsEnabled,
-    this.eksteriorCatatan,
+    List<String>? eksteriorCatatanList,
 
   }) : keteranganEksterior = keteranganEksterior ?? [],
        keteranganInterior = keteranganInterior ?? [],
        keteranganKakiKaki = keteranganKakiKaki ?? [],
        keteranganMesin = keteranganMesin ?? [],
        deskripsiKeseluruhan = deskripsiKeseluruhan ?? [],
-       repairEstimations = repairEstimations ?? [];
+       repairEstimations = repairEstimations ?? [],
+       mesinCatatanList = mesinCatatanList ?? [],
+       interiorCatatanList = interiorCatatanList ?? [],
+       eksteriorCatatanList = eksteriorCatatanList ?? [];
 
   // Add methods to update data if needed, or update directly
 }

--- a/lib/pages/page_five_five.dart
+++ b/lib/pages/page_five_five.dart
@@ -22,7 +22,7 @@ class PageFiveFive extends StatelessWidget {
                 children: [
                   PageNumber(data: '5/9'),
                   const SizedBox(height: 8.0),
-                  PageTitle(data: 'Penilaian'),
+                  PageTitle(data: 'Penilaian (5)'),
                   const SizedBox(height: 24.0),
                   const HeadingOne(text: 'Ban dan Kaki-kaki'),
                   const SizedBox(height: 32.0),

--- a/lib/pages/page_five_four.dart
+++ b/lib/pages/page_five_four.dart
@@ -22,21 +22,15 @@ class PageFiveFour extends ConsumerStatefulWidget {
 class _PageFiveFourState extends ConsumerState<PageFiveFour> {
   late FocusScopeNode _focusScopeNode;
 
-  // State variable for ExpandableTextField
-  late TextEditingController _eksteriorCatatanController;
-
   @override
   void initState() {
     super.initState();
     _focusScopeNode = FocusScopeNode();
-    final formData = ref.read(formProvider);
-    _eksteriorCatatanController = TextEditingController(text: formData.eksteriorCatatan ?? '');
   }
 
   @override
   void dispose() {
     _focusScopeNode.dispose();
-    _eksteriorCatatanController.dispose();
     super.dispose();
   }
 
@@ -558,9 +552,9 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ExpandableTextField(
                           label: 'Catatan',
                           hintText: 'Masukkan catatan di sini',
-                          controller: _eksteriorCatatanController,
+                          initialLines: formData.eksteriorCatatanList,
                           onChangedList: (lines) {
-                            formNotifier.updateEksteriorCatatan(lines.join('\n'));
+                            formNotifier.updateEksteriorCatatanList(lines);
                           },
                         ),
                         const SizedBox(height: 32.0),

--- a/lib/pages/page_five_four.dart
+++ b/lib/pages/page_five_four.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:form_app/widgets/common_layout.dart';
 import 'package:form_app/widgets/heading_one.dart';
 import 'package:form_app/widgets/navigation_button_row.dart';
@@ -6,9 +7,706 @@ import 'package:form_app/widgets/page_number.dart';
 import 'package:form_app/widgets/page_title.dart';
 import 'package:form_app/widgets/footer.dart';
 import 'package:form_app/pages/page_five_five.dart'; // Import PageFiveFive
+import 'package:form_app/providers/form_provider.dart';
+import 'package:form_app/widgets/toggleable_numbered_button_list.dart';
+import 'package:form_app/widgets/expandable_text_field.dart';
 
-class PageFiveFour extends StatelessWidget {
+
+class PageFiveFour extends ConsumerStatefulWidget {
   const PageFiveFour({super.key});
+
+  @override
+  ConsumerState<PageFiveFour> createState() => _PageFiveFourState();
+}
+
+class _PageFiveFourState extends ConsumerState<PageFiveFour> {
+  // State variables for ToggleableNumberedButtonList
+  late int _bumperDepanSelectedIndex;
+  late bool _bumperDepanIsEnabled;
+  late int _kapMesinSelectedIndex;
+  late bool _kapMesinIsEnabled;
+  late int _lampuUtamaSelectedIndex;
+  late bool _lampuUtamaIsEnabled;
+  late int _panelAtapSelectedIndex;
+  late bool _panelAtapIsEnabled;
+  late int _grillSelectedIndex;
+  late bool _grillIsEnabled;
+  late int _lampuFoglampSelectedIndex;
+  late bool _lampuFoglampIsEnabled;
+  late int _kacaBeningSelectedIndex;
+  late bool _kacaBeningIsEnabled;
+  late int _wiperBelakangSelectedIndex;
+  late bool _wiperBelakangIsEnabled;
+  late int _bumperBelakangSelectedIndex;
+  late bool _bumperBelakangIsEnabled;
+  late int _lampuBelakangSelectedIndex;
+  late bool _lampuBelakangIsEnabled;
+  late int _trunklidSelectedIndex;
+  late bool _trunklidIsEnabled;
+  late int _kacaDepanSelectedIndex;
+  late bool _kacaDepanIsEnabled;
+  late int _fenderKananSelectedIndex;
+  late bool _fenderKananIsEnabled;
+  late int _quarterPanelKananSelectedIndex;
+  late bool _quarterPanelKananIsEnabled;
+  late int _pintuBelakangKananSelectedIndex;
+  late bool _pintuBelakangKananIsEnabled;
+  late int _spionKananSelectedIndex;
+  late bool _spionKananIsEnabled;
+  late int _lisplangKananSelectedIndex;
+  late bool _lisplangKananIsEnabled;
+  late int _sideSkirtKananSelectedIndex;
+  late bool _sideSkirtKananIsEnabled;
+  late int _daunWiperSelectedIndex;
+  late bool _daunWiperIsEnabled;
+  late int _pintuBelakangSelectedIndex;
+  late bool _pintuBelakangIsEnabled;
+  late int _fenderKiriSelectedIndex;
+  late bool _fenderKiriIsEnabled;
+  late int _quarterPanelKiriSelectedIndex;
+  late bool _quarterPanelKiriIsEnabled;
+  late int _pintuDepanSelectedIndex;
+  late bool _pintuDepanIsEnabled;
+  late int _kacaJendelaKananSelectedIndex;
+  late bool _kacaJendelaKananIsEnabled;
+  late int _pintuBelakangKiriSelectedIndex;
+  late bool _pintuBelakangKiriIsEnabled;
+  late int _spionKiriSelectedIndex;
+  late bool _spionKiriIsEnabled;
+  late int _pintuDepanKiriSelectedIndex;
+  late bool _pintuDepanKiriIsEnabled;
+  late int _kacaJendelaKiriSelectedIndex;
+  late bool _kacaJendelaKiriIsEnabled;
+  late int _lisplangKiriSelectedIndex;
+  late bool _lisplangKiriIsEnabled;
+  late int _sideSkirtKiriSelectedIndex;
+  late bool _sideSkirtKiriIsEnabled;
+
+  // State variable for ExpandableTextField
+  late TextEditingController _eksteriorCatatanController;
+
+
+  @override
+  void initState() {
+    super.initState();
+    final formData = ref.read(formProvider);
+    // Initialize state variables from formProvider
+    _bumperDepanSelectedIndex = formData.bumperDepanSelectedIndex ?? 0;
+    _bumperDepanIsEnabled = formData.bumperDepanIsEnabled ?? true;
+    _kapMesinSelectedIndex = formData.kapMesinSelectedIndex ?? 0;
+    _kapMesinIsEnabled = formData.kapMesinIsEnabled ?? true;
+    _lampuUtamaSelectedIndex = formData.lampuUtamaSelectedIndex ?? 0;
+    _lampuUtamaIsEnabled = formData.lampuUtamaIsEnabled ?? true;
+    _panelAtapSelectedIndex = formData.panelAtapSelectedIndex ?? 0;
+    _panelAtapIsEnabled = formData.panelAtapIsEnabled ?? true;
+    _grillSelectedIndex = formData.grillSelectedIndex ?? 0;
+    _grillIsEnabled = formData.grillIsEnabled ?? true;
+    _lampuFoglampSelectedIndex = formData.lampuFoglampSelectedIndex ?? 0;
+    _lampuFoglampIsEnabled = formData.lampuFoglampIsEnabled ?? true;
+    _kacaBeningSelectedIndex = formData.kacaBeningSelectedIndex ?? 0;
+    _kacaBeningIsEnabled = formData.kacaBeningIsEnabled ?? true;
+    _wiperBelakangSelectedIndex = formData.wiperBelakangSelectedIndex ?? 0;
+    _wiperBelakangIsEnabled = formData.wiperBelakangIsEnabled ?? true;
+    _bumperBelakangSelectedIndex = formData.bumperBelakangSelectedIndex ?? 0;
+    _bumperBelakangIsEnabled = formData.bumperBelakangIsEnabled ?? true;
+    _lampuBelakangSelectedIndex = formData.lampuBelakangSelectedIndex ?? 0;
+    _lampuBelakangIsEnabled = formData.lampuBelakangIsEnabled ?? true;
+    _trunklidSelectedIndex = formData.trunklidSelectedIndex ?? 0;
+    _trunklidIsEnabled = formData.trunklidIsEnabled ?? true;
+    _kacaDepanSelectedIndex = formData.kacaDepanSelectedIndex ?? 0;
+    _kacaDepanIsEnabled = formData.kacaDepanIsEnabled ?? true;
+    _fenderKananSelectedIndex = formData.fenderKananSelectedIndex ?? 0;
+    _fenderKananIsEnabled = formData.fenderKananIsEnabled ?? true;
+    _quarterPanelKananSelectedIndex = formData.quarterPanelKananSelectedIndex ?? 0;
+    _quarterPanelKananIsEnabled = formData.quarterPanelKananIsEnabled ?? true;
+    _pintuBelakangKananSelectedIndex = formData.pintuBelakangKananSelectedIndex ?? 0;
+    _pintuBelakangKananIsEnabled = formData.pintuBelakangKananIsEnabled ?? true;
+    _spionKananSelectedIndex = formData.spionKananSelectedIndex ?? 0;
+    _spionKananIsEnabled = formData.spionKananIsEnabled ?? true;
+    _lisplangKananSelectedIndex = formData.lisplangKananSelectedIndex ?? 0;
+    _lisplangKananIsEnabled = formData.lisplangKananIsEnabled ?? true;
+    _sideSkirtKananSelectedIndex = formData.sideSkirtKananSelectedIndex ?? 0;
+    _sideSkirtKananIsEnabled = formData.sideSkirtKananIsEnabled ?? true;
+    _daunWiperSelectedIndex = formData.daunWiperSelectedIndex ?? 0;
+    _daunWiperIsEnabled = formData.daunWiperIsEnabled ?? true;
+    _pintuBelakangSelectedIndex = formData.pintuBelakangSelectedIndex ?? 0;
+    _pintuBelakangIsEnabled = formData.pintuBelakangIsEnabled ?? true;
+    _fenderKiriSelectedIndex = formData.fenderKiriSelectedIndex ?? 0;
+    _fenderKiriIsEnabled = formData.fenderKiriIsEnabled ?? true;
+    _quarterPanelKiriSelectedIndex = formData.quarterPanelKiriSelectedIndex ?? 0;
+    _quarterPanelKiriIsEnabled = formData.quarterPanelKiriIsEnabled ?? true;
+    _pintuDepanSelectedIndex = formData.pintuDepanSelectedIndex ?? 0;
+    _pintuDepanIsEnabled = formData.pintuDepanIsEnabled ?? true;
+    _kacaJendelaKananSelectedIndex = formData.kacaJendelaKananSelectedIndex ?? 0;
+    _kacaJendelaKananIsEnabled = formData.kacaJendelaKananIsEnabled ?? true;
+    _pintuBelakangKiriSelectedIndex = formData.pintuBelakangKiriSelectedIndex ?? 0;
+    _pintuBelakangKiriIsEnabled = formData.pintuBelakangKiriIsEnabled ?? true;
+    _spionKiriSelectedIndex = formData.spionKiriSelectedIndex ?? 0;
+    _spionKiriIsEnabled = formData.spionKiriIsEnabled ?? true;
+    _pintuDepanKiriSelectedIndex = formData.pintuDepanKiriSelectedIndex ?? 0;
+    _pintuDepanKiriIsEnabled = formData.pintuDepanKiriIsEnabled ?? true;
+    _kacaJendelaKiriSelectedIndex = formData.kacaJendelaKiriSelectedIndex ?? 0;
+    _kacaJendelaKiriIsEnabled = formData.kacaJendelaKiriIsEnabled ?? true;
+    _lisplangKiriSelectedIndex = formData.lisplangKiriSelectedIndex ?? 0;
+    _lisplangKiriIsEnabled = formData.lisplangKiriIsEnabled ?? true;
+    _sideSkirtKiriSelectedIndex = formData.sideSkirtKiriSelectedIndex ?? 0;
+    _sideSkirtKiriIsEnabled = formData.sideSkirtKiriIsEnabled ?? true;
+
+    _eksteriorCatatanController = TextEditingController(text: formData.eksteriorCatatan ?? '');
+  }
+
+  @override
+  void dispose() {
+    _eksteriorCatatanController.dispose();
+    super.dispose();
+  }
+
+  // Callback methods for ToggleableNumberedButtonList
+  void _onBumperDepanItemSelected(int index) {
+    setState(() {
+      _bumperDepanSelectedIndex = index;
+    });
+    ref.read(formProvider.notifier).updateBumperDepanSelectedIndex(index);
+  }
+
+  void _onBumperDepanEnabledChanged(bool enabled) {
+    setState(() {
+      _bumperDepanIsEnabled = enabled;
+      if (!enabled) {
+        _bumperDepanSelectedIndex = 0;
+      }
+    });
+    ref.read(formProvider.notifier).updateBumperDepanIsEnabled(enabled);
+    ref.read(formProvider.notifier).updateBumperDepanSelectedIndex(_bumperDepanSelectedIndex);
+  }
+
+  void _onKapMesinItemSelected(int index) {
+    setState(() {
+      _kapMesinSelectedIndex = index;
+    });
+    ref.read(formProvider.notifier).updateKapMesinSelectedIndex(index);
+  }
+
+  void _onKapMesinEnabledChanged(bool enabled) {
+    setState(() {
+      _kapMesinIsEnabled = enabled;
+      if (!enabled) {
+        _kapMesinSelectedIndex = 0;
+      }
+    });
+    ref.read(formProvider.notifier).updateKapMesinIsEnabled(enabled);
+    ref.read(formProvider.notifier).updateKapMesinSelectedIndex(_kapMesinSelectedIndex);
+  }
+
+  void _onLampuUtamaItemSelected(int index) {
+    setState(() {
+      _lampuUtamaSelectedIndex = index;
+    });
+    ref.read(formProvider.notifier).updateLampuUtamaSelectedIndex(index);
+  }
+
+  void _onLampuUtamaEnabledChanged(bool enabled) {
+    setState(() {
+      _lampuUtamaIsEnabled = enabled;
+      if (!enabled) {
+        _lampuUtamaSelectedIndex = 0;
+      }
+    });
+    ref.read(formProvider.notifier).updateLampuUtamaIsEnabled(enabled);
+    ref.read(formProvider.notifier).updateLampuUtamaSelectedIndex(_lampuUtamaSelectedIndex);
+  }
+
+  void _onPanelAtapItemSelected(int index) {
+    setState(() {
+      _panelAtapSelectedIndex = index;
+    });
+    ref.read(formProvider.notifier).updatePanelAtapSelectedIndex(index);
+  }
+
+  void _onPanelAtapEnabledChanged(bool enabled) {
+    setState(() {
+      _panelAtapIsEnabled = enabled;
+      if (!enabled) {
+        _panelAtapSelectedIndex = 0;
+      }
+    });
+    ref.read(formProvider.notifier).updatePanelAtapIsEnabled(enabled);
+    ref.read(formProvider.notifier).updatePanelAtapSelectedIndex(_panelAtapSelectedIndex);
+  }
+
+  void _onGrillItemSelected(int index) {
+    setState(() {
+      _grillSelectedIndex = index;
+    });
+    ref.read(formProvider.notifier).updateGrillSelectedIndex(index);
+  }
+
+  void _onGrillEnabledChanged(bool enabled) {
+    setState(() {
+      _grillIsEnabled = enabled;
+      if (!enabled) {
+        _grillSelectedIndex = 0;
+      }
+    });
+    ref.read(formProvider.notifier).updateGrillIsEnabled(enabled);
+    ref.read(formProvider.notifier).updateGrillSelectedIndex(_grillSelectedIndex);
+  }
+
+  void _onLampuFoglampItemSelected(int index) {
+    setState(() {
+      _lampuFoglampSelectedIndex = index;
+    });
+    ref.read(formProvider.notifier).updateLampuFoglampSelectedIndex(index);
+  }
+
+  void _onLampuFoglampEnabledChanged(bool enabled) {
+    setState(() {
+      _lampuFoglampIsEnabled = enabled;
+      if (!enabled) {
+        _lampuFoglampSelectedIndex = 0;
+      }
+    });
+    ref.read(formProvider.notifier).updateLampuFoglampIsEnabled(enabled);
+    ref.read(formProvider.notifier).updateLampuFoglampSelectedIndex(_lampuFoglampSelectedIndex);
+  }
+
+  void _onKacaBeningItemSelected(int index) {
+    setState(() {
+      _kacaBeningSelectedIndex = index;
+    });
+    ref.read(formProvider.notifier).updateKacaBeningSelectedIndex(index);
+  }
+
+  void _onKacaBeningEnabledChanged(bool enabled) {
+    setState(() {
+      _kacaBeningIsEnabled = enabled;
+      if (!enabled) {
+        _kacaBeningSelectedIndex = 0;
+      }
+    });
+    ref.read(formProvider.notifier).updateKacaBeningIsEnabled(enabled);
+    ref.read(formProvider.notifier).updateKacaBeningSelectedIndex(_kacaBeningSelectedIndex);
+  }
+
+  void _onWiperBelakangItemSelected(int index) {
+    setState(() {
+      _wiperBelakangSelectedIndex = index;
+    });
+    ref.read(formProvider.notifier).updateWiperBelakangSelectedIndex(index);
+  }
+
+  void _onWiperBelakangEnabledChanged(bool enabled) {
+    setState(() {
+      _wiperBelakangIsEnabled = enabled;
+      if (!enabled) {
+        _wiperBelakangSelectedIndex = 0;
+      }
+    });
+    ref.read(formProvider.notifier).updateWiperBelakangIsEnabled(enabled);
+    ref.read(formProvider.notifier).updateWiperBelakangSelectedIndex(_wiperBelakangSelectedIndex);
+  }
+
+  void _onBumperBelakangItemSelected(int index) {
+    setState(() {
+      _bumperBelakangSelectedIndex = index;
+    });
+    ref.read(formProvider.notifier).updateBumperBelakangSelectedIndex(index);
+  }
+
+  void _onBumperBelakangEnabledChanged(bool enabled) {
+    setState(() {
+      _bumperBelakangIsEnabled = enabled;
+      if (!enabled) {
+        _bumperBelakangSelectedIndex = 0;
+      }
+    });
+    ref.read(formProvider.notifier).updateBumperBelakangIsEnabled(enabled);
+    ref.read(formProvider.notifier).updateBumperBelakangSelectedIndex(_bumperBelakangSelectedIndex);
+  }
+
+  void _onLampuBelakangItemSelected(int index) {
+    setState(() {
+      _lampuBelakangSelectedIndex = index;
+    });
+    ref.read(formProvider.notifier).updateLampuBelakangSelectedIndex(index);
+  }
+
+  void _onLampuBelakangEnabledChanged(bool enabled) {
+    setState(() {
+      _lampuBelakangIsEnabled = enabled;
+      if (!enabled) {
+        _lampuBelakangSelectedIndex = 0;
+      }
+    });
+    ref.read(formProvider.notifier).updateLampuBelakangIsEnabled(enabled);
+    ref.read(formProvider.notifier).updateLampuBelakangSelectedIndex(_lampuBelakangSelectedIndex);
+  }
+
+  void _onTrunklidItemSelected(int index) {
+    setState(() {
+      _trunklidSelectedIndex = index;
+    });
+    ref.read(formProvider.notifier).updateTrunklidSelectedIndex(index);
+  }
+
+  void _onTrunklidEnabledChanged(bool enabled) {
+    setState(() {
+      _trunklidIsEnabled = enabled;
+      if (!enabled) {
+        _trunklidSelectedIndex = 0;
+      }
+    });
+    ref.read(formProvider.notifier).updateTrunklidIsEnabled(enabled);
+    ref.read(formProvider.notifier).updateTrunklidSelectedIndex(_trunklidSelectedIndex);
+  }
+
+  void _onKacaDepanItemSelected(int index) {
+    setState(() {
+      _kacaDepanSelectedIndex = index;
+    });
+    ref.read(formProvider.notifier).updateKacaDepanSelectedIndex(index);
+  }
+
+  void _onKacaDepanEnabledChanged(bool enabled) {
+    setState(() {
+      _kacaDepanIsEnabled = enabled;
+      if (!enabled) {
+        _kacaDepanSelectedIndex = 0;
+      }
+    });
+    ref.read(formProvider.notifier).updateKacaDepanIsEnabled(enabled);
+    ref.read(formProvider.notifier).updateKacaDepanSelectedIndex(_kacaDepanSelectedIndex);
+  }
+
+  void _onFenderKananItemSelected(int index) {
+    setState(() {
+      _fenderKananSelectedIndex = index;
+    });
+    ref.read(formProvider.notifier).updateFenderKananSelectedIndex(index);
+  }
+
+  void _onFenderKananEnabledChanged(bool enabled) {
+    setState(() {
+      _fenderKananIsEnabled = enabled;
+      if (!enabled) {
+        _fenderKananSelectedIndex = 0;
+      }
+    });
+    ref.read(formProvider.notifier).updateFenderKananIsEnabled(enabled);
+    ref.read(formProvider.notifier).updateFenderKananSelectedIndex(_fenderKananSelectedIndex);
+  }
+
+  void _onQuarterPanelKananItemSelected(int index) {
+    setState(() {
+      _quarterPanelKananSelectedIndex = index;
+    });
+    ref.read(formProvider.notifier).updateQuarterPanelKananSelectedIndex(index);
+  }
+
+  void _onQuarterPanelKananEnabledChanged(bool enabled) {
+    setState(() {
+      _quarterPanelKananIsEnabled = enabled;
+      if (!enabled) {
+        _quarterPanelKananSelectedIndex = 0;
+      }
+    });
+    ref.read(formProvider.notifier).updateQuarterPanelKananIsEnabled(enabled);
+    ref.read(formProvider.notifier).updateQuarterPanelKananSelectedIndex(_quarterPanelKananSelectedIndex);
+  }
+
+  void _onPintuBelakangKananItemSelected(int index) {
+    setState(() {
+      _pintuBelakangKananSelectedIndex = index;
+    });
+    ref.read(formProvider.notifier).updatePintuBelakangKananSelectedIndex(index);
+  }
+
+  void _onPintuBelakangKananEnabledChanged(bool enabled) {
+    setState(() {
+      _pintuBelakangKananIsEnabled = enabled;
+      if (!enabled) {
+        _pintuBelakangKananSelectedIndex = 0;
+      }
+    });
+    ref.read(formProvider.notifier).updatePintuBelakangKananIsEnabled(enabled);
+    ref.read(formProvider.notifier).updatePintuBelakangKananSelectedIndex(_pintuBelakangKananSelectedIndex);
+  }
+
+  void _onSpionKananItemSelected(int index) {
+    setState(() {
+      _spionKananSelectedIndex = index;
+    });
+    ref.read(formProvider.notifier).updateSpionKananSelectedIndex(index);
+  }
+
+  void _onSpionKananEnabledChanged(bool enabled) {
+    setState(() {
+      _spionKananIsEnabled = enabled;
+      if (!enabled) {
+        _spionKananSelectedIndex = 0;
+      }
+    });
+    ref.read(formProvider.notifier).updateSpionKananIsEnabled(enabled);
+    ref.read(formProvider.notifier).updateSpionKananSelectedIndex(_spionKananSelectedIndex);
+  }
+
+  void _onLisplangKananItemSelected(int index) {
+    setState(() {
+      _lisplangKananSelectedIndex = index;
+    });
+    ref.read(formProvider.notifier).updateLisplangKananSelectedIndex(index);
+  }
+
+  void _onLisplangKananEnabledChanged(bool enabled) {
+    setState(() {
+      _lisplangKananIsEnabled = enabled;
+      if (!enabled) {
+        _lisplangKananSelectedIndex = 0;
+      }
+    });
+    ref.read(formProvider.notifier).updateLisplangKananIsEnabled(enabled);
+    ref.read(formProvider.notifier).updateLisplangKananSelectedIndex(_lisplangKananSelectedIndex);
+  }
+
+  void _onSideSkirtKananItemSelected(int index) {
+    setState(() {
+      _sideSkirtKananSelectedIndex = index;
+    });
+    ref.read(formProvider.notifier).updateSideSkirtKananSelectedIndex(index);
+  }
+
+  void _onSideSkirtKananEnabledChanged(bool enabled) {
+    setState(() {
+      _sideSkirtKananIsEnabled = enabled;
+      if (!enabled) {
+        _sideSkirtKananSelectedIndex = 0;
+      }
+    });
+    ref.read(formProvider.notifier).updateSideSkirtKananIsEnabled(enabled);
+    ref.read(formProvider.notifier).updateSideSkirtKananSelectedIndex(_sideSkirtKananSelectedIndex);
+  }
+
+  void _onDaunWiperItemSelected(int index) {
+    setState(() {
+      _daunWiperSelectedIndex = index;
+    });
+    ref.read(formProvider.notifier).updateDaunWiperSelectedIndex(index);
+  }
+
+  void _onDaunWiperEnabledChanged(bool enabled) {
+    setState(() {
+      _daunWiperIsEnabled = enabled;
+      if (!enabled) {
+        _daunWiperSelectedIndex = 0;
+      }
+    });
+    ref.read(formProvider.notifier).updateDaunWiperIsEnabled(enabled);
+    ref.read(formProvider.notifier).updateDaunWiperSelectedIndex(_daunWiperSelectedIndex);
+  }
+
+  void _onPintuBelakangItemSelected(int index) {
+    setState(() {
+      _pintuBelakangSelectedIndex = index;
+    });
+    ref.read(formProvider.notifier).updatePintuBelakangSelectedIndex(index);
+  }
+
+  void _onPintuBelakangEnabledChanged(bool enabled) {
+    setState(() {
+      _pintuBelakangIsEnabled = enabled;
+      if (!enabled) {
+        _pintuBelakangSelectedIndex = 0;
+      }
+    });
+    ref.read(formProvider.notifier).updatePintuBelakangIsEnabled(enabled);
+    ref.read(formProvider.notifier).updatePintuBelakangSelectedIndex(_pintuBelakangSelectedIndex);
+  }
+
+  void _onFenderKiriItemSelected(int index) {
+    setState(() {
+      _fenderKiriSelectedIndex = index;
+    });
+    ref.read(formProvider.notifier).updateFenderKiriSelectedIndex(index);
+  }
+
+  void _onFenderKiriEnabledChanged(bool enabled) {
+    setState(() {
+      _fenderKiriIsEnabled = enabled;
+      if (!enabled) {
+        _fenderKiriSelectedIndex = 0;
+      }
+    });
+    ref.read(formProvider.notifier).updateFenderKiriIsEnabled(enabled);
+    ref.read(formProvider.notifier).updateFenderKiriSelectedIndex(_fenderKiriSelectedIndex);
+  }
+
+  void _onQuarterPanelKiriItemSelected(int index) {
+    setState(() {
+      _quarterPanelKiriSelectedIndex = index;
+    });
+    ref.read(formProvider.notifier).updateQuarterPanelKiriSelectedIndex(index);
+  }
+
+  void _onQuarterPanelKiriEnabledChanged(bool enabled) {
+    setState(() {
+      _quarterPanelKiriIsEnabled = enabled;
+      if (!enabled) {
+        _quarterPanelKiriSelectedIndex = 0;
+      }
+    });
+    ref.read(formProvider.notifier).updateQuarterPanelKiriIsEnabled(enabled);
+    ref.read(formProvider.notifier).updateQuarterPanelKiriSelectedIndex(_quarterPanelKiriSelectedIndex);
+  }
+
+  void _onPintuDepanItemSelected(int index) {
+    setState(() {
+      _pintuDepanSelectedIndex = index;
+    });
+    ref.read(formProvider.notifier).updatePintuDepanSelectedIndex(index);
+  }
+
+  void _onPintuDepanEnabledChanged(bool enabled) {
+    setState(() {
+      _pintuDepanIsEnabled = enabled;
+      if (!enabled) {
+        _pintuDepanSelectedIndex = 0;
+      }
+    });
+    ref.read(formProvider.notifier).updatePintuDepanIsEnabled(enabled);
+    ref.read(formProvider.notifier).updatePintuDepanSelectedIndex(_pintuDepanSelectedIndex);
+  }
+
+  void _onKacaJendelaKananItemSelected(int index) {
+    setState(() {
+      _kacaJendelaKananSelectedIndex = index;
+    });
+    ref.read(formProvider.notifier).updateKacaJendelaKananSelectedIndex(index);
+  }
+
+  void _onKacaJendelaKananEnabledChanged(bool enabled) {
+    setState(() {
+      _kacaJendelaKananIsEnabled = enabled;
+      if (!enabled) {
+        _kacaJendelaKananSelectedIndex = 0;
+      }
+    });
+    ref.read(formProvider.notifier).updateKacaJendelaKananIsEnabled(enabled);
+    ref.read(formProvider.notifier).updateKacaJendelaKananSelectedIndex(_kacaJendelaKananSelectedIndex);
+  }
+
+  void _onPintuBelakangKiriItemSelected(int index) {
+    setState(() {
+      _pintuBelakangKiriSelectedIndex = index;
+    });
+    ref.read(formProvider.notifier).updatePintuBelakangKiriSelectedIndex(index);
+  }
+
+  void _onPintuBelakangKiriEnabledChanged(bool enabled) {
+    setState(() {
+      _pintuBelakangKiriIsEnabled = enabled;
+      if (!enabled) {
+        _pintuBelakangKiriSelectedIndex = 0;
+      }
+    });
+    ref.read(formProvider.notifier).updatePintuBelakangKiriIsEnabled(enabled);
+    ref.read(formProvider.notifier).updatePintuBelakangKiriSelectedIndex(_pintuBelakangKiriSelectedIndex);
+  }
+
+  void _onSpionKiriItemSelected(int index) {
+    setState(() {
+      _spionKiriSelectedIndex = index;
+    });
+    ref.read(formProvider.notifier).updateSpionKiriSelectedIndex(index);
+  }
+
+  void _onSpionKiriEnabledChanged(bool enabled) {
+    setState(() {
+      _spionKiriIsEnabled = enabled;
+      if (!enabled) {
+        _spionKiriSelectedIndex = 0;
+      }
+    });
+    ref.read(formProvider.notifier).updateSpionKiriIsEnabled(enabled);
+    ref.read(formProvider.notifier).updateSpionKiriSelectedIndex(_spionKiriSelectedIndex);
+  }
+
+  void _onPintuDepanKiriItemSelected(int index) {
+    setState(() {
+      _pintuDepanKiriSelectedIndex = index;
+    });
+    ref.read(formProvider.notifier).updatePintuDepanKiriSelectedIndex(index);
+  }
+
+  void _onPintuDepanKiriEnabledChanged(bool enabled) {
+    setState(() {
+      _pintuDepanKiriIsEnabled = enabled;
+      if (!enabled) {
+        _pintuDepanKiriSelectedIndex = 0;
+      }
+    });
+    ref.read(formProvider.notifier).updatePintuDepanKiriIsEnabled(enabled);
+    ref.read(formProvider.notifier).updatePintuDepanKiriSelectedIndex(_pintuDepanKiriSelectedIndex);
+  }
+
+  void _onKacaJendelaKiriItemSelected(int index) {
+    setState(() {
+      _kacaJendelaKiriSelectedIndex = index;
+    });
+    ref.read(formProvider.notifier).updateKacaJendelaKiriSelectedIndex(index);
+  }
+
+  void _onKacaJendelaKiriEnabledChanged(bool enabled) {
+    setState(() {
+      _kacaJendelaKiriIsEnabled = enabled;
+      if (!enabled) {
+        _kacaJendelaKiriSelectedIndex = 0;
+      }
+    });
+    ref.read(formProvider.notifier).updateKacaJendelaKiriIsEnabled(enabled);
+    ref.read(formProvider.notifier).updateKacaJendelaKiriSelectedIndex(_kacaJendelaKiriSelectedIndex);
+  }
+
+  void _onLisplangKiriItemSelected(int index) {
+    setState(() {
+      _lisplangKiriSelectedIndex = index;
+    });
+    ref.read(formProvider.notifier).updateLisplangKiriSelectedIndex(index);
+  }
+
+  void _onLisplangKiriEnabledChanged(bool enabled) {
+    setState(() {
+      _lisplangKiriIsEnabled = enabled;
+      if (!enabled) {
+        _lisplangKiriSelectedIndex = 0;
+      }
+    });
+    ref.read(formProvider.notifier).updateLisplangKiriIsEnabled(enabled);
+    ref.read(formProvider.notifier).updateLisplangKiriSelectedIndex(_lisplangKiriSelectedIndex);
+  }
+
+  void _onSideSkirtKiriItemSelected(int index) {
+    setState(() {
+      _sideSkirtKiriSelectedIndex = index;
+    });
+    ref.read(formProvider.notifier).updateSideSkirtKiriSelectedIndex(index);
+  }
+
+  void _onSideSkirtKiriEnabledChanged(bool enabled) {
+    setState(() {
+      _sideSkirtKiriIsEnabled = enabled;
+      if (!enabled) {
+        _sideSkirtKiriSelectedIndex = 0;
+      }
+    });
+    ref.read(formProvider.notifier).updateSideSkirtKiriIsEnabled(enabled);
+    ref.read(formProvider.notifier).updateSideSkirtKiriSelectedIndex(_sideSkirtKiriSelectedIndex);
+  }
+
+  // Callback method for ExpandableTextField
+  void _onEksteriorCatatanChanged(List<String> lines) {
+    ref.read(formProvider.notifier).updateEksteriorCatatan(lines.join('\n'));
+  }
+
 
   @override
   Widget build(BuildContext context) {
@@ -22,10 +720,292 @@ class PageFiveFour extends StatelessWidget {
                 children: [
                   PageNumber(data: '5/9'),
                   const SizedBox(height: 8.0),
-                  PageTitle(data: 'Penilaian'),
+                  PageTitle(data: 'Penilaian (4)'),
                   const SizedBox(height: 24.0),
                   const HeadingOne(text: 'Hasil Inspeksi Eksterior'),
+                  const SizedBox(height: 16.0),
+
+                  // ToggleableNumberedButtonList widgets
+                  ToggleableNumberedButtonList(
+                    label: 'Bumper Depan',
+                    count: 10,
+                    selectedIndex: _bumperDepanSelectedIndex,
+                    onItemSelected: _onBumperDepanItemSelected,
+                    initialEnabled: _bumperDepanIsEnabled,
+                    onEnabledChanged: _onBumperDepanEnabledChanged,
+                  ),
+                  const SizedBox(height: 16.0),
+                  ToggleableNumberedButtonList(
+                    label: 'Kap Mesin',
+                    count: 10,
+                    selectedIndex: _kapMesinSelectedIndex,
+                    onItemSelected: _onKapMesinItemSelected,
+                    initialEnabled: _kapMesinIsEnabled,
+                    onEnabledChanged: _onKapMesinEnabledChanged,
+                  ),
+                  const SizedBox(height: 16.0),
+                  ToggleableNumberedButtonList(
+                    label: 'Lampu Utama',
+                    count: 10,
+                    selectedIndex: _lampuUtamaSelectedIndex,
+                    onItemSelected: _onLampuUtamaItemSelected,
+                    initialEnabled: _lampuUtamaIsEnabled,
+                    onEnabledChanged: _onLampuUtamaEnabledChanged,
+                  ),
+                  const SizedBox(height: 16.0),
+                  ToggleableNumberedButtonList(
+                    label: 'Panel Atap',
+                    count: 10,
+                    selectedIndex: _panelAtapSelectedIndex,
+                    onItemSelected: _onPanelAtapItemSelected,
+                    initialEnabled: _panelAtapIsEnabled,
+                    onEnabledChanged: _onPanelAtapEnabledChanged,
+                  ),
+                  const SizedBox(height: 16.0),
+                  ToggleableNumberedButtonList(
+                    label: 'Grill',
+                    count: 10,
+                    selectedIndex: _grillSelectedIndex,
+                    onItemSelected: _onGrillItemSelected,
+                    initialEnabled: _grillIsEnabled,
+                    onEnabledChanged: _onGrillEnabledChanged,
+                  ),
+                  const SizedBox(height: 16.0),
+                  ToggleableNumberedButtonList(
+                    label: 'Lampu Foglamp',
+                    count: 10,
+                    selectedIndex: _lampuFoglampSelectedIndex,
+                    onItemSelected: _onLampuFoglampItemSelected,
+                    initialEnabled: _lampuFoglampIsEnabled,
+                    onEnabledChanged: _onLampuFoglampEnabledChanged,
+                  ),
+                  const SizedBox(height: 16.0),
+                  ToggleableNumberedButtonList(
+                    label: 'Kaca Bening',
+                    count: 10,
+                    selectedIndex: _kacaBeningSelectedIndex,
+                    onItemSelected: _onKacaBeningItemSelected,
+                    initialEnabled: _kacaBeningIsEnabled,
+                    onEnabledChanged: _onKacaBeningEnabledChanged,
+                  ),
+                  const SizedBox(height: 16.0),
+                  ToggleableNumberedButtonList(
+                    label: 'Wiper Belakang',
+                    count: 10,
+                    selectedIndex: _wiperBelakangSelectedIndex,
+                    onItemSelected: _onWiperBelakangItemSelected,
+                    initialEnabled: _wiperBelakangIsEnabled,
+                    onEnabledChanged: _onWiperBelakangEnabledChanged,
+                  ),
+                  const SizedBox(height: 16.0),
+                  ToggleableNumberedButtonList(
+                    label: 'Bumper Belakang',
+                    count: 10,
+                    selectedIndex: _bumperBelakangSelectedIndex,
+                    onItemSelected: _onBumperBelakangItemSelected,
+                    initialEnabled: _bumperBelakangIsEnabled,
+                    onEnabledChanged: _onBumperBelakangEnabledChanged,
+                  ),
+                  const SizedBox(height: 16.0),
+                  ToggleableNumberedButtonList(
+                    label: 'Lampu Belakang',
+                    count: 10,
+                    selectedIndex: _lampuBelakangSelectedIndex,
+                    onItemSelected: _onLampuBelakangItemSelected,
+                    initialEnabled: _lampuBelakangIsEnabled,
+                    onEnabledChanged: _onLampuBelakangEnabledChanged,
+                  ),
+                  const SizedBox(height: 16.0),
+                  ToggleableNumberedButtonList(
+                    label: 'Trunklid',
+                    count: 10,
+                    selectedIndex: _trunklidSelectedIndex,
+                    onItemSelected: _onTrunklidItemSelected,
+                    initialEnabled: _trunklidIsEnabled,
+                    onEnabledChanged: _onTrunklidEnabledChanged,
+                  ),
+                  const SizedBox(height: 16.0),
+                  ToggleableNumberedButtonList(
+                    label: 'Kaca Depan',
+                    count: 10,
+                    selectedIndex: _kacaDepanSelectedIndex,
+                    onItemSelected: _onKacaDepanItemSelected,
+                    initialEnabled: _kacaDepanIsEnabled,
+                    onEnabledChanged: _onKacaDepanEnabledChanged,
+                  ),
+                  const SizedBox(height: 16.0),
+                  ToggleableNumberedButtonList(
+                    label: 'Fender Kanan',
+                    count: 10,
+                    selectedIndex: _fenderKananSelectedIndex,
+                    onItemSelected: _onFenderKananItemSelected,
+                    initialEnabled: _fenderKananIsEnabled,
+                    onEnabledChanged: _onFenderKananEnabledChanged,
+                  ),
+                  const SizedBox(height: 16.0),
+                  ToggleableNumberedButtonList(
+                    label: 'Quarter Panel Kanan',
+                    count: 10,
+                    selectedIndex: _quarterPanelKananSelectedIndex,
+                    onItemSelected: _onQuarterPanelKananItemSelected,
+                    initialEnabled: _quarterPanelKananIsEnabled,
+                    onEnabledChanged: _onQuarterPanelKananEnabledChanged,
+                  ),
+                  const SizedBox(height: 16.0),
+                  ToggleableNumberedButtonList(
+                    label: 'Pintu Belakang Kanan',
+                    count: 10,
+                    selectedIndex: _pintuBelakangKananSelectedIndex,
+                    onItemSelected: _onPintuBelakangKananItemSelected,
+                    initialEnabled: _pintuBelakangKananIsEnabled,
+                    onEnabledChanged: _onPintuBelakangKananEnabledChanged,
+                  ),
+                  const SizedBox(height: 16.0),
+                  ToggleableNumberedButtonList(
+                    label: 'Spion Kanan',
+                    count: 10,
+                    selectedIndex: _spionKananSelectedIndex,
+                    onItemSelected: _onSpionKananItemSelected,
+                    initialEnabled: _spionKananIsEnabled,
+                    onEnabledChanged: _onSpionKananEnabledChanged,
+                  ),
+                  const SizedBox(height: 16.0),
+                  ToggleableNumberedButtonList(
+                    label: 'Lisplang Kanan',
+                    count: 10,
+                    selectedIndex: _lisplangKananSelectedIndex,
+                    onItemSelected: _onLisplangKananItemSelected,
+                    initialEnabled: _lisplangKananIsEnabled,
+                    onEnabledChanged: _onLisplangKananEnabledChanged,
+                  ),
+                  const SizedBox(height: 16.0),
+                  ToggleableNumberedButtonList(
+                    label: 'Side Skirt Kanan',
+                    count: 10,
+                    selectedIndex: _sideSkirtKananSelectedIndex,
+                    onItemSelected: _onSideSkirtKananItemSelected,
+                    initialEnabled: _sideSkirtKananIsEnabled,
+                    onEnabledChanged: _onSideSkirtKananEnabledChanged,
+                  ),
+                  const SizedBox(height: 16.0),
+                  ToggleableNumberedButtonList(
+                    label: 'Daun Wiper',
+                    count: 10,
+                    selectedIndex: _daunWiperSelectedIndex,
+                    onItemSelected: _onDaunWiperItemSelected,
+                    initialEnabled: _daunWiperIsEnabled,
+                    onEnabledChanged: _onDaunWiperEnabledChanged,
+                  ),
+                  const SizedBox(height: 16.0),
+                  ToggleableNumberedButtonList(
+                    label: 'Pintu Belakang',
+                    count: 10,
+                    selectedIndex: _pintuBelakangSelectedIndex,
+                    onItemSelected: _onPintuBelakangItemSelected,
+                    initialEnabled: _pintuBelakangIsEnabled,
+                    onEnabledChanged: _onPintuBelakangEnabledChanged,
+                  ),
+                  const SizedBox(height: 16.0),
+                  ToggleableNumberedButtonList(
+                    label: 'Fender Kiri',
+                    count: 10,
+                    selectedIndex: _fenderKiriSelectedIndex,
+                    onItemSelected: _onFenderKiriItemSelected,
+                    initialEnabled: _fenderKiriIsEnabled,
+                    onEnabledChanged: _onFenderKiriEnabledChanged,
+                  ),
+                  const SizedBox(height: 16.0),
+                  ToggleableNumberedButtonList(
+                    label: 'Quarter Panel Kiri',
+                    count: 10,
+                    selectedIndex: _quarterPanelKiriSelectedIndex,
+                    onItemSelected: _onQuarterPanelKiriItemSelected,
+                    initialEnabled: _quarterPanelKiriIsEnabled,
+                    onEnabledChanged: _onQuarterPanelKiriEnabledChanged,
+                  ),
+                  const SizedBox(height: 16.0),
+                  ToggleableNumberedButtonList(
+                    label: 'Pintu Depan',
+                    count: 10,
+                    selectedIndex: _pintuDepanSelectedIndex,
+                    onItemSelected: _onPintuDepanItemSelected,
+                    initialEnabled: _pintuDepanIsEnabled,
+                    onEnabledChanged: _onPintuDepanEnabledChanged,
+                  ),
+                  const SizedBox(height: 16.0),
+                  ToggleableNumberedButtonList(
+                    label: 'Kaca Jendela Kanan',
+                    count: 10,
+                    selectedIndex: _kacaJendelaKananSelectedIndex,
+                    onItemSelected: _onKacaJendelaKananItemSelected,
+                    initialEnabled: _kacaJendelaKananIsEnabled,
+                    onEnabledChanged: _onKacaJendelaKananEnabledChanged,
+                  ),
+                  const SizedBox(height: 16.0),
+                  ToggleableNumberedButtonList(
+                    label: 'Pintu Belakang Kiri',
+                    count: 10,
+                    selectedIndex: _pintuBelakangKiriSelectedIndex,
+                    onItemSelected: _onPintuBelakangKiriItemSelected,
+                    initialEnabled: _pintuBelakangKiriIsEnabled,
+                    onEnabledChanged: _onPintuBelakangKiriEnabledChanged,
+                  ),
+                  const SizedBox(height: 16.0),
+                  ToggleableNumberedButtonList(
+                    label: 'Spion Kiri',
+                    count: 10,
+                    selectedIndex: _spionKiriSelectedIndex,
+                    onItemSelected: _onSpionKiriItemSelected,
+                    initialEnabled: _spionKiriIsEnabled,
+                    onEnabledChanged: _onSpionKiriEnabledChanged,
+                  ),
+                  const SizedBox(height: 16.0),
+                  ToggleableNumberedButtonList(
+                    label: 'Pintu Depan Kiri',
+                    count: 10,
+                    selectedIndex: _pintuDepanKiriSelectedIndex,
+                    onItemSelected: _onPintuDepanKiriItemSelected,
+                    initialEnabled: _pintuDepanKiriIsEnabled,
+                    onEnabledChanged: _onPintuDepanKiriEnabledChanged,
+                  ),
+                  const SizedBox(height: 16.0),
+                  ToggleableNumberedButtonList(
+                    label: 'Kaca Jendela Kiri',
+                    count: 10,
+                    selectedIndex: _kacaJendelaKiriSelectedIndex,
+                    onItemSelected: _onKacaJendelaKiriItemSelected,
+                    initialEnabled: _kacaJendelaKiriIsEnabled,
+                    onEnabledChanged: _onKacaJendelaKiriEnabledChanged,
+                  ),
+                  const SizedBox(height: 16.0),
+                  ToggleableNumberedButtonList(
+                    label: 'Lisplang Kiri',
+                    count: 10,
+                    selectedIndex: _lisplangKiriSelectedIndex,
+                    onItemSelected: _onLisplangKiriItemSelected,
+                    initialEnabled: _lisplangKiriIsEnabled,
+                    onEnabledChanged: _onLisplangKiriEnabledChanged,
+                  ),
+                  const SizedBox(height: 16.0),
+                  ToggleableNumberedButtonList(
+                    label: 'Side Skirt Kiri',
+                    count: 10,
+                    selectedIndex: _sideSkirtKiriSelectedIndex,
+                    onItemSelected: _onSideSkirtKiriItemSelected,
+                    initialEnabled: _sideSkirtKiriIsEnabled,
+                    onEnabledChanged: _onSideSkirtKiriEnabledChanged,
+                  ),
+                  const SizedBox(height: 16.0),
+
+                  // ExpandableTextField
+                  ExpandableTextField(
+                    label: 'Catatan',
+                    hintText: 'Masukkan catatan di sini',
+                    controller: _eksteriorCatatanController,
+                    onChangedList: _onEksteriorCatatanChanged,
+                  ),
                   const SizedBox(height: 32.0),
+
                   NavigationButtonRow(
                     onBackPressed: () => Navigator.pop(context),
                     onNextPressed: () {

--- a/lib/pages/page_five_four.dart
+++ b/lib/pages/page_five_four.dart
@@ -20,1009 +20,571 @@ class PageFiveFour extends ConsumerStatefulWidget {
 }
 
 class _PageFiveFourState extends ConsumerState<PageFiveFour> {
-  // State variables for ToggleableNumberedButtonList
-  late int _bumperDepanSelectedIndex;
-  late bool _bumperDepanIsEnabled;
-  late int _kapMesinSelectedIndex;
-  late bool _kapMesinIsEnabled;
-  late int _lampuUtamaSelectedIndex;
-  late bool _lampuUtamaIsEnabled;
-  late int _panelAtapSelectedIndex;
-  late bool _panelAtapIsEnabled;
-  late int _grillSelectedIndex;
-  late bool _grillIsEnabled;
-  late int _lampuFoglampSelectedIndex;
-  late bool _lampuFoglampIsEnabled;
-  late int _kacaBeningSelectedIndex;
-  late bool _kacaBeningIsEnabled;
-  late int _wiperBelakangSelectedIndex;
-  late bool _wiperBelakangIsEnabled;
-  late int _bumperBelakangSelectedIndex;
-  late bool _bumperBelakangIsEnabled;
-  late int _lampuBelakangSelectedIndex;
-  late bool _lampuBelakangIsEnabled;
-  late int _trunklidSelectedIndex;
-  late bool _trunklidIsEnabled;
-  late int _kacaDepanSelectedIndex;
-  late bool _kacaDepanIsEnabled;
-  late int _fenderKananSelectedIndex;
-  late bool _fenderKananIsEnabled;
-  late int _quarterPanelKananSelectedIndex;
-  late bool _quarterPanelKananIsEnabled;
-  late int _pintuBelakangKananSelectedIndex;
-  late bool _pintuBelakangKananIsEnabled;
-  late int _spionKananSelectedIndex;
-  late bool _spionKananIsEnabled;
-  late int _lisplangKananSelectedIndex;
-  late bool _lisplangKananIsEnabled;
-  late int _sideSkirtKananSelectedIndex;
-  late bool _sideSkirtKananIsEnabled;
-  late int _daunWiperSelectedIndex;
-  late bool _daunWiperIsEnabled;
-  late int _pintuBelakangSelectedIndex;
-  late bool _pintuBelakangIsEnabled;
-  late int _fenderKiriSelectedIndex;
-  late bool _fenderKiriIsEnabled;
-  late int _quarterPanelKiriSelectedIndex;
-  late bool _quarterPanelKiriIsEnabled;
-  late int _pintuDepanSelectedIndex;
-  late bool _pintuDepanIsEnabled;
-  late int _kacaJendelaKananSelectedIndex;
-  late bool _kacaJendelaKananIsEnabled;
-  late int _pintuBelakangKiriSelectedIndex;
-  late bool _pintuBelakangKiriIsEnabled;
-  late int _spionKiriSelectedIndex;
-  late bool _spionKiriIsEnabled;
-  late int _pintuDepanKiriSelectedIndex;
-  late bool _pintuDepanKiriIsEnabled;
-  late int _kacaJendelaKiriSelectedIndex;
-  late bool _kacaJendelaKiriIsEnabled;
-  late int _lisplangKiriSelectedIndex;
-  late bool _lisplangKiriIsEnabled;
-  late int _sideSkirtKiriSelectedIndex;
-  late bool _sideSkirtKiriIsEnabled;
+  late FocusScopeNode _focusScopeNode;
 
   // State variable for ExpandableTextField
   late TextEditingController _eksteriorCatatanController;
 
-
   @override
   void initState() {
     super.initState();
+    _focusScopeNode = FocusScopeNode();
     final formData = ref.read(formProvider);
-    // Initialize state variables from formProvider
-    _bumperDepanSelectedIndex = formData.bumperDepanSelectedIndex ?? 0;
-    _bumperDepanIsEnabled = formData.bumperDepanIsEnabled ?? true;
-    _kapMesinSelectedIndex = formData.kapMesinSelectedIndex ?? 0;
-    _kapMesinIsEnabled = formData.kapMesinIsEnabled ?? true;
-    _lampuUtamaSelectedIndex = formData.lampuUtamaSelectedIndex ?? 0;
-    _lampuUtamaIsEnabled = formData.lampuUtamaIsEnabled ?? true;
-    _panelAtapSelectedIndex = formData.panelAtapSelectedIndex ?? 0;
-    _panelAtapIsEnabled = formData.panelAtapIsEnabled ?? true;
-    _grillSelectedIndex = formData.grillSelectedIndex ?? 0;
-    _grillIsEnabled = formData.grillIsEnabled ?? true;
-    _lampuFoglampSelectedIndex = formData.lampuFoglampSelectedIndex ?? 0;
-    _lampuFoglampIsEnabled = formData.lampuFoglampIsEnabled ?? true;
-    _kacaBeningSelectedIndex = formData.kacaBeningSelectedIndex ?? 0;
-    _kacaBeningIsEnabled = formData.kacaBeningIsEnabled ?? true;
-    _wiperBelakangSelectedIndex = formData.wiperBelakangSelectedIndex ?? 0;
-    _wiperBelakangIsEnabled = formData.wiperBelakangIsEnabled ?? true;
-    _bumperBelakangSelectedIndex = formData.bumperBelakangSelectedIndex ?? 0;
-    _bumperBelakangIsEnabled = formData.bumperBelakangIsEnabled ?? true;
-    _lampuBelakangSelectedIndex = formData.lampuBelakangSelectedIndex ?? 0;
-    _lampuBelakangIsEnabled = formData.lampuBelakangIsEnabled ?? true;
-    _trunklidSelectedIndex = formData.trunklidSelectedIndex ?? 0;
-    _trunklidIsEnabled = formData.trunklidIsEnabled ?? true;
-    _kacaDepanSelectedIndex = formData.kacaDepanSelectedIndex ?? 0;
-    _kacaDepanIsEnabled = formData.kacaDepanIsEnabled ?? true;
-    _fenderKananSelectedIndex = formData.fenderKananSelectedIndex ?? 0;
-    _fenderKananIsEnabled = formData.fenderKananIsEnabled ?? true;
-    _quarterPanelKananSelectedIndex = formData.quarterPanelKananSelectedIndex ?? 0;
-    _quarterPanelKananIsEnabled = formData.quarterPanelKananIsEnabled ?? true;
-    _pintuBelakangKananSelectedIndex = formData.pintuBelakangKananSelectedIndex ?? 0;
-    _pintuBelakangKananIsEnabled = formData.pintuBelakangKananIsEnabled ?? true;
-    _spionKananSelectedIndex = formData.spionKananSelectedIndex ?? 0;
-    _spionKananIsEnabled = formData.spionKananIsEnabled ?? true;
-    _lisplangKananSelectedIndex = formData.lisplangKananSelectedIndex ?? 0;
-    _lisplangKananIsEnabled = formData.lisplangKananIsEnabled ?? true;
-    _sideSkirtKananSelectedIndex = formData.sideSkirtKananSelectedIndex ?? 0;
-    _sideSkirtKananIsEnabled = formData.sideSkirtKananIsEnabled ?? true;
-    _daunWiperSelectedIndex = formData.daunWiperSelectedIndex ?? 0;
-    _daunWiperIsEnabled = formData.daunWiperIsEnabled ?? true;
-    _pintuBelakangSelectedIndex = formData.pintuBelakangSelectedIndex ?? 0;
-    _pintuBelakangIsEnabled = formData.pintuBelakangIsEnabled ?? true;
-    _fenderKiriSelectedIndex = formData.fenderKiriSelectedIndex ?? 0;
-    _fenderKiriIsEnabled = formData.fenderKiriIsEnabled ?? true;
-    _quarterPanelKiriSelectedIndex = formData.quarterPanelKiriSelectedIndex ?? 0;
-    _quarterPanelKiriIsEnabled = formData.quarterPanelKiriIsEnabled ?? true;
-    _pintuDepanSelectedIndex = formData.pintuDepanSelectedIndex ?? 0;
-    _pintuDepanIsEnabled = formData.pintuDepanIsEnabled ?? true;
-    _kacaJendelaKananSelectedIndex = formData.kacaJendelaKananSelectedIndex ?? 0;
-    _kacaJendelaKananIsEnabled = formData.kacaJendelaKananIsEnabled ?? true;
-    _pintuBelakangKiriSelectedIndex = formData.pintuBelakangKiriSelectedIndex ?? 0;
-    _pintuBelakangKiriIsEnabled = formData.pintuBelakangKiriIsEnabled ?? true;
-    _spionKiriSelectedIndex = formData.spionKiriSelectedIndex ?? 0;
-    _spionKiriIsEnabled = formData.spionKiriIsEnabled ?? true;
-    _pintuDepanKiriSelectedIndex = formData.pintuDepanKiriSelectedIndex ?? 0;
-    _pintuDepanKiriIsEnabled = formData.pintuDepanKiriIsEnabled ?? true;
-    _kacaJendelaKiriSelectedIndex = formData.kacaJendelaKiriSelectedIndex ?? 0;
-    _kacaJendelaKiriIsEnabled = formData.kacaJendelaKiriIsEnabled ?? true;
-    _lisplangKiriSelectedIndex = formData.lisplangKiriSelectedIndex ?? 0;
-    _lisplangKiriIsEnabled = formData.lisplangKiriIsEnabled ?? true;
-    _sideSkirtKiriSelectedIndex = formData.sideSkirtKiriSelectedIndex ?? 0;
-    _sideSkirtKiriIsEnabled = formData.sideSkirtKiriIsEnabled ?? true;
-
     _eksteriorCatatanController = TextEditingController(text: formData.eksteriorCatatan ?? '');
   }
 
   @override
   void dispose() {
+    _focusScopeNode.dispose();
     _eksteriorCatatanController.dispose();
     super.dispose();
   }
 
-  // Callback methods for ToggleableNumberedButtonList
-  void _onBumperDepanItemSelected(int index) {
-    setState(() {
-      _bumperDepanSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateBumperDepanSelectedIndex(index);
-  }
-
-  void _onBumperDepanEnabledChanged(bool enabled) {
-    setState(() {
-      _bumperDepanIsEnabled = enabled;
-      if (!enabled) {
-        _bumperDepanSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateBumperDepanIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateBumperDepanSelectedIndex(_bumperDepanSelectedIndex);
-  }
-
-  void _onKapMesinItemSelected(int index) {
-    setState(() {
-      _kapMesinSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateKapMesinSelectedIndex(index);
-  }
-
-  void _onKapMesinEnabledChanged(bool enabled) {
-    setState(() {
-      _kapMesinIsEnabled = enabled;
-      if (!enabled) {
-        _kapMesinSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateKapMesinIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateKapMesinSelectedIndex(_kapMesinSelectedIndex);
-  }
-
-  void _onLampuUtamaItemSelected(int index) {
-    setState(() {
-      _lampuUtamaSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateLampuUtamaSelectedIndex(index);
-  }
-
-  void _onLampuUtamaEnabledChanged(bool enabled) {
-    setState(() {
-      _lampuUtamaIsEnabled = enabled;
-      if (!enabled) {
-        _lampuUtamaSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateLampuUtamaIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateLampuUtamaSelectedIndex(_lampuUtamaSelectedIndex);
-  }
-
-  void _onPanelAtapItemSelected(int index) {
-    setState(() {
-      _panelAtapSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updatePanelAtapSelectedIndex(index);
-  }
-
-  void _onPanelAtapEnabledChanged(bool enabled) {
-    setState(() {
-      _panelAtapIsEnabled = enabled;
-      if (!enabled) {
-        _panelAtapSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updatePanelAtapIsEnabled(enabled);
-    ref.read(formProvider.notifier).updatePanelAtapSelectedIndex(_panelAtapSelectedIndex);
-  }
-
-  void _onGrillItemSelected(int index) {
-    setState(() {
-      _grillSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateGrillSelectedIndex(index);
-  }
-
-  void _onGrillEnabledChanged(bool enabled) {
-    setState(() {
-      _grillIsEnabled = enabled;
-      if (!enabled) {
-        _grillSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateGrillIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateGrillSelectedIndex(_grillSelectedIndex);
-  }
-
-  void _onLampuFoglampItemSelected(int index) {
-    setState(() {
-      _lampuFoglampSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateLampuFoglampSelectedIndex(index);
-  }
-
-  void _onLampuFoglampEnabledChanged(bool enabled) {
-    setState(() {
-      _lampuFoglampIsEnabled = enabled;
-      if (!enabled) {
-        _lampuFoglampSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateLampuFoglampIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateLampuFoglampSelectedIndex(_lampuFoglampSelectedIndex);
-  }
-
-  void _onKacaBeningItemSelected(int index) {
-    setState(() {
-      _kacaBeningSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateKacaBeningSelectedIndex(index);
-  }
-
-  void _onKacaBeningEnabledChanged(bool enabled) {
-    setState(() {
-      _kacaBeningIsEnabled = enabled;
-      if (!enabled) {
-        _kacaBeningSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateKacaBeningIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateKacaBeningSelectedIndex(_kacaBeningSelectedIndex);
-  }
-
-  void _onWiperBelakangItemSelected(int index) {
-    setState(() {
-      _wiperBelakangSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateWiperBelakangSelectedIndex(index);
-  }
-
-  void _onWiperBelakangEnabledChanged(bool enabled) {
-    setState(() {
-      _wiperBelakangIsEnabled = enabled;
-      if (!enabled) {
-        _wiperBelakangSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateWiperBelakangIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateWiperBelakangSelectedIndex(_wiperBelakangSelectedIndex);
-  }
-
-  void _onBumperBelakangItemSelected(int index) {
-    setState(() {
-      _bumperBelakangSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateBumperBelakangSelectedIndex(index);
-  }
-
-  void _onBumperBelakangEnabledChanged(bool enabled) {
-    setState(() {
-      _bumperBelakangIsEnabled = enabled;
-      if (!enabled) {
-        _bumperBelakangSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateBumperBelakangIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateBumperBelakangSelectedIndex(_bumperBelakangSelectedIndex);
-  }
-
-  void _onLampuBelakangItemSelected(int index) {
-    setState(() {
-      _lampuBelakangSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateLampuBelakangSelectedIndex(index);
-  }
-
-  void _onLampuBelakangEnabledChanged(bool enabled) {
-    setState(() {
-      _lampuBelakangIsEnabled = enabled;
-      if (!enabled) {
-        _lampuBelakangSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateLampuBelakangIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateLampuBelakangSelectedIndex(_lampuBelakangSelectedIndex);
-  }
-
-  void _onTrunklidItemSelected(int index) {
-    setState(() {
-      _trunklidSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateTrunklidSelectedIndex(index);
-  }
-
-  void _onTrunklidEnabledChanged(bool enabled) {
-    setState(() {
-      _trunklidIsEnabled = enabled;
-      if (!enabled) {
-        _trunklidSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateTrunklidIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateTrunklidSelectedIndex(_trunklidSelectedIndex);
-  }
-
-  void _onKacaDepanItemSelected(int index) {
-    setState(() {
-      _kacaDepanSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateKacaDepanSelectedIndex(index);
-  }
-
-  void _onKacaDepanEnabledChanged(bool enabled) {
-    setState(() {
-      _kacaDepanIsEnabled = enabled;
-      if (!enabled) {
-        _kacaDepanSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateKacaDepanIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateKacaDepanSelectedIndex(_kacaDepanSelectedIndex);
-  }
-
-  void _onFenderKananItemSelected(int index) {
-    setState(() {
-      _fenderKananSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateFenderKananSelectedIndex(index);
-  }
-
-  void _onFenderKananEnabledChanged(bool enabled) {
-    setState(() {
-      _fenderKananIsEnabled = enabled;
-      if (!enabled) {
-        _fenderKananSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateFenderKananIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateFenderKananSelectedIndex(_fenderKananSelectedIndex);
-  }
-
-  void _onQuarterPanelKananItemSelected(int index) {
-    setState(() {
-      _quarterPanelKananSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateQuarterPanelKananSelectedIndex(index);
-  }
-
-  void _onQuarterPanelKananEnabledChanged(bool enabled) {
-    setState(() {
-      _quarterPanelKananIsEnabled = enabled;
-      if (!enabled) {
-        _quarterPanelKananSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateQuarterPanelKananIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateQuarterPanelKananSelectedIndex(_quarterPanelKananSelectedIndex);
-  }
-
-  void _onPintuBelakangKananItemSelected(int index) {
-    setState(() {
-      _pintuBelakangKananSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updatePintuBelakangKananSelectedIndex(index);
-  }
-
-  void _onPintuBelakangKananEnabledChanged(bool enabled) {
-    setState(() {
-      _pintuBelakangKananIsEnabled = enabled;
-      if (!enabled) {
-        _pintuBelakangKananSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updatePintuBelakangKananIsEnabled(enabled);
-    ref.read(formProvider.notifier).updatePintuBelakangKananSelectedIndex(_pintuBelakangKananSelectedIndex);
-  }
-
-  void _onSpionKananItemSelected(int index) {
-    setState(() {
-      _spionKananSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateSpionKananSelectedIndex(index);
-  }
-
-  void _onSpionKananEnabledChanged(bool enabled) {
-    setState(() {
-      _spionKananIsEnabled = enabled;
-      if (!enabled) {
-        _spionKananSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateSpionKananIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateSpionKananSelectedIndex(_spionKananSelectedIndex);
-  }
-
-  void _onLisplangKananItemSelected(int index) {
-    setState(() {
-      _lisplangKananSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateLisplangKananSelectedIndex(index);
-  }
-
-  void _onLisplangKananEnabledChanged(bool enabled) {
-    setState(() {
-      _lisplangKananIsEnabled = enabled;
-      if (!enabled) {
-        _lisplangKananSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateLisplangKananIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateLisplangKananSelectedIndex(_lisplangKananSelectedIndex);
-  }
-
-  void _onSideSkirtKananItemSelected(int index) {
-    setState(() {
-      _sideSkirtKananSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateSideSkirtKananSelectedIndex(index);
-  }
-
-  void _onSideSkirtKananEnabledChanged(bool enabled) {
-    setState(() {
-      _sideSkirtKananIsEnabled = enabled;
-      if (!enabled) {
-        _sideSkirtKananSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateSideSkirtKananIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateSideSkirtKananSelectedIndex(_sideSkirtKananSelectedIndex);
-  }
-
-  void _onDaunWiperItemSelected(int index) {
-    setState(() {
-      _daunWiperSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateDaunWiperSelectedIndex(index);
-  }
-
-  void _onDaunWiperEnabledChanged(bool enabled) {
-    setState(() {
-      _daunWiperIsEnabled = enabled;
-      if (!enabled) {
-        _daunWiperSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateDaunWiperIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateDaunWiperSelectedIndex(_daunWiperSelectedIndex);
-  }
-
-  void _onPintuBelakangItemSelected(int index) {
-    setState(() {
-      _pintuBelakangSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updatePintuBelakangSelectedIndex(index);
-  }
-
-  void _onPintuBelakangEnabledChanged(bool enabled) {
-    setState(() {
-      _pintuBelakangIsEnabled = enabled;
-      if (!enabled) {
-        _pintuBelakangSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updatePintuBelakangIsEnabled(enabled);
-    ref.read(formProvider.notifier).updatePintuBelakangSelectedIndex(_pintuBelakangSelectedIndex);
-  }
-
-  void _onFenderKiriItemSelected(int index) {
-    setState(() {
-      _fenderKiriSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateFenderKiriSelectedIndex(index);
-  }
-
-  void _onFenderKiriEnabledChanged(bool enabled) {
-    setState(() {
-      _fenderKiriIsEnabled = enabled;
-      if (!enabled) {
-        _fenderKiriSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateFenderKiriIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateFenderKiriSelectedIndex(_fenderKiriSelectedIndex);
-  }
-
-  void _onQuarterPanelKiriItemSelected(int index) {
-    setState(() {
-      _quarterPanelKiriSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateQuarterPanelKiriSelectedIndex(index);
-  }
-
-  void _onQuarterPanelKiriEnabledChanged(bool enabled) {
-    setState(() {
-      _quarterPanelKiriIsEnabled = enabled;
-      if (!enabled) {
-        _quarterPanelKiriSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateQuarterPanelKiriIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateQuarterPanelKiriSelectedIndex(_quarterPanelKiriSelectedIndex);
-  }
-
-  void _onPintuDepanItemSelected(int index) {
-    setState(() {
-      _pintuDepanSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updatePintuDepanSelectedIndex(index);
-  }
-
-  void _onPintuDepanEnabledChanged(bool enabled) {
-    setState(() {
-      _pintuDepanIsEnabled = enabled;
-      if (!enabled) {
-        _pintuDepanSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updatePintuDepanIsEnabled(enabled);
-    ref.read(formProvider.notifier).updatePintuDepanSelectedIndex(_pintuDepanSelectedIndex);
-  }
-
-  void _onKacaJendelaKananItemSelected(int index) {
-    setState(() {
-      _kacaJendelaKananSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateKacaJendelaKananSelectedIndex(index);
-  }
-
-  void _onKacaJendelaKananEnabledChanged(bool enabled) {
-    setState(() {
-      _kacaJendelaKananIsEnabled = enabled;
-      if (!enabled) {
-        _kacaJendelaKananSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateKacaJendelaKananIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateKacaJendelaKananSelectedIndex(_kacaJendelaKananSelectedIndex);
-  }
-
-  void _onPintuBelakangKiriItemSelected(int index) {
-    setState(() {
-      _pintuBelakangKiriSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updatePintuBelakangKiriSelectedIndex(index);
-  }
-
-  void _onPintuBelakangKiriEnabledChanged(bool enabled) {
-    setState(() {
-      _pintuBelakangKiriIsEnabled = enabled;
-      if (!enabled) {
-        _pintuBelakangKiriSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updatePintuBelakangKiriIsEnabled(enabled);
-    ref.read(formProvider.notifier).updatePintuBelakangKiriSelectedIndex(_pintuBelakangKiriSelectedIndex);
-  }
-
-  void _onSpionKiriItemSelected(int index) {
-    setState(() {
-      _spionKiriSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateSpionKiriSelectedIndex(index);
-  }
-
-  void _onSpionKiriEnabledChanged(bool enabled) {
-    setState(() {
-      _spionKiriIsEnabled = enabled;
-      if (!enabled) {
-        _spionKiriSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateSpionKiriIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateSpionKiriSelectedIndex(_spionKiriSelectedIndex);
-  }
-
-  void _onPintuDepanKiriItemSelected(int index) {
-    setState(() {
-      _pintuDepanKiriSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updatePintuDepanKiriSelectedIndex(index);
-  }
-
-  void _onPintuDepanKiriEnabledChanged(bool enabled) {
-    setState(() {
-      _pintuDepanKiriIsEnabled = enabled;
-      if (!enabled) {
-        _pintuDepanKiriSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updatePintuDepanKiriIsEnabled(enabled);
-    ref.read(formProvider.notifier).updatePintuDepanKiriSelectedIndex(_pintuDepanKiriSelectedIndex);
-  }
-
-  void _onKacaJendelaKiriItemSelected(int index) {
-    setState(() {
-      _kacaJendelaKiriSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateKacaJendelaKiriSelectedIndex(index);
-  }
-
-  void _onKacaJendelaKiriEnabledChanged(bool enabled) {
-    setState(() {
-      _kacaJendelaKiriIsEnabled = enabled;
-      if (!enabled) {
-        _kacaJendelaKiriSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateKacaJendelaKiriIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateKacaJendelaKiriSelectedIndex(_kacaJendelaKiriSelectedIndex);
-  }
-
-  void _onLisplangKiriItemSelected(int index) {
-    setState(() {
-      _lisplangKiriSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateLisplangKiriSelectedIndex(index);
-  }
-
-  void _onLisplangKiriEnabledChanged(bool enabled) {
-    setState(() {
-      _lisplangKiriIsEnabled = enabled;
-      if (!enabled) {
-        _lisplangKiriSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateLisplangKiriIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateLisplangKiriSelectedIndex(_lisplangKiriSelectedIndex);
-  }
-
-  void _onSideSkirtKiriItemSelected(int index) {
-    setState(() {
-      _sideSkirtKiriSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateSideSkirtKiriSelectedIndex(index);
-  }
-
-  void _onSideSkirtKiriEnabledChanged(bool enabled) {
-    setState(() {
-      _sideSkirtKiriIsEnabled = enabled;
-      if (!enabled) {
-        _sideSkirtKiriSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateSideSkirtKiriIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateSideSkirtKiriSelectedIndex(_sideSkirtKiriSelectedIndex);
-  }
-
-  // Callback method for ExpandableTextField
-  void _onEksteriorCatatanChanged(List<String> lines) {
-    ref.read(formProvider.notifier).updateEksteriorCatatan(lines.join('\n'));
-  }
-
-
   @override
   Widget build(BuildContext context) {
-    return CommonLayout(
-      child: Column(
-        children: [
-          Expanded(
-            child: SingleChildScrollView(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  PageNumber(data: '5/9'),
-                  const SizedBox(height: 8.0),
-                  PageTitle(data: 'Penilaian (4)'),
-                  const SizedBox(height: 24.0),
-                  const HeadingOne(text: 'Hasil Inspeksi Eksterior'),
-                  const SizedBox(height: 16.0),
+    final formData = ref.watch(formProvider);
+    final formNotifier = ref.read(formProvider.notifier);
 
-                  // ToggleableNumberedButtonList widgets
-                  ToggleableNumberedButtonList(
-                    label: 'Bumper Depan',
-                    count: 10,
-                    selectedIndex: _bumperDepanSelectedIndex,
-                    onItemSelected: _onBumperDepanItemSelected,
-                    initialEnabled: _bumperDepanIsEnabled,
-                    onEnabledChanged: _onBumperDepanEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Kap Mesin',
-                    count: 10,
-                    selectedIndex: _kapMesinSelectedIndex,
-                    onItemSelected: _onKapMesinItemSelected,
-                    initialEnabled: _kapMesinIsEnabled,
-                    onEnabledChanged: _onKapMesinEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Lampu Utama',
-                    count: 10,
-                    selectedIndex: _lampuUtamaSelectedIndex,
-                    onItemSelected: _onLampuUtamaItemSelected,
-                    initialEnabled: _lampuUtamaIsEnabled,
-                    onEnabledChanged: _onLampuUtamaEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Panel Atap',
-                    count: 10,
-                    selectedIndex: _panelAtapSelectedIndex,
-                    onItemSelected: _onPanelAtapItemSelected,
-                    initialEnabled: _panelAtapIsEnabled,
-                    onEnabledChanged: _onPanelAtapEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Grill',
-                    count: 10,
-                    selectedIndex: _grillSelectedIndex,
-                    onItemSelected: _onGrillItemSelected,
-                    initialEnabled: _grillIsEnabled,
-                    onEnabledChanged: _onGrillEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Lampu Foglamp',
-                    count: 10,
-                    selectedIndex: _lampuFoglampSelectedIndex,
-                    onItemSelected: _onLampuFoglampItemSelected,
-                    initialEnabled: _lampuFoglampIsEnabled,
-                    onEnabledChanged: _onLampuFoglampEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Kaca Bening',
-                    count: 10,
-                    selectedIndex: _kacaBeningSelectedIndex,
-                    onItemSelected: _onKacaBeningItemSelected,
-                    initialEnabled: _kacaBeningIsEnabled,
-                    onEnabledChanged: _onKacaBeningEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Wiper Belakang',
-                    count: 10,
-                    selectedIndex: _wiperBelakangSelectedIndex,
-                    onItemSelected: _onWiperBelakangItemSelected,
-                    initialEnabled: _wiperBelakangIsEnabled,
-                    onEnabledChanged: _onWiperBelakangEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Bumper Belakang',
-                    count: 10,
-                    selectedIndex: _bumperBelakangSelectedIndex,
-                    onItemSelected: _onBumperBelakangItemSelected,
-                    initialEnabled: _bumperBelakangIsEnabled,
-                    onEnabledChanged: _onBumperBelakangEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Lampu Belakang',
-                    count: 10,
-                    selectedIndex: _lampuBelakangSelectedIndex,
-                    onItemSelected: _onLampuBelakangItemSelected,
-                    initialEnabled: _lampuBelakangIsEnabled,
-                    onEnabledChanged: _onLampuBelakangEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Trunklid',
-                    count: 10,
-                    selectedIndex: _trunklidSelectedIndex,
-                    onItemSelected: _onTrunklidItemSelected,
-                    initialEnabled: _trunklidIsEnabled,
-                    onEnabledChanged: _onTrunklidEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Kaca Depan',
-                    count: 10,
-                    selectedIndex: _kacaDepanSelectedIndex,
-                    onItemSelected: _onKacaDepanItemSelected,
-                    initialEnabled: _kacaDepanIsEnabled,
-                    onEnabledChanged: _onKacaDepanEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Fender Kanan',
-                    count: 10,
-                    selectedIndex: _fenderKananSelectedIndex,
-                    onItemSelected: _onFenderKananItemSelected,
-                    initialEnabled: _fenderKananIsEnabled,
-                    onEnabledChanged: _onFenderKananEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Quarter Panel Kanan',
-                    count: 10,
-                    selectedIndex: _quarterPanelKananSelectedIndex,
-                    onItemSelected: _onQuarterPanelKananItemSelected,
-                    initialEnabled: _quarterPanelKananIsEnabled,
-                    onEnabledChanged: _onQuarterPanelKananEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Pintu Belakang Kanan',
-                    count: 10,
-                    selectedIndex: _pintuBelakangKananSelectedIndex,
-                    onItemSelected: _onPintuBelakangKananItemSelected,
-                    initialEnabled: _pintuBelakangKananIsEnabled,
-                    onEnabledChanged: _onPintuBelakangKananEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Spion Kanan',
-                    count: 10,
-                    selectedIndex: _spionKananSelectedIndex,
-                    onItemSelected: _onSpionKananItemSelected,
-                    initialEnabled: _spionKananIsEnabled,
-                    onEnabledChanged: _onSpionKananEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Lisplang Kanan',
-                    count: 10,
-                    selectedIndex: _lisplangKananSelectedIndex,
-                    onItemSelected: _onLisplangKananItemSelected,
-                    initialEnabled: _lisplangKananIsEnabled,
-                    onEnabledChanged: _onLisplangKananEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Side Skirt Kanan',
-                    count: 10,
-                    selectedIndex: _sideSkirtKananSelectedIndex,
-                    onItemSelected: _onSideSkirtKananItemSelected,
-                    initialEnabled: _sideSkirtKananIsEnabled,
-                    onEnabledChanged: _onSideSkirtKananEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Daun Wiper',
-                    count: 10,
-                    selectedIndex: _daunWiperSelectedIndex,
-                    onItemSelected: _onDaunWiperItemSelected,
-                    initialEnabled: _daunWiperIsEnabled,
-                    onEnabledChanged: _onDaunWiperEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Pintu Belakang',
-                    count: 10,
-                    selectedIndex: _pintuBelakangSelectedIndex,
-                    onItemSelected: _onPintuBelakangItemSelected,
-                    initialEnabled: _pintuBelakangIsEnabled,
-                    onEnabledChanged: _onPintuBelakangEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Fender Kiri',
-                    count: 10,
-                    selectedIndex: _fenderKiriSelectedIndex,
-                    onItemSelected: _onFenderKiriItemSelected,
-                    initialEnabled: _fenderKiriIsEnabled,
-                    onEnabledChanged: _onFenderKiriEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Quarter Panel Kiri',
-                    count: 10,
-                    selectedIndex: _quarterPanelKiriSelectedIndex,
-                    onItemSelected: _onQuarterPanelKiriItemSelected,
-                    initialEnabled: _quarterPanelKiriIsEnabled,
-                    onEnabledChanged: _onQuarterPanelKiriEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Pintu Depan',
-                    count: 10,
-                    selectedIndex: _pintuDepanSelectedIndex,
-                    onItemSelected: _onPintuDepanItemSelected,
-                    initialEnabled: _pintuDepanIsEnabled,
-                    onEnabledChanged: _onPintuDepanEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Kaca Jendela Kanan',
-                    count: 10,
-                    selectedIndex: _kacaJendelaKananSelectedIndex,
-                    onItemSelected: _onKacaJendelaKananItemSelected,
-                    initialEnabled: _kacaJendelaKananIsEnabled,
-                    onEnabledChanged: _onKacaJendelaKananEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Pintu Belakang Kiri',
-                    count: 10,
-                    selectedIndex: _pintuBelakangKiriSelectedIndex,
-                    onItemSelected: _onPintuBelakangKiriItemSelected,
-                    initialEnabled: _pintuBelakangKiriIsEnabled,
-                    onEnabledChanged: _onPintuBelakangKiriEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Spion Kiri',
-                    count: 10,
-                    selectedIndex: _spionKiriSelectedIndex,
-                    onItemSelected: _onSpionKiriItemSelected,
-                    initialEnabled: _spionKiriIsEnabled,
-                    onEnabledChanged: _onSpionKiriEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Pintu Depan Kiri',
-                    count: 10,
-                    selectedIndex: _pintuDepanKiriSelectedIndex,
-                    onItemSelected: _onPintuDepanKiriItemSelected,
-                    initialEnabled: _pintuDepanKiriIsEnabled,
-                    onEnabledChanged: _onPintuDepanKiriEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Kaca Jendela Kiri',
-                    count: 10,
-                    selectedIndex: _kacaJendelaKiriSelectedIndex,
-                    onItemSelected: _onKacaJendelaKiriItemSelected,
-                    initialEnabled: _kacaJendelaKiriIsEnabled,
-                    onEnabledChanged: _onKacaJendelaKiriEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Lisplang Kiri',
-                    count: 10,
-                    selectedIndex: _lisplangKiriSelectedIndex,
-                    onItemSelected: _onLisplangKiriItemSelected,
-                    initialEnabled: _lisplangKiriIsEnabled,
-                    onEnabledChanged: _onLisplangKiriEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Side Skirt Kiri',
-                    count: 10,
-                    selectedIndex: _sideSkirtKiriSelectedIndex,
-                    onItemSelected: _onSideSkirtKiriItemSelected,
-                    initialEnabled: _sideSkirtKiriIsEnabled,
-                    onEnabledChanged: _onSideSkirtKiriEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
+    return PopScope(
+      onPopInvokedWithResult: (bool didPop, dynamic result) {
+        if (didPop) {
+          _focusScopeNode.unfocus();
+        }
+      },
+      child: FocusScope(
+        node: _focusScopeNode,
+        child: CommonLayout(
+          child: GestureDetector(
+            onTap: () {
+              _focusScopeNode.unfocus();
+            },
+            child: Column(
+              children: [
+                Expanded(
+                  child: SingleChildScrollView(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        PageNumber(data: '5/9'),
+                        const SizedBox(height: 8.0),
+                        PageTitle(data: 'Penilaian (4)'),
+                        const SizedBox(height: 24.0),
+                        const HeadingOne(text: 'Hasil Inspeksi Eksterior'),
+                        const SizedBox(height: 16.0),
 
-                  // ExpandableTextField
-                  ExpandableTextField(
-                    label: 'Catatan',
-                    hintText: 'Masukkan catatan di sini',
-                    controller: _eksteriorCatatanController,
-                    onChangedList: _onEksteriorCatatanChanged,
-                  ),
-                  const SizedBox(height: 32.0),
+                        // ToggleableNumberedButtonList widgets
+                        ToggleableNumberedButtonList(
+                          label: 'Bumper Depan',
+                          count: 10,
+                          selectedIndex: formData.bumperDepanSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateBumperDepanSelectedIndex(index);
+                          },
+                          initialEnabled: formData.bumperDepanIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateBumperDepanIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateBumperDepanSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Kap Mesin',
+                          count: 10,
+                          selectedIndex: formData.kapMesinSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateKapMesinSelectedIndex(index);
+                          },
+                          initialEnabled: formData.kapMesinIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateKapMesinIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateKapMesinSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Lampu Utama',
+                          count: 10,
+                          selectedIndex: formData.lampuUtamaSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateLampuUtamaSelectedIndex(index);
+                          },
+                          initialEnabled: formData.lampuUtamaIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateLampuUtamaIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateLampuUtamaSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Panel Atap',
+                          count: 10,
+                          selectedIndex: formData.panelAtapSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updatePanelAtapSelectedIndex(index);
+                          },
+                          initialEnabled: formData.panelAtapIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updatePanelAtapIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updatePanelAtapSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Grill',
+                          count: 10,
+                          selectedIndex: formData.grillSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateGrillSelectedIndex(index);
+                          },
+                          initialEnabled: formData.grillIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateGrillIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateGrillSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Lampu Foglamp',
+                          count: 10,
+                          selectedIndex: formData.lampuFoglampSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateLampuFoglampSelectedIndex(index);
+                          },
+                          initialEnabled: formData.lampuFoglampIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateLampuFoglampIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateLampuFoglampSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Kaca Bening',
+                          count: 10,
+                          selectedIndex: formData.kacaBeningSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateKacaBeningSelectedIndex(index);
+                          },
+                          initialEnabled: formData.kacaBeningIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateKacaBeningIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateKacaBeningSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Wiper Belakang',
+                          count: 10,
+                          selectedIndex: formData.wiperBelakangSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateWiperBelakangSelectedIndex(index);
+                          },
+                          initialEnabled: formData.wiperBelakangIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateWiperBelakangIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateWiperBelakangSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Bumper Belakang',
+                          count: 10,
+                          selectedIndex: formData.bumperBelakangSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateBumperBelakangSelectedIndex(index);
+                          },
+                          initialEnabled: formData.bumperBelakangIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateBumperBelakangIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateBumperBelakangSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Lampu Belakang',
+                          count: 10,
+                          selectedIndex: formData.lampuBelakangSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateLampuBelakangSelectedIndex(index);
+                          },
+                          initialEnabled: formData.lampuBelakangIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateLampuBelakangIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateLampuBelakangSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Trunklid',
+                          count: 10,
+                          selectedIndex: formData.trunklidSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateTrunklidSelectedIndex(index);
+                          },
+                          initialEnabled: formData.trunklidIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateTrunklidIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateTrunklidSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Kaca Depan',
+                          count: 10,
+                          selectedIndex: formData.kacaDepanSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateKacaDepanSelectedIndex(index);
+                          },
+                          initialEnabled: formData.kacaDepanIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateKacaDepanIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateKacaDepanSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Fender Kanan',
+                          count: 10,
+                          selectedIndex: formData.fenderKananSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateFenderKananSelectedIndex(index);
+                          },
+                          initialEnabled: formData.fenderKananIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateFenderKananIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateFenderKananSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Quarter Panel Kanan',
+                          count: 10,
+                          selectedIndex: formData.quarterPanelKananSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateQuarterPanelKananSelectedIndex(index);
+                          },
+                          initialEnabled: formData.quarterPanelKananIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateQuarterPanelKananIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateQuarterPanelKananSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Pintu Belakang Kanan',
+                          count: 10,
+                          selectedIndex: formData.pintuBelakangKananSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updatePintuBelakangKananSelectedIndex(index);
+                          },
+                          initialEnabled: formData.pintuBelakangKananIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updatePintuBelakangKananIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updatePintuBelakangKananSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Spion Kanan',
+                          count: 10,
+                          selectedIndex: formData.spionKananSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateSpionKananSelectedIndex(index);
+                          },
+                          initialEnabled: formData.spionKananIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateSpionKananIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateSpionKananSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Lisplang Kanan',
+                          count: 10,
+                          selectedIndex: formData.lisplangKananSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateLisplangKananSelectedIndex(index);
+                          },
+                          initialEnabled: formData.lisplangKananIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateLisplangKananIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateLisplangKananSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Side Skirt Kanan',
+                          count: 10,
+                          selectedIndex: formData.sideSkirtKananSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateSideSkirtKananSelectedIndex(index);
+                          },
+                          initialEnabled: formData.sideSkirtKananIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateSideSkirtKananIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateSideSkirtKananSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Daun Wiper',
+                          count: 10,
+                          selectedIndex: formData.daunWiperSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateDaunWiperSelectedIndex(index);
+                          },
+                          initialEnabled: formData.daunWiperIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateDaunWiperIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateDaunWiperSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Pintu Belakang',
+                          count: 10,
+                          selectedIndex: formData.pintuBelakangSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updatePintuBelakangSelectedIndex(index);
+                          },
+                          initialEnabled: formData.pintuBelakangIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updatePintuBelakangIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updatePintuBelakangSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Fender Kiri',
+                          count: 10,
+                          selectedIndex: formData.fenderKiriSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateFenderKiriSelectedIndex(index);
+                          },
+                          initialEnabled: formData.fenderKiriIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateFenderKiriIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateFenderKiriSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Quarter Panel Kiri',
+                          count: 10,
+                          selectedIndex: formData.quarterPanelKiriSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateQuarterPanelKiriSelectedIndex(index);
+                          },
+                          initialEnabled: formData.quarterPanelKiriIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateQuarterPanelKiriIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateQuarterPanelKiriSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Pintu Depan',
+                          count: 10,
+                          selectedIndex: formData.pintuDepanSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updatePintuDepanSelectedIndex(index);
+                          },
+                          initialEnabled: formData.pintuDepanIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updatePintuDepanIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updatePintuDepanSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Kaca Jendela Kanan',
+                          count: 10,
+                          selectedIndex: formData.kacaJendelaKananSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateKacaJendelaKananSelectedIndex(index);
+                          },
+                          initialEnabled: formData.kacaJendelaKananIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateKacaJendelaKananIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateKacaJendelaKananSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Pintu Belakang Kiri',
+                          count: 10,
+                          selectedIndex: formData.pintuBelakangKiriSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updatePintuBelakangKiriSelectedIndex(index);
+                          },
+                          initialEnabled: formData.pintuBelakangKiriIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updatePintuBelakangKiriIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updatePintuBelakangKiriSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Spion Kiri',
+                          count: 10,
+                          selectedIndex: formData.spionKiriSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateSpionKiriSelectedIndex(index);
+                          },
+                          initialEnabled: formData.spionKiriIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateSpionKiriIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateSpionKiriSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Pintu Depan Kiri',
+                          count: 10,
+                          selectedIndex: formData.pintuDepanKiriSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updatePintuDepanKiriSelectedIndex(index);
+                          },
+                          initialEnabled: formData.pintuDepanKiriIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updatePintuDepanKiriIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updatePintuDepanKiriSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Kaca Jendela Kiri',
+                          count: 10,
+                          selectedIndex: formData.kacaJendelaKiriSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateKacaJendelaKiriSelectedIndex(index);
+                          },
+                          initialEnabled: formData.kacaJendelaKiriIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateKacaJendelaKiriIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateKacaJendelaKiriSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Lisplang Kiri',
+                          count: 10,
+                          selectedIndex: formData.lisplangKiriSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateLisplangKiriSelectedIndex(index);
+                          },
+                          initialEnabled: formData.lisplangKiriIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateLisplangKiriIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateLisplangKiriSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Side Skirt Kiri',
+                          count: 10,
+                          selectedIndex: formData.sideSkirtKiriSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateSideSkirtKiriSelectedIndex(index);
+                          },
+                          initialEnabled: formData.sideSkirtKiriIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateSideSkirtKiriIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateSideSkirtKiriSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
 
-                  NavigationButtonRow(
-                    onBackPressed: () => Navigator.pop(context),
-                    onNextPressed: () {
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(builder: (context) => const PageFiveFive()),
-                      );
-                    },
+                        // ExpandableTextField
+                        ExpandableTextField(
+                          label: 'Catatan',
+                          hintText: 'Masukkan catatan di sini',
+                          controller: _eksteriorCatatanController,
+                          onChangedList: (lines) {
+                            formNotifier.updateEksteriorCatatan(lines.join('\n'));
+                          },
+                        ),
+                        const SizedBox(height: 32.0),
+
+                        NavigationButtonRow(
+                          onBackPressed: () => Navigator.pop(context),
+                          onNextPressed: () {
+                            Navigator.push(
+                              context,
+                              MaterialPageRoute(builder: (context) => const PageFiveFive()),
+                            );
+                          },
+                        ),
+                        const SizedBox(height: 32.0), // Optional spacing below the content
+                        // Footer
+                        Footer(),
+                      ],
+                    ),
                   ),
-                  const SizedBox(height: 32.0), // Optional spacing below the content
-                  // Footer
-                  Footer(),
-                ],
-              ),
+                ),
+              ],
             ),
           ),
-        ],
+        ),
       ),
     );
   }

--- a/lib/pages/page_five_one.dart
+++ b/lib/pages/page_five_one.dart
@@ -31,8 +31,6 @@ class _PageFiveOneState extends ConsumerState<PageFiveOne> {
   int _sistemAcSelectedIndex = -1;
   bool _sistemAcIsEnabled = true;
 
-  late TextEditingController _fiturCatatanController;
-
   @override
   void initState() {
     super.initState();
@@ -45,12 +43,10 @@ class _PageFiveOneState extends ConsumerState<PageFiveOne> {
     _powerWindowIsEnabled = formData.powerWindowIsEnabled ?? true;
     _sistemAcSelectedIndex = formData.sistemAcSelectedIndex ?? -1;
     _sistemAcIsEnabled = formData.sistemAcIsEnabled ?? true;
-    _fiturCatatanController = TextEditingController(text: formData.fiturCatatan ?? '');
   }
 
   @override
   void dispose() {
-    _fiturCatatanController.dispose();
     super.dispose();
   }
 
@@ -127,11 +123,12 @@ class _PageFiveOneState extends ConsumerState<PageFiveOne> {
   }
 
   void _onFiturCatatanChanged(List<String> lines) {
-    ref.read(formProvider.notifier).updateFiturCatatan(lines.join('\n'));
+    ref.read(formProvider.notifier).updateFiturCatatanList(lines);
   }
 
   @override
   Widget build(BuildContext context) {
+    final formData = ref.watch(formProvider);
     return CommonLayout(
       child: Column(
         children: [
@@ -185,7 +182,7 @@ class _PageFiveOneState extends ConsumerState<PageFiveOne> {
                   ExpandableTextField(
                     label: 'Catatan',
                     hintText: 'Masukkan catatan di sini',
-                    controller: _fiturCatatanController,
+                    initialLines: formData.fiturCatatanList,
                     onChangedList: _onFiturCatatanChanged,
                   ),
                   const SizedBox(height: 32.0),

--- a/lib/pages/page_five_one.dart
+++ b/lib/pages/page_five_one.dart
@@ -19,189 +19,146 @@ class PageFiveOne extends ConsumerStatefulWidget {
 }
 
 class _PageFiveOneState extends ConsumerState<PageFiveOne> {
-  int _airbagSelectedIndex = -1;
-  bool _airbagIsEnabled = true;
-
-  int _sistemAudioSelectedIndex = -1;
-  bool _sistemAudioIsEnabled = true;
-
-  int _powerWindowSelectedIndex = -1;
-  bool _powerWindowIsEnabled = true;
-
-  int _sistemAcSelectedIndex = -1;
-  bool _sistemAcIsEnabled = true;
+  late FocusScopeNode _focusScopeNode;
 
   @override
   void initState() {
     super.initState();
-    final formData = ref.read(formProvider);
-    _airbagSelectedIndex = formData.airbagSelectedIndex ?? -1;
-    _airbagIsEnabled = formData.airbagIsEnabled ?? true;
-    _sistemAudioSelectedIndex = formData.sistemAudioSelectedIndex ?? -1;
-    _sistemAudioIsEnabled = formData.sistemAudioIsEnabled ?? true;
-    _powerWindowSelectedIndex = formData.powerWindowSelectedIndex ?? -1;
-    _powerWindowIsEnabled = formData.powerWindowIsEnabled ?? true;
-    _sistemAcSelectedIndex = formData.sistemAcSelectedIndex ?? -1;
-    _sistemAcIsEnabled = formData.sistemAcIsEnabled ?? true;
+    _focusScopeNode = FocusScopeNode();
   }
 
   @override
   void dispose() {
+    _focusScopeNode.dispose();
     super.dispose();
-  }
-
-  void _onAirbagItemSelected(int index) {
-    setState(() {
-      _airbagSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateAirbagSelectedIndex(index);
-  }
-
-  void _onAirbagEnabledChanged(bool enabled) {
-    setState(() {
-      _airbagIsEnabled = enabled;
-      if (!enabled) {
-        _airbagSelectedIndex = -1; // Reset selected index when disabled
-      }
-    });
-    ref.read(formProvider.notifier).updateAirbagIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateAirbagSelectedIndex(_airbagSelectedIndex);
-  }
-
-  void _onSistemAudioItemSelected(int index) {
-    setState(() {
-      _sistemAudioSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateSistemAudioSelectedIndex(index);
-  }
-
-  void _onSistemAudioEnabledChanged(bool enabled) {
-    setState(() {
-      _sistemAudioIsEnabled = enabled;
-      if (!enabled) {
-        _sistemAudioSelectedIndex = -1;
-      }
-    });
-    ref.read(formProvider.notifier).updateSistemAudioIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateSistemAudioSelectedIndex(_sistemAudioSelectedIndex);
-  }
-
-  void _onPowerWindowItemSelected(int index) {
-    setState(() {
-      _powerWindowSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updatePowerWindowSelectedIndex(index);
-  }
-
-  void _onPowerWindowEnabledChanged(bool enabled) {
-    setState(() {
-      _powerWindowIsEnabled = enabled;
-      if (!enabled) {
-        _powerWindowSelectedIndex = -1;
-      }
-    });
-    ref.read(formProvider.notifier).updatePowerWindowIsEnabled(enabled);
-    ref.read(formProvider.notifier).updatePowerWindowSelectedIndex(_powerWindowSelectedIndex);
-  }
-
-  void _onSistemAcItemSelected(int index) {
-    setState(() {
-      _sistemAcSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateSistemAcSelectedIndex(index);
-  }
-
-  void _onSistemAcEnabledChanged(bool enabled) {
-    setState(() {
-      _sistemAcIsEnabled = enabled;
-      if (!enabled) {
-        _sistemAcSelectedIndex = -1;
-      }
-    });
-    ref.read(formProvider.notifier).updateSistemAcIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateSistemAcSelectedIndex(_sistemAcSelectedIndex);
-  }
-
-  void _onFiturCatatanChanged(List<String> lines) {
-    ref.read(formProvider.notifier).updateFiturCatatanList(lines);
   }
 
   @override
   Widget build(BuildContext context) {
     final formData = ref.watch(formProvider);
-    return CommonLayout(
-      child: Column(
-        children: [
-          Expanded(
-            child: SingleChildScrollView(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  PageNumber(data: '5/9'),
-                  const SizedBox(height: 8.0),
-                  PageTitle(data: 'Penilaian'),
-                  const SizedBox(height: 24.0),
-                  HeadingOne(text: 'Fitur'),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Airbag',
-                    count: 10,
-                    selectedIndex: _airbagSelectedIndex,
-                    onItemSelected: _onAirbagItemSelected,
-                    initialEnabled: _airbagIsEnabled,
-                    onEnabledChanged: _onAirbagEnabledChanged,
+    final formNotifier = ref.read(formProvider.notifier);
+
+    return PopScope(
+      // Wrap with PopScope
+      onPopInvokedWithResult: (bool didPop, dynamic result) {
+        if (didPop) {
+          _focusScopeNode.unfocus(); // Unfocus when navigating back
+        }
+      },
+      child: FocusScope(
+        // Wrap with FocusScope
+        node: _focusScopeNode,
+        child: CommonLayout(
+          child: GestureDetector(
+            // Wrap with GestureDetector
+            onTap: () {
+              _focusScopeNode.unfocus(); // Unfocus on tap outside text fields
+            },
+            child: Column(
+              children: [
+                Expanded(
+                  child: SingleChildScrollView(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        PageNumber(data: '5/9'),
+                        const SizedBox(height: 8.0),
+                        PageTitle(data: 'Penilaian'),
+                        const SizedBox(height: 24.0),
+                        HeadingOne(text: 'Fitur'),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Airbag',
+                          count: 10,
+                          selectedIndex: formData.airbagSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateAirbagSelectedIndex(index);
+                          },
+                          initialEnabled: formData.airbagIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateAirbagIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateAirbagSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Sistem Audio',
+                          count: 10,
+                          selectedIndex: formData.sistemAudioSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateSistemAudioSelectedIndex(index);
+                          },
+                          initialEnabled: formData.sistemAudioIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateSistemAudioIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateSistemAudioSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Power Window',
+                          count: 10,
+                          selectedIndex: formData.powerWindowSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updatePowerWindowSelectedIndex(index);
+                          },
+                          initialEnabled: formData.powerWindowIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updatePowerWindowIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updatePowerWindowSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Sistem AC',
+                          count: 10,
+                          selectedIndex: formData.sistemAcSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateSistemAcSelectedIndex(index);
+                          },
+                          initialEnabled: formData.sistemAcIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateSistemAcIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateSistemAcSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ExpandableTextField(
+                          label: 'Catatan',
+                          hintText: 'Masukkan catatan di sini',
+                          initialLines: formData.fiturCatatanList,
+                          onChangedList: (lines) {
+                            formNotifier.updateFiturCatatanList(lines);
+                          },
+                        ),
+                        const SizedBox(height: 32.0),
+                        NavigationButtonRow(
+                          onBackPressed: () => Navigator.pop(context),
+                          onNextPressed: () {
+                            Navigator.push(
+                              context,
+                              MaterialPageRoute(builder: (context) => const PageFiveTwo()),
+                            );
+                          },
+                        ),
+                        const SizedBox(height: 32.0),
+                        Footer(),
+                      ],
+                    ),
                   ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Sistem Audio',
-                    count: 10,
-                    selectedIndex: _sistemAudioSelectedIndex,
-                    onItemSelected: _onSistemAudioItemSelected,
-                    initialEnabled: _sistemAudioIsEnabled,
-                    onEnabledChanged: _onSistemAudioEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Power Window',
-                    count: 10,
-                    selectedIndex: _powerWindowSelectedIndex,
-                    onItemSelected: _onPowerWindowItemSelected,
-                    initialEnabled: _powerWindowIsEnabled,
-                    onEnabledChanged: _onPowerWindowEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Sistem AC',
-                    count: 10,
-                    selectedIndex: _sistemAcSelectedIndex,
-                    onItemSelected: _onSistemAcItemSelected,
-                    initialEnabled: _sistemAcIsEnabled,
-                    onEnabledChanged: _onSistemAcEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ExpandableTextField(
-                    label: 'Catatan',
-                    hintText: 'Masukkan catatan di sini',
-                    initialLines: formData.fiturCatatanList,
-                    onChangedList: _onFiturCatatanChanged,
-                  ),
-                  const SizedBox(height: 32.0),
-                  NavigationButtonRow(
-                    onBackPressed: () => Navigator.pop(context),
-                    onNextPressed: () {
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(builder: (context) => const PageFiveTwo()),
-                      );
-                    },
-                  ),
-                  const SizedBox(height: 32.0),
-                  Footer(),
-                ],
-              ),
+                ),
+              ],
             ),
           ),
-        ],
+        ),
       ),
     );
   }

--- a/lib/pages/page_five_one.dart
+++ b/lib/pages/page_five_one.dart
@@ -63,7 +63,7 @@ class _PageFiveOneState extends ConsumerState<PageFiveOne> {
                       children: [
                         PageNumber(data: '5/9'),
                         const SizedBox(height: 8.0),
-                        PageTitle(data: 'Penilaian'),
+                        PageTitle(data: 'Penilaian (1)'),
                         const SizedBox(height: 24.0),
                         HeadingOne(text: 'Fitur'),
                         const SizedBox(height: 16.0),

--- a/lib/pages/page_five_three.dart
+++ b/lib/pages/page_five_three.dart
@@ -20,823 +20,475 @@ class PageFiveThree extends ConsumerStatefulWidget {
 }
 
 class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
-  // State variables for ToggleableNumberedButtonList
-  late int _stirSelectedIndex;
-  late bool _stirIsEnabled;
-  late int _remTonganSelectedIndex;
-  late bool _remTonganIsEnabled;
-  late int _pedalSelectedIndex;
-  late bool _pedalIsEnabled;
-  late int _switchWiperSelectedIndex;
-  late bool _switchWiperIsEnabled;
-  late int _lampuHazardSelectedIndex;
-  late bool _lampuHazardIsEnabled;
-  late int _panelDashboardSelectedIndex;
-  late bool _panelDashboardIsEnabled;
-  late int _pembukaKapMesinSelectedIndex;
-  late bool _pembukaKapMesinIsEnabled;
-  late int _pembukaBagasiSelectedIndex;
-  late bool _pembukaBagasiIsEnabled;
-  late int _jokDepanSelectedIndex;
-  late bool _jokDepanIsEnabled;
-  late int _aromaInteriorSelectedIndex;
-  late bool _aromaInteriorIsEnabled;
-  late int _handlePintuSelectedIndex;
-  late bool _handlePintuIsEnabled;
-  late int _consoleBoxSelectedIndex;
-  late bool _consoleBoxIsEnabled;
-  late int _spionTengahSelectedIndex;
-  late bool _spionTengahIsEnabled;
-  late int _tuasPersnelingSelectedIndex;
-  late bool _tuasPersnelingIsEnabled;
-  late int _jokBelakangSelectedIndex;
-  late bool _jokBelakangIsEnabled;
-  late int _panelIndikatorSelectedIndex;
-  late bool _panelIndikatorIsEnabled;
-  late int _switchLampuSelectedIndex;
-  late bool _switchLampuIsEnabled;
-  late int _karpetDasarSelectedIndex;
-  late bool _karpetDasarIsEnabled;
-  late int _klaksonSelectedIndex;
-  late bool _klaksonIsEnabled;
-  late int _sunVisorSelectedIndex;
-  late bool _sunVisorIsEnabled;
-  late int _tuasTangkiBensinSelectedIndex;
-  late bool _tuasTangkiBensinIsEnabled;
-  late int _sabukPengamanSelectedIndex;
-  late bool _sabukPengamanIsEnabled;
-  late int _trimInteriorSelectedIndex;
-  late bool _trimInteriorIsEnabled;
-  late int _plafonSelectedIndex;
-  late bool _plafonIsEnabled;
+  late FocusScopeNode _focusScopeNode;
 
   // State variable for ExpandableTextField
   late TextEditingController _interiorCatatanController;
 
-
   @override
   void initState() {
     super.initState();
+    _focusScopeNode = FocusScopeNode();
     final formData = ref.read(formProvider);
-    // Initialize state variables from formProvider
-    _stirSelectedIndex = formData.stirSelectedIndex ?? 0;
-    _stirIsEnabled = formData.stirIsEnabled ?? true;
-    _remTonganSelectedIndex = formData.remTonganSelectedIndex ?? 0;
-    _remTonganIsEnabled = formData.remTonganIsEnabled ?? true;
-    _pedalSelectedIndex = formData.pedalSelectedIndex ?? 0;
-    _pedalIsEnabled = formData.pedalIsEnabled ?? true;
-    _switchWiperSelectedIndex = formData.switchWiperSelectedIndex ?? 0;
-    _switchWiperIsEnabled = formData.switchWiperIsEnabled ?? true;
-    _lampuHazardSelectedIndex = formData.lampuHazardSelectedIndex ?? 0;
-    _lampuHazardIsEnabled = formData.lampuHazardIsEnabled ?? true;
-    _panelDashboardSelectedIndex = formData.panelDashboardSelectedIndex ?? 0;
-    _panelDashboardIsEnabled = formData.panelDashboardIsEnabled ?? true;
-    _pembukaKapMesinSelectedIndex = formData.pembukaKapMesinSelectedIndex ?? 0;
-    _pembukaKapMesinIsEnabled = formData.pembukaKapMesinIsEnabled ?? true;
-    _pembukaBagasiSelectedIndex = formData.pembukaBagasiSelectedIndex ?? 0;
-    _pembukaBagasiIsEnabled = formData.pembukaBagasiIsEnabled ?? true;
-    _jokDepanSelectedIndex = formData.jokDepanSelectedIndex ?? 0;
-    _jokDepanIsEnabled = formData.jokDepanIsEnabled ?? true;
-    _aromaInteriorSelectedIndex = formData.aromaInteriorSelectedIndex ?? 0;
-    _aromaInteriorIsEnabled = formData.aromaInteriorIsEnabled ?? true;
-    _handlePintuSelectedIndex = formData.handlePintuSelectedIndex ?? 0;
-    _handlePintuIsEnabled = formData.handlePintuIsEnabled ?? true;
-    _consoleBoxSelectedIndex = formData.consoleBoxSelectedIndex ?? 0;
-    _consoleBoxIsEnabled = formData.consoleBoxIsEnabled ?? true;
-    _spionTengahSelectedIndex = formData.spionTengahSelectedIndex ?? 0;
-    _spionTengahIsEnabled = formData.spionTengahIsEnabled ?? true;
-    _tuasPersnelingSelectedIndex = formData.tuasPersnelingSelectedIndex ?? 0;
-    _tuasPersnelingIsEnabled = formData.tuasPersnelingIsEnabled ?? true;
-    _jokBelakangSelectedIndex = formData.jokBelakangSelectedIndex ?? 0;
-    _jokBelakangIsEnabled = formData.jokBelakangIsEnabled ?? true;
-    _panelIndikatorSelectedIndex = formData.panelIndikatorSelectedIndex ?? 0;
-    _panelIndikatorIsEnabled = formData.panelIndikatorIsEnabled ?? true;
-    _switchLampuSelectedIndex = formData.switchLampuSelectedIndex ?? 0;
-    _switchLampuIsEnabled = formData.switchLampuIsEnabled ?? true;
-    _karpetDasarSelectedIndex = formData.karpetDasarSelectedIndex ?? 0;
-    _karpetDasarIsEnabled = formData.karpetDasarIsEnabled ?? true;
-    _klaksonSelectedIndex = formData.klaksonSelectedIndex ?? 0;
-    _klaksonIsEnabled = formData.klaksonIsEnabled ?? true;
-    _sunVisorSelectedIndex = formData.sunVisorSelectedIndex ?? 0;
-    _sunVisorIsEnabled = formData.sunVisorIsEnabled ?? true;
-    _tuasTangkiBensinSelectedIndex = formData.tuasTangkiBensinSelectedIndex ?? 0;
-    _tuasTangkiBensinIsEnabled = formData.tuasTangkiBensinIsEnabled ?? true;
-    _sabukPengamanSelectedIndex = formData.sabukPengamanSelectedIndex ?? 0;
-    _sabukPengamanIsEnabled = formData.sabukPengamanIsEnabled ?? true;
-    _trimInteriorSelectedIndex = formData.trimInteriorSelectedIndex ?? 0;
-    _trimInteriorIsEnabled = formData.trimInteriorIsEnabled ?? true;
-    _plafonSelectedIndex = formData.plafonSelectedIndex ?? 0;
-    _plafonIsEnabled = formData.plafonIsEnabled ?? true;
-
     _interiorCatatanController = TextEditingController(text: formData.interiorCatatan ?? '');
   }
 
   @override
   void dispose() {
+    _focusScopeNode.dispose();
     _interiorCatatanController.dispose();
     super.dispose();
   }
 
-  // Callback methods for ToggleableNumberedButtonList
-  void _onStirItemSelected(int index) {
-    setState(() {
-      _stirSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateStirSelectedIndex(index);
-  }
-
-  void _onStirEnabledChanged(bool enabled) {
-    setState(() {
-      _stirIsEnabled = enabled;
-      if (!enabled) {
-        _stirSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateStirIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateStirSelectedIndex(_stirSelectedIndex);
-  }
-
-  void _onRemTonganItemSelected(int index) {
-    setState(() {
-      _remTonganSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateRemTonganSelectedIndex(index);
-  }
-
-  void _onRemTonganEnabledChanged(bool enabled) {
-    setState(() {
-      _remTonganIsEnabled = enabled;
-      if (!enabled) {
-        _remTonganSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateRemTonganIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateRemTonganSelectedIndex(_remTonganSelectedIndex);
-  }
-
-  void _onPedalItemSelected(int index) {
-    setState(() {
-      _pedalSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updatePedalSelectedIndex(index);
-  }
-
-  void _onPedalEnabledChanged(bool enabled) {
-    setState(() {
-      _pedalIsEnabled = enabled;
-      if (!enabled) {
-        _pedalSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updatePedalIsEnabled(enabled);
-    ref.read(formProvider.notifier).updatePedalSelectedIndex(_pedalSelectedIndex);
-  }
-
-  void _onSwitchWiperItemSelected(int index) {
-    setState(() {
-      _switchWiperSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateSwitchWiperSelectedIndex(index);
-  }
-
-  void _onSwitchWiperEnabledChanged(bool enabled) {
-    setState(() {
-      _switchWiperIsEnabled = enabled;
-      if (!enabled) {
-        _switchWiperSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateSwitchWiperIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateSwitchWiperSelectedIndex(_switchWiperSelectedIndex);
-  }
-
-  void _onLampuHazardItemSelected(int index) {
-    setState(() {
-      _lampuHazardSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateLampuHazardSelectedIndex(index);
-  }
-
-  void _onLampuHazardEnabledChanged(bool enabled) {
-    setState(() {
-      _lampuHazardIsEnabled = enabled;
-      if (!enabled) {
-        _lampuHazardSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateLampuHazardIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateLampuHazardSelectedIndex(_lampuHazardSelectedIndex);
-  }
-
-  void _onPanelDashboardItemSelected(int index) {
-    setState(() {
-      _panelDashboardSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updatePanelDashboardSelectedIndex(index);
-  }
-
-  void _onPanelDashboardEnabledChanged(bool enabled) {
-    setState(() {
-      _panelDashboardIsEnabled = enabled;
-      if (!enabled) {
-        _panelDashboardSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updatePanelDashboardIsEnabled(enabled);
-    ref.read(formProvider.notifier).updatePanelDashboardSelectedIndex(_panelDashboardSelectedIndex);
-  }
-
-  void _onPembukaKapMesinItemSelected(int index) {
-    setState(() {
-      _pembukaKapMesinSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updatePembukaKapMesinSelectedIndex(index);
-  }
-
-  void _onPembukaKapMesinEnabledChanged(bool enabled) {
-    setState(() {
-      _pembukaKapMesinIsEnabled = enabled;
-      if (!enabled) {
-        _pembukaKapMesinSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updatePembukaKapMesinIsEnabled(enabled);
-    ref.read(formProvider.notifier).updatePembukaKapMesinSelectedIndex(_pembukaKapMesinSelectedIndex);
-  }
-
-  void _onPembukaBagasiItemSelected(int index) {
-    setState(() {
-      _pembukaBagasiSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updatePembukaBagasiSelectedIndex(index);
-  }
-
-  void _onPembukaBagasiEnabledChanged(bool enabled) {
-    setState(() {
-      _pembukaBagasiIsEnabled = enabled;
-      if (!enabled) {
-        _pembukaBagasiSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updatePembukaBagasiIsEnabled(enabled);
-    ref.read(formProvider.notifier).updatePembukaBagasiSelectedIndex(_pembukaBagasiSelectedIndex);
-  }
-
-  void _onJokDepanItemSelected(int index) {
-    setState(() {
-      _jokDepanSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateJokDepanSelectedIndex(index);
-  }
-
-  void _onJokDepanEnabledChanged(bool enabled) {
-    setState(() {
-      _jokDepanIsEnabled = enabled;
-      if (!enabled) {
-        _jokDepanSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateJokDepanIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateJokDepanSelectedIndex(_jokDepanSelectedIndex);
-  }
-
-  void _onAromaInteriorItemSelected(int index) {
-    setState(() {
-      _aromaInteriorSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateAromaInteriorSelectedIndex(index);
-  }
-
-  void _onAromaInteriorEnabledChanged(bool enabled) {
-    setState(() {
-      _aromaInteriorIsEnabled = enabled;
-      if (!enabled) {
-        _aromaInteriorSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateAromaInteriorIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateAromaInteriorSelectedIndex(_aromaInteriorSelectedIndex);
-  }
-
-  void _onHandlePintuItemSelected(int index) {
-    setState(() {
-      _handlePintuSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateHandlePintuSelectedIndex(index);
-  }
-
-  void _onHandlePintuEnabledChanged(bool enabled) {
-    setState(() {
-      _handlePintuIsEnabled = enabled;
-      if (!enabled) {
-        _handlePintuSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateHandlePintuIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateHandlePintuSelectedIndex(_handlePintuSelectedIndex);
-  }
-
-  void _onConsoleBoxItemSelected(int index) {
-    setState(() {
-      _consoleBoxSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateConsoleBoxSelectedIndex(index);
-  }
-
-  void _onConsoleBoxEnabledChanged(bool enabled) {
-    setState(() {
-      _consoleBoxIsEnabled = enabled;
-      if (!enabled) {
-        _consoleBoxSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateConsoleBoxIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateConsoleBoxSelectedIndex(_consoleBoxSelectedIndex);
-  }
-
-  void _onSpionTengahItemSelected(int index) {
-    setState(() {
-      _spionTengahSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateSpionTengahSelectedIndex(index);
-  }
-
-  void _onSpionTengahEnabledChanged(bool enabled) {
-    setState(() {
-      _spionTengahIsEnabled = enabled;
-      if (!enabled) {
-        _spionTengahSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateSpionTengahIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateSpionTengahSelectedIndex(_spionTengahSelectedIndex);
-  }
-
-  void _onTuasPersnelingItemSelected(int index) {
-    setState(() {
-      _tuasPersnelingSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateTuasPersnelingSelectedIndex(index);
-  }
-
-  void _onTuasPersnelingEnabledChanged(bool enabled) {
-    setState(() {
-      _tuasPersnelingIsEnabled = enabled;
-      if (!enabled) {
-        _tuasPersnelingSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateTuasPersnelingIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateTuasPersnelingSelectedIndex(_tuasPersnelingSelectedIndex);
-  }
-
-  void _onJokBelakangItemSelected(int index) {
-    setState(() {
-      _jokBelakangSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateJokBelakangSelectedIndex(index);
-  }
-
-  void _onJokBelakangEnabledChanged(bool enabled) {
-    setState(() {
-      _jokBelakangIsEnabled = enabled;
-      if (!enabled) {
-        _jokBelakangSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateJokBelakangIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateJokBelakangSelectedIndex(_jokBelakangSelectedIndex);
-  }
-
-  void _onPanelIndikatorItemSelected(int index) {
-    setState(() {
-      _panelIndikatorSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updatePanelIndikatorSelectedIndex(index);
-  }
-
-  void _onPanelIndikatorEnabledChanged(bool enabled) {
-    setState(() {
-      _panelIndikatorIsEnabled = enabled;
-      if (!enabled) {
-        _panelIndikatorSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updatePanelIndikatorIsEnabled(enabled);
-    ref.read(formProvider.notifier).updatePanelIndikatorSelectedIndex(_panelIndikatorSelectedIndex);
-  }
-
-  void _onSwitchLampuItemSelected(int index) {
-    setState(() {
-      _switchLampuSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateSwitchLampuSelectedIndex(index);
-  }
-
-  void _onSwitchLampuEnabledChanged(bool enabled) {
-    setState(() {
-      _switchLampuIsEnabled = enabled;
-      if (!enabled) {
-        _switchLampuSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateSwitchLampuIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateSwitchLampuSelectedIndex(_switchLampuSelectedIndex);
-  }
-
-  void _onKarpetDasarItemSelected(int index) {
-    setState(() {
-      _karpetDasarSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateKarpetDasarSelectedIndex(index);
-  }
-
-  void _onKarpetDasarEnabledChanged(bool enabled) {
-    setState(() {
-      _karpetDasarIsEnabled = enabled;
-      if (!enabled) {
-        _karpetDasarSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateKarpetDasarIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateKarpetDasarSelectedIndex(_karpetDasarSelectedIndex);
-  }
-
-  void _onKlaksonItemSelected(int index) {
-    setState(() {
-      _klaksonSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateKlaksonSelectedIndex(index);
-  }
-
-  void _onKlaksonEnabledChanged(bool enabled) {
-    setState(() {
-      _klaksonIsEnabled = enabled;
-      if (!enabled) {
-        _klaksonSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateKlaksonIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateKlaksonSelectedIndex(_klaksonSelectedIndex);
-  }
-
-  void _onSunVisorItemSelected(int index) {
-    setState(() {
-      _sunVisorSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateSunVisorSelectedIndex(index);
-  }
-
-  void _onSunVisorEnabledChanged(bool enabled) {
-    setState(() {
-      _sunVisorIsEnabled = enabled;
-      if (!enabled) {
-        _sunVisorSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateSunVisorIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateSunVisorSelectedIndex(_sunVisorSelectedIndex);
-  }
-
-  void _onTuasTangkiBensinItemSelected(int index) {
-    setState(() {
-      _tuasTangkiBensinSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateTuasTangkiBensinSelectedIndex(index);
-  }
-
-  void _onTuasTangkiBensinEnabledChanged(bool enabled) {
-    setState(() {
-      _tuasTangkiBensinIsEnabled = enabled;
-      if (!enabled) {
-        _tuasTangkiBensinSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateTuasTangkiBensinIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateTuasTangkiBensinSelectedIndex(_tuasTangkiBensinSelectedIndex);
-  }
-
-  void _onSabukPengamanItemSelected(int index) {
-    setState(() {
-      _sabukPengamanSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateSabukPengamanSelectedIndex(index);
-  }
-
-  void _onSabukPengamanEnabledChanged(bool enabled) {
-    setState(() {
-      _sabukPengamanIsEnabled = enabled;
-      if (!enabled) {
-        _sabukPengamanSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateSabukPengamanIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateSabukPengamanSelectedIndex(_sabukPengamanSelectedIndex);
-  }
-
-  void _onTrimInteriorItemSelected(int index) {
-    setState(() {
-      _trimInteriorSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateTrimInteriorSelectedIndex(index);
-  }
-
-  void _onTrimInteriorEnabledChanged(bool enabled) {
-    setState(() {
-      _trimInteriorIsEnabled = enabled;
-      if (!enabled) {
-        _trimInteriorSelectedIndex = 0;
-      }
-      });
-    ref.read(formProvider.notifier).updateTrimInteriorIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateTrimInteriorSelectedIndex(_trimInteriorSelectedIndex);
-  }
-
-  void _onPlafonItemSelected(int index) {
-    setState(() {
-      _plafonSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updatePlafonSelectedIndex(index);
-  }
-
-  void _onPlafonEnabledChanged(bool enabled) {
-    setState(() {
-      _plafonIsEnabled = enabled;
-      if (!enabled) {
-        _plafonSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updatePlafonIsEnabled(enabled);
-    ref.read(formProvider.notifier).updatePlafonSelectedIndex(_plafonSelectedIndex);
-  }
-
-  // Callback method for ExpandableTextField
-  void _onInteriorCatatanChanged(List<String> lines) {
-    ref.read(formProvider.notifier).updateInteriorCatatan(lines.join('\n'));
-  }
-
-
   @override
   Widget build(BuildContext context) {
-    return CommonLayout(
-      child: Column(
-        children: [
-          Expanded(
-            child: SingleChildScrollView(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  PageNumber(data: '5/9'),
-                  const SizedBox(height: 8.0),
-                  PageTitle(data: 'Penilaian (3)'),
-                  const SizedBox(height: 24.0),
-                  const HeadingOne(text: 'Hasil Inspeksi Interior'),
-                  const SizedBox(height: 16.0),
+    final formData = ref.watch(formProvider);
+    final formNotifier = ref.read(formProvider.notifier);
 
-                  // ToggleableNumberedButtonList widgets
-                  ToggleableNumberedButtonList(
-                    label: 'Stir',
-                    count: 10,
-                    selectedIndex: _stirSelectedIndex,
-                    onItemSelected: _onStirItemSelected,
-                    initialEnabled: _stirIsEnabled,
-                    onEnabledChanged: _onStirEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Rem Tangan',
-                    count: 10,
-                    selectedIndex: _remTonganSelectedIndex,
-                    onItemSelected: _onRemTonganItemSelected,
-                    initialEnabled: _remTonganIsEnabled,
-                    onEnabledChanged: _onRemTonganEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Pedal',
-                    count: 10,
-                    selectedIndex: _pedalSelectedIndex,
-                    onItemSelected: _onPedalItemSelected,
-                    initialEnabled: _pedalIsEnabled,
-                    onEnabledChanged: _onPedalEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Switch Wiper',
-                    count: 10,
-                    selectedIndex: _switchWiperSelectedIndex,
-                    onItemSelected: _onSwitchWiperItemSelected,
-                    initialEnabled: _switchWiperIsEnabled,
-                    onEnabledChanged: _onSwitchWiperEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Lampu Hazard',
-                    count: 10,
-                    selectedIndex: _lampuHazardSelectedIndex,
-                    onItemSelected: _onLampuHazardItemSelected,
-                    initialEnabled: _lampuHazardIsEnabled,
-                    onEnabledChanged: _onLampuHazardEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Panel Dashboard',
-                    count: 10,
-                    selectedIndex: _panelDashboardSelectedIndex,
-                    onItemSelected: _onPanelDashboardItemSelected,
-                    initialEnabled: _panelDashboardIsEnabled,
-                    onEnabledChanged: _onPanelDashboardEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Pembuka Kap Mesin',
-                    count: 10,
-                    selectedIndex: _pembukaKapMesinSelectedIndex,
-                    onItemSelected: _onPembukaKapMesinItemSelected,
-                    initialEnabled: _pembukaKapMesinIsEnabled,
-                    onEnabledChanged: _onPembukaKapMesinEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Pembuka Bagasi',
-                    count: 10,
-                    selectedIndex: _pembukaBagasiSelectedIndex,
-                    onItemSelected: _onPembukaBagasiItemSelected,
-                    initialEnabled: _pembukaBagasiIsEnabled,
-                    onEnabledChanged: _onPembukaBagasiEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Jok Depan',
-                    count: 10,
-                    selectedIndex: _jokDepanSelectedIndex,
-                    onItemSelected: _onJokDepanItemSelected,
-                    initialEnabled: _jokDepanIsEnabled,
-                    onEnabledChanged: _onJokDepanEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Aroma Interior',
-                    count: 10,
-                    selectedIndex: _aromaInteriorSelectedIndex,
-                    onItemSelected: _onAromaInteriorItemSelected,
-                    initialEnabled: _aromaInteriorIsEnabled,
-                    onEnabledChanged: _onAromaInteriorEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Handle Pintu',
-                    count: 10,
-                    selectedIndex: _handlePintuSelectedIndex,
-                    onItemSelected: _onHandlePintuItemSelected,
-                    initialEnabled: _handlePintuIsEnabled,
-                    onEnabledChanged: _onHandlePintuEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Console Box',
-                    count: 10,
-                    selectedIndex: _consoleBoxSelectedIndex,
-                    onItemSelected: _onConsoleBoxItemSelected,
-                    initialEnabled: _consoleBoxIsEnabled,
-                    onEnabledChanged: _onConsoleBoxEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Spion Tengah',
-                    count: 10,
-                    selectedIndex: _spionTengahSelectedIndex,
-                    onItemSelected: _onSpionTengahItemSelected,
-                    initialEnabled: _spionTengahIsEnabled,
-                    onEnabledChanged: _onSpionTengahEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Tuas Persneling',
-                    count: 10,
-                    selectedIndex: _tuasPersnelingSelectedIndex,
-                    onItemSelected: _onTuasPersnelingItemSelected,
-                    initialEnabled: _tuasPersnelingIsEnabled,
-                    onEnabledChanged: _onTuasPersnelingEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Jok Belakang',
-                    count: 10,
-                    selectedIndex: _jokBelakangSelectedIndex,
-                    onItemSelected: _onJokBelakangItemSelected,
-                    initialEnabled: _jokBelakangIsEnabled,
-                    onEnabledChanged: _onJokBelakangEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Panel Indikator',
-                    count: 10,
-                    selectedIndex: _panelIndikatorSelectedIndex,
-                    onItemSelected: _onPanelIndikatorItemSelected,
-                    initialEnabled: _panelIndikatorIsEnabled,
-                    onEnabledChanged: _onPanelIndikatorEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Switch Lampu',
-                    count: 10,
-                    selectedIndex: _switchLampuSelectedIndex,
-                    onItemSelected: _onSwitchLampuItemSelected,
-                    initialEnabled: _switchLampuIsEnabled,
-                    onEnabledChanged: _onSwitchLampuEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Karpet Dasar',
-                    count: 10,
-                    selectedIndex: _karpetDasarSelectedIndex,
-                    onItemSelected: _onKarpetDasarItemSelected,
-                    initialEnabled: _karpetDasarIsEnabled,
-                    onEnabledChanged: _onKarpetDasarEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Klakson',
-                    count: 10,
-                    selectedIndex: _klaksonSelectedIndex,
-                    onItemSelected: _onKlaksonItemSelected,
-                    initialEnabled: _klaksonIsEnabled,
-                    onEnabledChanged: _onKlaksonEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Sun Visor',
-                    count: 10,
-                    selectedIndex: _sunVisorSelectedIndex,
-                    onItemSelected: _onSunVisorItemSelected,
-                    initialEnabled: _sunVisorIsEnabled,
-                    onEnabledChanged: _onSunVisorEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Tuas Tangki Bensin',
-                    count: 10,
-                    selectedIndex: _tuasTangkiBensinSelectedIndex,
-                    onItemSelected: _onTuasTangkiBensinItemSelected,
-                    initialEnabled: _tuasTangkiBensinIsEnabled,
-                    onEnabledChanged: _onTuasTangkiBensinEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Sabuk Pengaman',
-                    count: 10,
-                    selectedIndex: _sabukPengamanSelectedIndex,
-                    onItemSelected: _onSabukPengamanItemSelected,
-                    initialEnabled: _sabukPengamanIsEnabled,
-                    onEnabledChanged: _onSabukPengamanEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Trim Interior',
-                    count: 10,
-                    selectedIndex: _trimInteriorSelectedIndex,
-                    onItemSelected: _onTrimInteriorItemSelected,
-                    initialEnabled: _trimInteriorIsEnabled,
-                    onEnabledChanged: _onTrimInteriorEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Plafon',
-                    count: 10,
-                    selectedIndex: _plafonSelectedIndex,
-                    onItemSelected: _onPlafonItemSelected,
-                    initialEnabled: _plafonIsEnabled,
-                    onEnabledChanged: _onPlafonEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
+    return PopScope(
+      onPopInvokedWithResult: (bool didPop, dynamic result) {
+        if (didPop) {
+          _focusScopeNode.unfocus();
+        }
+      },
+      child: FocusScope(
+        node: _focusScopeNode,
+        child: CommonLayout(
+          child: GestureDetector(
+            onTap: () {
+              _focusScopeNode.unfocus();
+            },
+            child: Column(
+              children: [
+                Expanded(
+                  child: SingleChildScrollView(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        PageNumber(data: '5/9'),
+                        const SizedBox(height: 8.0),
+                        PageTitle(data: 'Penilaian (3)'),
+                        const SizedBox(height: 24.0),
+                        const HeadingOne(text: 'Hasil Inspeksi Interior'),
+                        const SizedBox(height: 16.0),
 
-                  // ExpandableTextField
-                  ExpandableTextField(
-                    label: 'Catatan',
-                    hintText: 'Masukkan catatan di sini',
-                    controller: _interiorCatatanController,
-                    onChangedList: _onInteriorCatatanChanged,
-                  ),
-                  const SizedBox(height: 32.0),
+                        // ToggleableNumberedButtonList widgets
+                        ToggleableNumberedButtonList(
+                          label: 'Stir',
+                          count: 10,
+                          selectedIndex: formData.stirSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateStirSelectedIndex(index);
+                          },
+                          initialEnabled: formData.stirIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateStirIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateStirSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Rem Tangan',
+                          count: 10,
+                          selectedIndex: formData.remTonganSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateRemTonganSelectedIndex(index);
+                          },
+                          initialEnabled: formData.remTonganIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateRemTonganIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateRemTonganSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Pedal',
+                          count: 10,
+                          selectedIndex: formData.pedalSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updatePedalSelectedIndex(index);
+                          },
+                          initialEnabled: formData.pedalIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updatePedalIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updatePedalSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Switch Wiper',
+                          count: 10,
+                          selectedIndex: formData.switchWiperSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateSwitchWiperSelectedIndex(index);
+                          },
+                          initialEnabled: formData.switchWiperIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateSwitchWiperIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateSwitchWiperSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Lampu Hazard',
+                          count: 10,
+                          selectedIndex: formData.lampuHazardSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateLampuHazardSelectedIndex(index);
+                          },
+                          initialEnabled: formData.lampuHazardIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateLampuHazardIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateLampuHazardSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Panel Dashboard',
+                          count: 10,
+                          selectedIndex: formData.panelDashboardSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updatePanelDashboardSelectedIndex(index);
+                          },
+                          initialEnabled: formData.panelDashboardIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updatePanelDashboardIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updatePanelDashboardSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Pembuka Kap Mesin',
+                          count: 10,
+                          selectedIndex: formData.pembukaKapMesinSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updatePembukaKapMesinSelectedIndex(index);
+                          },
+                          initialEnabled: formData.pembukaKapMesinIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updatePembukaKapMesinIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updatePembukaKapMesinSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Pembuka Bagasi',
+                          count: 10,
+                          selectedIndex: formData.pembukaBagasiSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updatePembukaBagasiSelectedIndex(index);
+                          },
+                          initialEnabled: formData.pembukaBagasiIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updatePembukaBagasiIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updatePembukaBagasiSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Jok Depan',
+                          count: 10,
+                          selectedIndex: formData.jokDepanSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateJokDepanSelectedIndex(index);
+                          },
+                          initialEnabled: formData.jokDepanIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateJokDepanIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateJokDepanSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Aroma Interior',
+                          count: 10,
+                          selectedIndex: formData.aromaInteriorSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateAromaInteriorSelectedIndex(index);
+                          },
+                          initialEnabled: formData.aromaInteriorIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateAromaInteriorIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateAromaInteriorSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Handle Pintu',
+                          count: 10,
+                          selectedIndex: formData.handlePintuSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateHandlePintuSelectedIndex(index);
+                          },
+                          initialEnabled: formData.handlePintuIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateHandlePintuIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateHandlePintuSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Console Box',
+                          count: 10,
+                          selectedIndex: formData.consoleBoxSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateConsoleBoxSelectedIndex(index);
+                          },
+                          initialEnabled: formData.consoleBoxIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateConsoleBoxIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateConsoleBoxSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Spion Tengah',
+                          count: 10,
+                          selectedIndex: formData.spionTengahSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateSpionTengahSelectedIndex(index);
+                          },
+                          initialEnabled: formData.spionTengahIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateSpionTengahIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateSpionTengahSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Tuas Persneling',
+                          count: 10,
+                          selectedIndex: formData.tuasPersnelingSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateTuasPersnelingSelectedIndex(index);
+                          },
+                          initialEnabled: formData.tuasPersnelingIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateTuasPersnelingIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateTuasPersnelingSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Jok Belakang',
+                          count: 10,
+                          selectedIndex: formData.jokBelakangSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateJokBelakangSelectedIndex(index);
+                          },
+                          initialEnabled: formData.jokBelakangIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateJokBelakangIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateJokBelakangSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Panel Indikator',
+                          count: 10,
+                          selectedIndex: formData.panelIndikatorSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updatePanelIndikatorSelectedIndex(index);
+                          },
+                          initialEnabled: formData.panelIndikatorIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updatePanelIndikatorIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updatePanelIndikatorSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Switch Lampu',
+                          count: 10,
+                          selectedIndex: formData.switchLampuSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateSwitchLampuSelectedIndex(index);
+                          },
+                          initialEnabled: formData.switchLampuIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateSwitchLampuIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateSwitchLampuSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Karpet Dasar',
+                          count: 10,
+                          selectedIndex: formData.karpetDasarSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateKarpetDasarSelectedIndex(index);
+                          },
+                          initialEnabled: formData.karpetDasarIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateKarpetDasarIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateKarpetDasarSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Klakson',
+                          count: 10,
+                          selectedIndex: formData.klaksonSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateKlaksonSelectedIndex(index);
+                          },
+                          initialEnabled: formData.klaksonIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateKlaksonIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateKlaksonSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Sun Visor',
+                          count: 10,
+                          selectedIndex: formData.sunVisorSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateSunVisorSelectedIndex(index);
+                          },
+                          initialEnabled: formData.sunVisorIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateSunVisorIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateSunVisorSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Tuas Tangki Bensin',
+                          count: 10,
+                          selectedIndex: formData.tuasTangkiBensinSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateTuasTangkiBensinSelectedIndex(index);
+                          },
+                          initialEnabled: formData.tuasTangkiBensinIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateTuasTangkiBensinIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateTuasTangkiBensinSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Sabuk Pengaman',
+                          count: 10,
+                          selectedIndex: formData.sabukPengamanSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateSabukPengamanSelectedIndex(index);
+                          },
+                          initialEnabled: formData.sabukPengamanIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateSabukPengamanIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateSabukPengamanSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Trim Interior',
+                          count: 10,
+                          selectedIndex: formData.trimInteriorSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateTrimInteriorSelectedIndex(index);
+                          },
+                          initialEnabled: formData.trimInteriorIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateTrimInteriorIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateTrimInteriorSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Plafon',
+                          count: 10,
+                          selectedIndex: formData.plafonSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updatePlafonSelectedIndex(index);
+                          },
+                          initialEnabled: formData.plafonIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updatePlafonIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updatePlafonSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
 
-                  NavigationButtonRow(
-                    onBackPressed: () => Navigator.pop(context),
-                    onNextPressed: () {
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(builder: (context) => const PageFiveFour()),
-                      );
-                    },
+                        // ExpandableTextField
+                        ExpandableTextField(
+                          label: 'Catatan',
+                          hintText: 'Masukkan catatan di sini',
+                          controller: _interiorCatatanController,
+                          onChangedList: (lines) {
+                            formNotifier.updateInteriorCatatan(lines.join('\n'));
+                          },
+                        ),
+                        const SizedBox(height: 32.0),
+
+                        NavigationButtonRow(
+                          onBackPressed: () => Navigator.pop(context),
+                          onNextPressed: () {
+                            Navigator.push(
+                              context,
+                              MaterialPageRoute(builder: (context) => const PageFiveFour()),
+                            );
+                          },
+                        ),
+                        const SizedBox(height: 32.0), // Optional spacing below the content
+                        // Footer
+                        Footer(),
+                      ],
+                    ),
                   ),
-                  const SizedBox(height: 32.0), // Optional spacing below the content
-                  // Footer
-                  Footer(),
-                ],
-              ),
+                ),
+              ],
             ),
           ),
-        ],
+        ),
       ),
     );
   }

--- a/lib/pages/page_five_three.dart
+++ b/lib/pages/page_five_three.dart
@@ -22,21 +22,15 @@ class PageFiveThree extends ConsumerStatefulWidget {
 class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
   late FocusScopeNode _focusScopeNode;
 
-  // State variable for ExpandableTextField
-  late TextEditingController _interiorCatatanController;
-
   @override
   void initState() {
     super.initState();
     _focusScopeNode = FocusScopeNode();
-    final formData = ref.read(formProvider);
-    _interiorCatatanController = TextEditingController(text: formData.interiorCatatan ?? '');
   }
 
   @override
   void dispose() {
     _focusScopeNode.dispose();
-    _interiorCatatanController.dispose();
     super.dispose();
   }
 
@@ -462,9 +456,9 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                         ExpandableTextField(
                           label: 'Catatan',
                           hintText: 'Masukkan catatan di sini',
-                          controller: _interiorCatatanController,
+                          initialLines: formData.interiorCatatanList,
                           onChangedList: (lines) {
-                            formNotifier.updateInteriorCatatan(lines.join('\n'));
+                            formNotifier.updateInteriorCatatanList(lines);
                           },
                         ),
                         const SizedBox(height: 32.0),

--- a/lib/pages/page_five_two.dart
+++ b/lib/pages/page_five_two.dart
@@ -21,21 +21,15 @@ class PageFiveTwo extends ConsumerStatefulWidget {
 class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
   late FocusScopeNode _focusScopeNode;
 
-  // State variable for ExpandableTextField
-  late TextEditingController _mesinCatatanController;
-
   @override
   void initState() {
     super.initState();
     _focusScopeNode = FocusScopeNode();
-    final formData = ref.read(formProvider);
-    _mesinCatatanController = TextEditingController(text: formData.mesinCatatan ?? '');
   }
 
   @override
   void dispose() {
     _focusScopeNode.dispose();
-    _mesinCatatanController.dispose();
     super.dispose();
   }
 
@@ -512,9 +506,9 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                         ExpandableTextField(
                           label: 'Catatan',
                           hintText: 'Masukkan catatan di sini',
-                          controller: _mesinCatatanController,
+                          initialLines: formData.mesinCatatanList,
                           onChangedList: (lines) {
-                            formNotifier.updateMesinCatatan(lines.join('\n'));
+                            formNotifier.updateMesinCatatanList(lines);
                           },
                         ),
                         const SizedBox(height: 32.0),

--- a/lib/pages/page_five_two.dart
+++ b/lib/pages/page_five_two.dart
@@ -19,61 +19,7 @@ class PageFiveTwo extends ConsumerStatefulWidget {
 }
 
 class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
-  // State variables for ToggleableNumberedButtonList
-  late int _getaranMesinSelectedIndex;
-  late bool _getaranMesinIsEnabled;
-  late int _suaraMesinSelectedIndex;
-  late bool _suaraMesinIsEnabled;
-  late int _transmisiSelectedIndex;
-  late bool _transmisiIsEnabled;
-  late int _pompaPowerSteeringSelectedIndex;
-  late bool _pompaPowerSteeringIsEnabled;
-  late int _coverTimingChainSelectedIndex;
-  late bool _coverTimingChainIsEnabled;
-  late int _oliPowerSteeringSelectedIndex;
-  late bool _oliPowerSteeringIsEnabled;
-  late int _accuSelectedIndex;
-  late bool _accuIsEnabled;
-  late int _kompressorAcSelectedIndex;
-  late bool _kompressorAcIsEnabled;
-  late int _fanSelectedIndex;
-  late bool _fanIsEnabled;
-  late int _selangSelectedIndex;
-  late bool _selangIsEnabled;
-  late int _karterOliSelectedIndex;
-  late bool _karterOliIsEnabled;
-  late int _oilRemSelectedIndex;
-  late bool _oilRemIsEnabled;
-  late int _kabelSelectedIndex;
-  late bool _kabelIsEnabled;
-  late int _kondensorSelectedIndex;
-  late bool _kondensorIsEnabled;
-  late int _radiatorSelectedIndex;
-  late bool _radiatorIsEnabled;
-  late int _cylinderHeadSelectedIndex;
-  late bool _cylinderHeadIsEnabled;
-  late int _oliMesinSelectedIndex;
-  late bool _oliMesinIsEnabled;
-  late int _airRadiatorSelectedIndex;
-  late bool _airRadiatorIsEnabled;
-  late int _coverKlepSelectedIndex;
-  late bool _coverKlepIsEnabled;
-  late int _alternatorSelectedIndex;
-  late bool _alternatorIsEnabled;
-  late int _waterPumpSelectedIndex;
-  late bool _waterPumpIsEnabled;
-  late int _beltSelectedIndex;
-  late bool _beltIsEnabled;
-  late int _oliTransmisiSelectedIndex;
-  late bool _oliTransmisiIsEnabled;
-  late int _cylinderBlockSelectedIndex;
-  late bool _cylinderBlockIsEnabled;
-  late int _bushingBesarSelectedIndex;
-  late bool _bushingBesarIsEnabled;
-  late int _bushingKecilSelectedIndex;
-  late bool _bushingKecilIsEnabled;
-  late int _tutupRadiatorSelectedIndex;
-  late bool _tutupRadiatorIsEnabled;
+  late FocusScopeNode _focusScopeNode;
 
   // State variable for ExpandableTextField
   late TextEditingController _mesinCatatanController;
@@ -81,851 +27,517 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
   @override
   void initState() {
     super.initState();
+    _focusScopeNode = FocusScopeNode();
     final formData = ref.read(formProvider);
-    // Initialize state variables from formProvider
-    _getaranMesinSelectedIndex = formData.getaranMesinSelectedIndex ?? 0;
-    _getaranMesinIsEnabled = formData.getaranMesinIsEnabled ?? true;
-    _suaraMesinSelectedIndex = formData.suaraMesinSelectedIndex ?? 0;
-    _suaraMesinIsEnabled = formData.suaraMesinIsEnabled ?? true;
-    _transmisiSelectedIndex = formData.transmisiSelectedIndex ?? 0;
-    _transmisiIsEnabled = formData.transmisiIsEnabled ?? true;
-    _pompaPowerSteeringSelectedIndex = formData.pompaPowerSteeringSelectedIndex ?? 0;
-    _pompaPowerSteeringIsEnabled = formData.pompaPowerSteeringIsEnabled ?? true;
-    _coverTimingChainSelectedIndex = formData.coverTimingChainSelectedIndex ?? 0;
-    _coverTimingChainIsEnabled = formData.coverTimingChainIsEnabled ?? true;
-    _oliPowerSteeringSelectedIndex = formData.oliPowerSteeringSelectedIndex ?? 0;
-    _oliPowerSteeringIsEnabled = formData.oliPowerSteeringIsEnabled ?? true;
-    _accuSelectedIndex = formData.accuSelectedIndex ?? 0;
-    _accuIsEnabled = formData.accuIsEnabled ?? true;
-    _kompressorAcSelectedIndex = formData.kompressorAcSelectedIndex ?? 0;
-    _kompressorAcIsEnabled = formData.kompressorAcIsEnabled ?? true;
-    _fanSelectedIndex = formData.fanSelectedIndex ?? 0;
-    _fanIsEnabled = formData.fanIsEnabled ?? true;
-    _selangSelectedIndex = formData.selangSelectedIndex ?? 0;
-    _selangIsEnabled = formData.selangIsEnabled ?? true;
-    _karterOliSelectedIndex = formData.karterOliSelectedIndex ?? 0;
-    _karterOliIsEnabled = formData.karterOliIsEnabled ?? true;
-    _oilRemSelectedIndex = formData.oilRemSelectedIndex ?? 0;
-    _oilRemIsEnabled = formData.oilRemIsEnabled ?? true;
-    _kabelSelectedIndex = formData.kabelSelectedIndex ?? 0;
-    _kabelIsEnabled = formData.kabelIsEnabled ?? true;
-    _kondensorSelectedIndex = formData.kondensorSelectedIndex ?? 0;
-    _kondensorIsEnabled = formData.kondensorIsEnabled ?? true;
-    _radiatorSelectedIndex = formData.radiatorSelectedIndex ?? 0;
-    _radiatorIsEnabled = formData.radiatorIsEnabled ?? true;
-    _cylinderHeadSelectedIndex = formData.cylinderHeadSelectedIndex ?? 0;
-    _cylinderHeadIsEnabled = formData.cylinderHeadIsEnabled ?? true;
-    _oliMesinSelectedIndex = formData.oliMesinSelectedIndex ?? 0;
-    _oliMesinIsEnabled = formData.oliMesinIsEnabled ?? true;
-    _airRadiatorSelectedIndex = formData.airRadiatorSelectedIndex ?? 0;
-    _airRadiatorIsEnabled = formData.airRadiatorIsEnabled ?? true;
-    _coverKlepSelectedIndex = formData.coverKlepSelectedIndex ?? 0;
-    _coverKlepIsEnabled = formData.coverKlepIsEnabled ?? true;
-    _alternatorSelectedIndex = formData.alternatorSelectedIndex ?? 0;
-    _alternatorIsEnabled = formData.alternatorIsEnabled ?? true;
-    _waterPumpSelectedIndex = formData.waterPumpSelectedIndex ?? 0;
-    _waterPumpIsEnabled = formData.waterPumpIsEnabled ?? true;
-    _beltSelectedIndex = formData.beltSelectedIndex ?? 0;
-    _beltIsEnabled = formData.beltIsEnabled ?? true;
-    _oliTransmisiSelectedIndex = formData.oliTransmisiSelectedIndex ?? 0;
-    _oliTransmisiIsEnabled = formData.oliTransmisiIsEnabled ?? true;
-    _cylinderBlockSelectedIndex = formData.cylinderBlockSelectedIndex ?? 0;
-    _cylinderBlockIsEnabled = formData.cylinderBlockIsEnabled ?? true;
-    _bushingBesarSelectedIndex = formData.bushingBesarSelectedIndex ?? 0;
-    _bushingBesarIsEnabled = formData.bushingBesarIsEnabled ?? true;
-    _bushingKecilSelectedIndex = formData.bushingKecilSelectedIndex ?? 0;
-    _bushingKecilIsEnabled = formData.bushingKecilIsEnabled ?? true;
-    _tutupRadiatorSelectedIndex = formData.tutupRadiatorSelectedIndex ?? 0;
-    _tutupRadiatorIsEnabled = formData.tutupRadiatorIsEnabled ?? true;
-
     _mesinCatatanController = TextEditingController(text: formData.mesinCatatan ?? '');
   }
 
   @override
   void dispose() {
+    _focusScopeNode.dispose();
     _mesinCatatanController.dispose();
     super.dispose();
   }
 
-  // Callback methods for ToggleableNumberedButtonList
-  void _onGetaranMesinItemSelected(int index) {
-    setState(() {
-      _getaranMesinSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateGetaranMesinSelectedIndex(index);
-  }
-
-  void _onGetaranMesinEnabledChanged(bool enabled) {
-    setState(() {
-      _getaranMesinIsEnabled = enabled;
-      if (!enabled) {
-        _getaranMesinSelectedIndex = 0; // Set to 0 when disabled
-      }
-    });
-    ref.read(formProvider.notifier).updateGetaranMesinIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateGetaranMesinSelectedIndex(_getaranMesinSelectedIndex);
-  }
-
-  void _onSuaraMesinItemSelected(int index) {
-    setState(() {
-      _suaraMesinSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateSuaraMesinSelectedIndex(index);
-  }
-
-  void _onSuaraMesinEnabledChanged(bool enabled) {
-    setState(() {
-      _suaraMesinIsEnabled = enabled;
-      if (!enabled) {
-        _suaraMesinSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateSuaraMesinIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateSuaraMesinSelectedIndex(_suaraMesinSelectedIndex);
-  }
-
-  void _onTransmisiItemSelected(int index) {
-    setState(() {
-      _transmisiSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateTransmisiSelectedIndex(index);
-  }
-
-  void _onTransmisiEnabledChanged(bool enabled) {
-    setState(() {
-      _transmisiIsEnabled = enabled;
-      if (!enabled) {
-        _transmisiSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateTransmisiIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateTransmisiSelectedIndex(_transmisiSelectedIndex);
-  }
-
-  void _onPompaPowerSteeringItemSelected(int index) {
-    setState(() {
-      _pompaPowerSteeringSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updatePompaPowerSteeringSelectedIndex(index);
-  }
-
-  void _onPompaPowerSteeringEnabledChanged(bool enabled) {
-    setState(() {
-      _pompaPowerSteeringIsEnabled = enabled;
-      if (!enabled) {
-        _pompaPowerSteeringSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updatePompaPowerSteeringIsEnabled(enabled);
-    ref.read(formProvider.notifier).updatePompaPowerSteeringSelectedIndex(_pompaPowerSteeringSelectedIndex);
-  }
-
-  void _onCoverTimingChainItemSelected(int index) {
-    setState(() {
-      _coverTimingChainSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateCoverTimingChainSelectedIndex(index);
-  }
-
-  void _onCoverTimingChainEnabledChanged(bool enabled) {
-    setState(() {
-      _coverTimingChainIsEnabled = enabled;
-      if (!enabled) {
-        _coverTimingChainSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateCoverTimingChainIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateCoverTimingChainSelectedIndex(_coverTimingChainSelectedIndex);
-  }
-
-  void _onOliPowerSteeringItemSelected(int index) {
-    setState(() {
-      _oliPowerSteeringSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateOliPowerSteeringSelectedIndex(index);
-  }
-
-  void _onOliPowerSteeringEnabledChanged(bool enabled) {
-    setState(() {
-      _oliPowerSteeringIsEnabled = enabled;
-      if (!enabled) {
-        _oliPowerSteeringSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateOliPowerSteeringIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateOliPowerSteeringSelectedIndex(_oliPowerSteeringSelectedIndex);
-  }
-
-  void _onAccuItemSelected(int index) {
-    setState(() {
-      _accuSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateAccuSelectedIndex(index);
-  }
-
-  void _onAccuEnabledChanged(bool enabled) {
-    setState(() {
-      _accuIsEnabled = enabled;
-      if (!enabled) {
-        _accuSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateAccuIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateAccuSelectedIndex(_accuSelectedIndex);
-  }
-
-  void _onKompressorAcItemSelected(int index) {
-    setState(() {
-      _kompressorAcSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateKompressorAcSelectedIndex(index);
-  }
-
-  void _onKompressorAcEnabledChanged(bool enabled) {
-    setState(() {
-      _kompressorAcIsEnabled = enabled;
-      if (!enabled) {
-        _kompressorAcSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateKompressorAcIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateKompressorAcSelectedIndex(_kompressorAcSelectedIndex);
-  }
-
-  void _onFanItemSelected(int index) {
-    setState(() {
-      _fanSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateFanSelectedIndex(index);
-  }
-
-  void _onFanEnabledChanged(bool enabled) {
-    setState(() {
-      _fanIsEnabled = enabled;
-      if (!enabled) {
-        _fanSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateFanIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateFanSelectedIndex(_fanSelectedIndex);
-  }
-
-  void _onSelangItemSelected(int index) {
-    setState(() {
-      _selangSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateSelangSelectedIndex(index);
-  }
-
-  void _onSelangEnabledChanged(bool enabled) {
-    setState(() {
-      _selangIsEnabled = enabled;
-      if (!enabled) {
-        _selangSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateSelangIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateSelangSelectedIndex(_selangSelectedIndex);
-  }
-
-  void _onKarterOliItemSelected(int index) {
-    setState(() {
-      _karterOliSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateKarterOliSelectedIndex(index);
-  }
-
-  void _onKarterOliEnabledChanged(bool enabled) {
-    setState(() {
-      _karterOliIsEnabled = enabled;
-      if (!enabled) {
-        _karterOliSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateKarterOliIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateKarterOliSelectedIndex(_karterOliSelectedIndex);
-  }
-
-  void _onOilRemItemSelected(int index) {
-    setState(() {
-      _oilRemSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateOilRemSelectedIndex(index);
-  }
-
-  void _onOilRemEnabledChanged(bool enabled) {
-    setState(() {
-      _oilRemIsEnabled = enabled;
-      if (!enabled) {
-        _oilRemSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateOilRemIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateOilRemSelectedIndex(_oilRemSelectedIndex);
-  }
-
-  void _onKabelItemSelected(int index) {
-    setState(() {
-      _kabelSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateKabelSelectedIndex(index);
-  }
-
-  void _onKabelEnabledChanged(bool enabled) {
-    setState(() {
-      _kabelIsEnabled = enabled;
-      if (!enabled) {
-        _kabelSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateKabelIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateKabelSelectedIndex(_kabelSelectedIndex);
-  }
-
-  void _onKondensorItemSelected(int index) {
-    setState(() {
-      _kondensorSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateKondensorSelectedIndex(index);
-  }
-
-  void _onKondensorEnabledChanged(bool enabled) {
-    setState(() {
-      _kondensorIsEnabled = enabled;
-      if (!enabled) {
-        _kondensorSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateKondensorIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateKondensorSelectedIndex(_kondensorSelectedIndex);
-  }
-
-  void _onRadiatorItemSelected(int index) {
-    setState(() {
-      _radiatorSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateRadiatorSelectedIndex(index);
-  }
-
-  void _onRadiatorEnabledChanged(bool enabled) {
-    setState(() {
-      _radiatorIsEnabled = enabled;
-      if (!enabled) {
-        _radiatorSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateRadiatorIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateRadiatorSelectedIndex(_radiatorSelectedIndex);
-  }
-
-  void _onCylinderHeadItemSelected(int index) {
-    setState(() {
-      _cylinderHeadSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateCylinderHeadSelectedIndex(index);
-  }
-
-  void _onCylinderHeadEnabledChanged(bool enabled) {
-    setState(() {
-      _cylinderHeadIsEnabled = enabled;
-      if (!enabled) {
-        _cylinderHeadSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateCylinderHeadIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateCylinderHeadSelectedIndex(_cylinderHeadSelectedIndex);
-  }
-
-  void _onOliMesinItemSelected(int index) {
-    setState(() {
-      _oliMesinSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateOliMesinSelectedIndex(index);
-  }
-
-  void _onOliMesinEnabledChanged(bool enabled) {
-    setState(() {
-      _oliMesinIsEnabled = enabled;
-      if (!enabled) {
-        _oliMesinSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateOliMesinIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateOliMesinSelectedIndex(_oliMesinSelectedIndex);
-  }
-
-  void _onAirRadiatorItemSelected(int index) {
-    setState(() {
-      _airRadiatorSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateAirRadiatorSelectedIndex(index);
-  }
-
-  void _onAirRadiatorEnabledChanged(bool enabled) {
-    setState(() {
-      _airRadiatorIsEnabled = enabled;
-      if (!enabled) {
-        _airRadiatorSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateAirRadiatorIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateAirRadiatorSelectedIndex(_airRadiatorSelectedIndex);
-  }
-
-  void _onCoverKlepItemSelected(int index) {
-    setState(() {
-      _coverKlepSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateCoverKlepSelectedIndex(index);
-  }
-
-  void _onCoverKlepEnabledChanged(bool enabled) {
-    setState(() {
-      _coverKlepIsEnabled = enabled;
-      if (!enabled) {
-        _coverKlepSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateCoverKlepIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateCoverKlepSelectedIndex(_coverKlepSelectedIndex);
-  }
-
-  void _onAlternatorItemSelected(int index) {
-    setState(() {
-      _alternatorSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateAlternatorSelectedIndex(index);
-  }
-
-  void _onAlternatorEnabledChanged(bool enabled) {
-    setState(() {
-      _alternatorIsEnabled = enabled;
-      if (!enabled) {
-        _alternatorSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateAlternatorIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateAlternatorSelectedIndex(_alternatorSelectedIndex);
-  }
-
-  void _onWaterPumpItemSelected(int index) {
-    setState(() {
-      _waterPumpSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateWaterPumpSelectedIndex(index);
-  }
-
-  void _onWaterPumpEnabledChanged(bool enabled) {
-    setState(() {
-      _waterPumpIsEnabled = enabled;
-      if (!enabled) {
-        _waterPumpSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateWaterPumpIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateWaterPumpSelectedIndex(_waterPumpSelectedIndex);
-  }
-
-  void _onBeltItemSelected(int index) {
-    setState(() {
-      _beltSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateBeltSelectedIndex(index);
-  }
-
-  void _onBeltEnabledChanged(bool enabled) {
-    setState(() {
-      _beltIsEnabled = enabled;
-      if (!enabled) {
-        _beltSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateBeltIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateBeltSelectedIndex(_beltSelectedIndex);
-  }
-
-  void _onOliTransmisiItemSelected(int index) {
-    setState(() {
-      _oliTransmisiSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateOliTransmisiSelectedIndex(index);
-  }
-
-  void _onOliTransmisiEnabledChanged(bool enabled) {
-    setState(() {
-      _oliTransmisiIsEnabled = enabled;
-      if (!enabled) {
-        _oliTransmisiSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateOliTransmisiIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateOliTransmisiSelectedIndex(_oliTransmisiSelectedIndex);
-  }
-
-  void _onCylinderBlockItemSelected(int index) {
-    setState(() {
-      _cylinderBlockSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateCylinderBlockSelectedIndex(index);
-  }
-
-  void _onCylinderBlockEnabledChanged(bool enabled) {
-    setState(() {
-      _cylinderBlockIsEnabled = enabled;
-      if (!enabled) {
-        _cylinderBlockSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateCylinderBlockIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateCylinderBlockSelectedIndex(_cylinderBlockSelectedIndex);
-  }
-
-  void _onBushingBesarItemSelected(int index) {
-    setState(() {
-      _bushingBesarSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateBushingBesarSelectedIndex(index);
-  }
-
-  void _onBushingBesarEnabledChanged(bool enabled) {
-    setState(() {
-      _bushingBesarIsEnabled = enabled;
-      if (!enabled) {
-        _bushingBesarSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateBushingBesarIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateBushingBesarSelectedIndex(_bushingBesarSelectedIndex);
-  }
-
-  void _onBushingKecilItemSelected(int index) {
-    setState(() {
-      _bushingKecilSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateBushingKecilSelectedIndex(index);
-  }
-
-  void _onBushingKecilEnabledChanged(bool enabled) {
-    setState(() {
-      _bushingKecilIsEnabled = enabled;
-      if (!enabled) {
-        _bushingKecilSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateBushingKecilIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateBushingKecilSelectedIndex(_bushingKecilSelectedIndex);
-  }
-
-  void _onTutupRadiatorItemSelected(int index) {
-    setState(() {
-      _tutupRadiatorSelectedIndex = index;
-    });
-    ref.read(formProvider.notifier).updateTutupRadiatorSelectedIndex(index);
-  }
-
-  void _onTutupRadiatorEnabledChanged(bool enabled) {
-    setState(() {
-      _tutupRadiatorIsEnabled = enabled;
-      if (!enabled) {
-        _tutupRadiatorSelectedIndex = 0;
-      }
-    });
-    ref.read(formProvider.notifier).updateTutupRadiatorIsEnabled(enabled);
-    ref.read(formProvider.notifier).updateTutupRadiatorSelectedIndex(_tutupRadiatorSelectedIndex);
-  }
-
-  // Callback method for ExpandableTextField
-  void _onMesinCatatanChanged(List<String> lines) {
-    ref.read(formProvider.notifier).updateMesinCatatan(lines.join('\n'));
-  }
-
   @override
   Widget build(BuildContext context) {
-    return CommonLayout(
-      child: Column(
-        children: [
-          Expanded(
-            child: SingleChildScrollView(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  PageNumber(data: '5/9'), // Assuming this page is still 5/9 or needs adjustment
-                  const SizedBox(height: 8.0),
-                  PageTitle(data: 'Penilaian'),
-                  const SizedBox(height: 24.0),
-                  const HeadingOne(text: 'Hasil Inspeksi Mesin'),
-                  const SizedBox(height: 16.0),
+    final formData = ref.watch(formProvider);
+    final formNotifier = ref.read(formProvider.notifier);
 
-                  // ToggleableNumberedButtonList widgets
-                  ToggleableNumberedButtonList(
-                    label: 'Getaran Mesin',
-                    count: 10,
-                    selectedIndex: _getaranMesinSelectedIndex,
-                    onItemSelected: _onGetaranMesinItemSelected,
-                    initialEnabled: _getaranMesinIsEnabled,
-                    onEnabledChanged: _onGetaranMesinEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Suara Mesin',
-                    count: 10,
-                    selectedIndex: _suaraMesinSelectedIndex,
-                    onItemSelected: _onSuaraMesinItemSelected,
-                    initialEnabled: _suaraMesinIsEnabled,
-                    onEnabledChanged: _onSuaraMesinEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Transmisi',
-                    count: 10,
-                    selectedIndex: _transmisiSelectedIndex,
-                    onItemSelected: _onTransmisiItemSelected,
-                    initialEnabled: _transmisiIsEnabled,
-                    onEnabledChanged: _onTransmisiEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Pompa Power Steering',
-                    count: 10,
-                    selectedIndex: _pompaPowerSteeringSelectedIndex,
-                    onItemSelected: _onPompaPowerSteeringItemSelected,
-                    initialEnabled: _pompaPowerSteeringIsEnabled,
-                    onEnabledChanged: _onPompaPowerSteeringEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Cover Timing Chain',
-                    count: 10,
-                    selectedIndex: _coverTimingChainSelectedIndex,
-                    onItemSelected: _onCoverTimingChainItemSelected,
-                    initialEnabled: _coverTimingChainIsEnabled,
-                    onEnabledChanged: _onCoverTimingChainEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Oli Power Steering',
-                    count: 10,
-                    selectedIndex: _oliPowerSteeringSelectedIndex,
-                    onItemSelected: _onOliPowerSteeringItemSelected,
-                    initialEnabled: _oliPowerSteeringIsEnabled,
-                    onEnabledChanged: _onOliPowerSteeringEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Accu',
-                    count: 10,
-                    selectedIndex: _accuSelectedIndex,
-                    onItemSelected: _onAccuItemSelected,
-                    initialEnabled: _accuIsEnabled,
-                    onEnabledChanged: _onAccuEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Kompressor AC',
-                    count: 10,
-                    selectedIndex: _kompressorAcSelectedIndex,
-                    onItemSelected: _onKompressorAcItemSelected,
-                    initialEnabled: _kompressorAcIsEnabled,
-                    onEnabledChanged: _onKompressorAcEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Fan',
-                    count: 10,
-                    selectedIndex: _fanSelectedIndex,
-                    onItemSelected: _onFanItemSelected,
-                    initialEnabled: _fanIsEnabled,
-                    onEnabledChanged: _onFanEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Selang',
-                    count: 10,
-                    selectedIndex: _selangSelectedIndex,
-                    onItemSelected: _onSelangItemSelected,
-                    initialEnabled: _selangIsEnabled,
-                    onEnabledChanged: _onSelangEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Karter Oli',
-                    count: 10,
-                    selectedIndex: _karterOliSelectedIndex,
-                    onItemSelected: _onKarterOliItemSelected,
-                    initialEnabled: _karterOliIsEnabled,
-                    onEnabledChanged: _onKarterOliEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Oil Rem',
-                    count: 10,
-                    selectedIndex: _oilRemSelectedIndex,
-                    onItemSelected: _onOilRemItemSelected,
-                    initialEnabled: _oilRemIsEnabled,
-                    onEnabledChanged: _onOilRemEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Kabel',
-                    count: 10,
-                    selectedIndex: _kabelSelectedIndex,
-                    onItemSelected: _onKabelItemSelected,
-                    initialEnabled: _kabelIsEnabled,
-                    onEnabledChanged: _onKabelEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Kondensor',
-                    count: 10,
-                    selectedIndex: _kondensorSelectedIndex,
-                    onItemSelected: _onKondensorItemSelected,
-                    initialEnabled: _kondensorIsEnabled,
-                    onEnabledChanged: _onKondensorEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Radiator',
-                    count: 10,
-                    selectedIndex: _radiatorSelectedIndex,
-                    onItemSelected: _onRadiatorItemSelected,
-                    initialEnabled: _radiatorIsEnabled,
-                    onEnabledChanged: _onRadiatorEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Cylinder Head',
-                    count: 10,
-                    selectedIndex: _cylinderHeadSelectedIndex,
-                    onItemSelected: _onCylinderHeadItemSelected,
-                    initialEnabled: _cylinderHeadIsEnabled,
-                    onEnabledChanged: _onCylinderHeadEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Oli Mesin',
-                    count: 10,
-                    selectedIndex: _oliMesinSelectedIndex,
-                    onItemSelected: _onOliMesinItemSelected,
-                    initialEnabled: _oliMesinIsEnabled,
-                    onEnabledChanged: _onOliMesinEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Air Radiator',
-                    count: 10,
-                    selectedIndex: _airRadiatorSelectedIndex,
-                    onItemSelected: _onAirRadiatorItemSelected,
-                    initialEnabled: _airRadiatorIsEnabled,
-                    onEnabledChanged: _onAirRadiatorEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Cover Klep',
-                    count: 10,
-                    selectedIndex: _coverKlepSelectedIndex,
-                    onItemSelected: _onCoverKlepItemSelected,
-                    initialEnabled: _coverKlepIsEnabled,
-                    onEnabledChanged: _onCoverKlepEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Alternator',
-                    count: 10,
-                    selectedIndex: _alternatorSelectedIndex,
-                    onItemSelected: _onAlternatorItemSelected,
-                    initialEnabled: _alternatorIsEnabled,
-                    onEnabledChanged: _onAlternatorEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Water Pump',
-                    count: 10,
-                    selectedIndex: _waterPumpSelectedIndex,
-                    onItemSelected: _onWaterPumpItemSelected,
-                    initialEnabled: _waterPumpIsEnabled,
-                    onEnabledChanged: _onWaterPumpEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Belt',
-                    count: 10,
-                    selectedIndex: _beltSelectedIndex,
-                    onItemSelected: _onBeltItemSelected,
-                    initialEnabled: _beltIsEnabled,
-                    onEnabledChanged: _onBeltEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Oli Transmisi',
-                    count: 10,
-                    selectedIndex: _oliTransmisiSelectedIndex,
-                    onItemSelected: _onOliTransmisiItemSelected,
-                    initialEnabled: _oliTransmisiIsEnabled,
-                    onEnabledChanged: _onOliTransmisiEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Cylinder Block',
-                    count: 10,
-                    selectedIndex: _cylinderBlockSelectedIndex,
-                    onItemSelected: _onCylinderBlockItemSelected,
-                    initialEnabled: _cylinderBlockIsEnabled,
-                    onEnabledChanged: _onCylinderBlockEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Bushing Besar',
-                    count: 10,
-                    selectedIndex: _bushingBesarSelectedIndex,
-                    onItemSelected: _onBushingBesarItemSelected,
-                    initialEnabled: _bushingBesarIsEnabled,
-                    onEnabledChanged: _onBushingBesarEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Bushing Kecil',
-                    count: 10,
-                    selectedIndex: _bushingKecilSelectedIndex,
-                    onItemSelected: _onBushingKecilItemSelected,
-                    initialEnabled: _bushingKecilIsEnabled,
-                    onEnabledChanged: _onBushingKecilEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
-                  ToggleableNumberedButtonList(
-                    label: 'Tutup Radiator',
-                    count: 10,
-                    selectedIndex: _tutupRadiatorSelectedIndex,
-                    onItemSelected: _onTutupRadiatorItemSelected,
-                    initialEnabled: _tutupRadiatorIsEnabled,
-                    onEnabledChanged: _onTutupRadiatorEnabledChanged,
-                  ),
-                  const SizedBox(height: 16.0),
+    return PopScope(
+      // Wrap with PopScope
+      onPopInvokedWithResult: (bool didPop, dynamic result) {
+        if (didPop) {
+          _focusScopeNode.unfocus(); // Unfocus when navigating back
+        }
+      },
+      child: FocusScope(
+        // Wrap with FocusScope
+        node: _focusScopeNode,
+        child: CommonLayout(
+          child: GestureDetector(
+            // Wrap with GestureDetector
+            onTap: () {
+              _focusScopeNode.unfocus(); // Unfocus on tap outside text fields
+            },
+            child: Column(
+              children: [
+                Expanded(
+                  child: SingleChildScrollView(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        PageNumber(data: '5/9'), // Assuming this page is still 5/9 or needs adjustment
+                        const SizedBox(height: 8.0),
+                        PageTitle(data: 'Penilaian'),
+                        const SizedBox(height: 24.0),
+                        const HeadingOne(text: 'Hasil Inspeksi Mesin'),
+                        const SizedBox(height: 16.0),
 
-                  // ExpandableTextField
-                  ExpandableTextField(
-                    label: 'Catatan',
-                    hintText: 'Masukkan catatan di sini',
-                    controller: _mesinCatatanController,
-                    onChangedList: _onMesinCatatanChanged,
-                  ),
-                  const SizedBox(height: 32.0),
+                        // ToggleableNumberedButtonList widgets
+                        ToggleableNumberedButtonList(
+                          label: 'Getaran Mesin',
+                          count: 10,
+                          selectedIndex: formData.getaranMesinSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateGetaranMesinSelectedIndex(index);
+                          },
+                          initialEnabled: formData.getaranMesinIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateGetaranMesinIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateGetaranMesinSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Suara Mesin',
+                          count: 10,
+                          selectedIndex: formData.suaraMesinSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateSuaraMesinSelectedIndex(index);
+                          },
+                          initialEnabled: formData.suaraMesinIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateSuaraMesinIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateSuaraMesinSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Transmisi',
+                          count: 10,
+                          selectedIndex: formData.transmisiSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateTransmisiSelectedIndex(index);
+                          },
+                          initialEnabled: formData.transmisiIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateTransmisiIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateTransmisiSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Pompa Power Steering',
+                          count: 10,
+                          selectedIndex: formData.pompaPowerSteeringSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updatePompaPowerSteeringSelectedIndex(index);
+                          },
+                          initialEnabled: formData.pompaPowerSteeringIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updatePompaPowerSteeringIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updatePompaPowerSteeringSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Cover Timing Chain',
+                          count: 10,
+                          selectedIndex: formData.coverTimingChainSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateCoverTimingChainSelectedIndex(index);
+                          },
+                          initialEnabled: formData.coverTimingChainIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateCoverTimingChainIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateCoverTimingChainSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Oli Power Steering',
+                          count: 10,
+                          selectedIndex: formData.oliPowerSteeringSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateOliPowerSteeringSelectedIndex(index);
+                          },
+                          initialEnabled: formData.oliPowerSteeringIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateOliPowerSteeringIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateOliPowerSteeringSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Accu',
+                          count: 10,
+                          selectedIndex: formData.accuSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateAccuSelectedIndex(index);
+                          },
+                          initialEnabled: formData.accuIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateAccuIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateAccuSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Kompressor AC',
+                          count: 10,
+                          selectedIndex: formData.kompressorAcSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateKompressorAcSelectedIndex(index);
+                          },
+                          initialEnabled: formData.kompressorAcIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateKompressorAcIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateKompressorAcSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Fan',
+                          count: 10,
+                          selectedIndex: formData.fanSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateFanSelectedIndex(index);
+                          },
+                          initialEnabled: formData.fanIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateFanIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateFanSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Selang',
+                          count: 10,
+                          selectedIndex: formData.selangSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateSelangSelectedIndex(index);
+                          },
+                          initialEnabled: formData.selangIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateSelangIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateSelangSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Karter Oli',
+                          count: 10,
+                          selectedIndex: formData.karterOliSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateKarterOliSelectedIndex(index);
+                          },
+                          initialEnabled: formData.karterOliIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateKarterOliIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateKarterOliSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Oil Rem',
+                          count: 10,
+                          selectedIndex: formData.oilRemSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateOilRemSelectedIndex(index);
+                          },
+                          initialEnabled: formData.oilRemIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateOilRemIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateOilRemSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Kabel',
+                          count: 10,
+                          selectedIndex: formData.kabelSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateKabelSelectedIndex(index);
+                          },
+                          initialEnabled: formData.kabelIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateKabelIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateKabelSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Kondensor',
+                          count: 10,
+                          selectedIndex: formData.kondensorSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateKondensorSelectedIndex(index);
+                          },
+                          initialEnabled: formData.kondensorIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateKondensorIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateKondensorSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Radiator',
+                          count: 10,
+                          selectedIndex: formData.radiatorSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateRadiatorSelectedIndex(index);
+                          },
+                          initialEnabled: formData.radiatorIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateRadiatorIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateRadiatorSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Cylinder Head',
+                          count: 10,
+                          selectedIndex: formData.cylinderHeadSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateCylinderHeadSelectedIndex(index);
+                          },
+                          initialEnabled: formData.cylinderHeadIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateCylinderHeadIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateCylinderHeadSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Oli Mesin',
+                          count: 10,
+                          selectedIndex: formData.oliMesinSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateOliMesinSelectedIndex(index);
+                          },
+                          initialEnabled: formData.oliMesinIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateOliMesinIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateOliMesinSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Air Radiator',
+                          count: 10,
+                          selectedIndex: formData.airRadiatorSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateAirRadiatorSelectedIndex(index);
+                          },
+                          initialEnabled: formData.airRadiatorIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateAirRadiatorIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateAirRadiatorSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Cover Klep',
+                          count: 10,
+                          selectedIndex: formData.coverKlepSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateCoverKlepSelectedIndex(index);
+                          },
+                          initialEnabled: formData.coverKlepIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateCoverKlepIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateCoverKlepSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Alternator',
+                          count: 10,
+                          selectedIndex: formData.alternatorSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateAlternatorSelectedIndex(index);
+                          },
+                          initialEnabled: formData.alternatorIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateAlternatorIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateAlternatorSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Water Pump',
+                          count: 10,
+                          selectedIndex: formData.waterPumpSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateWaterPumpSelectedIndex(index);
+                          },
+                          initialEnabled: formData.waterPumpIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateWaterPumpIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateWaterPumpSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Belt',
+                          count: 10,
+                          selectedIndex: formData.beltSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateBeltSelectedIndex(index);
+                          },
+                          initialEnabled: formData.beltIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateBeltIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateBeltSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Oli Transmisi',
+                          count: 10,
+                          selectedIndex: formData.oliTransmisiSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateOliTransmisiSelectedIndex(index);
+                          },
+                          initialEnabled: formData.oliTransmisiIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateOliTransmisiIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateOliTransmisiSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Cylinder Block',
+                          count: 10,
+                          selectedIndex: formData.cylinderBlockSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateCylinderBlockSelectedIndex(index);
+                          },
+                          initialEnabled: formData.cylinderBlockIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateCylinderBlockIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateCylinderBlockSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Bushing Besar',
+                          count: 10,
+                          selectedIndex: formData.bushingBesarSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateBushingBesarSelectedIndex(index);
+                          },
+                          initialEnabled: formData.bushingBesarIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateBushingBesarIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateBushingBesarSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Bushing Kecil',
+                          count: 10,
+                          selectedIndex: formData.bushingKecilSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateBushingKecilSelectedIndex(index);
+                          },
+                          initialEnabled: formData.bushingKecilIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateBushingKecilIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateBushingKecilSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Tutup Radiator',
+                          count: 10,
+                          selectedIndex: formData.tutupRadiatorSelectedIndex ?? -1,
+                          onItemSelected: (index) {
+                            formNotifier.updateTutupRadiatorSelectedIndex(index);
+                          },
+                          initialEnabled: formData.tutupRadiatorIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateTutupRadiatorIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateTutupRadiatorSelectedIndex(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
 
-                  NavigationButtonRow(
-                    onBackPressed: () => Navigator.pop(context),
-                    onNextPressed: () {
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(builder: (context) => const PageFiveThree()),
-                      );
-                    },
+                        // ExpandableTextField
+                        ExpandableTextField(
+                          label: 'Catatan',
+                          hintText: 'Masukkan catatan di sini',
+                          controller: _mesinCatatanController,
+                          onChangedList: (lines) {
+                            formNotifier.updateMesinCatatan(lines.join('\n'));
+                          },
+                        ),
+                        const SizedBox(height: 32.0),
+
+                        NavigationButtonRow(
+                          onBackPressed: () => Navigator.pop(context),
+                          onNextPressed: () {
+                            Navigator.push(
+                              context,
+                              MaterialPageRoute(builder: (context) => const PageFiveThree()),
+                            );
+                          },
+                        ),
+                        const SizedBox(height: 32.0),
+                        Footer(),
+                      ],
+                    ),
                   ),
-                  const SizedBox(height: 32.0),
-                  Footer(),
-                ],
-              ),
+                ),
+              ],
             ),
           ),
-        ],
+        ),
       ),
     );
   }

--- a/lib/pages/page_five_two.dart
+++ b/lib/pages/page_five_two.dart
@@ -69,7 +69,7 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                       children: [
                         PageNumber(data: '5/9'), // Assuming this page is still 5/9 or needs adjustment
                         const SizedBox(height: 8.0),
-                        PageTitle(data: 'Penilaian'),
+                        PageTitle(data: 'Penilaian (2)'),
                         const SizedBox(height: 24.0),
                         const HeadingOne(text: 'Hasil Inspeksi Mesin'),
                         const SizedBox(height: 16.0),

--- a/lib/pages/page_one.dart
+++ b/lib/pages/page_one.dart
@@ -20,10 +20,6 @@ class PageOne extends ConsumerStatefulWidget {
 
 class _PageOneState extends ConsumerState<PageOne> {
   late FocusScopeNode _focusScopeNode;
-  late FocusNode _namaInspektorFocusNode;
-  late FocusNode _namaCustomerFocusNode;
-  late FocusNode _cabangInspeksiFocusNode;
-  late FocusNode _tanggalInspeksiFocusNode;
 
   final _formKey = GlobalKey<FormState>(); // GlobalKey for the form
   bool _formSubmitted = false; // Track if the form has been submitted
@@ -32,19 +28,11 @@ class _PageOneState extends ConsumerState<PageOne> {
   void initState() {
     super.initState();
     _focusScopeNode = FocusScopeNode();
-    _namaInspektorFocusNode = FocusNode();
-    _namaCustomerFocusNode = FocusNode();
-    _cabangInspeksiFocusNode = FocusNode();
-    _tanggalInspeksiFocusNode = FocusNode();
   }
 
   @override
   void dispose() {
     _focusScopeNode.dispose();
-    _namaInspektorFocusNode.dispose();
-    _namaCustomerFocusNode.dispose();
-    _cabangInspeksiFocusNode.dispose();
-    _tanggalInspeksiFocusNode.dispose();
     super.dispose();
   }
 
@@ -112,7 +100,6 @@ class _PageOneState extends ConsumerState<PageOne> {
                         LabeledTextField(
                           label: 'Nama Inspektor',
                           hintText: 'Masukkan nama inspektor',
-                          focusNode: _namaInspektorFocusNode,
                           initialValue:
                               formData
                                   .namaInspektor, // Initialize with data from provider
@@ -135,7 +122,6 @@ class _PageOneState extends ConsumerState<PageOne> {
                         LabeledTextField(
                           label: 'Nama Customer',
                           hintText: 'Masukkan nama customer',
-                          focusNode: _namaCustomerFocusNode,
                           initialValue:
                               formData
                                   .namaCustomer, // Initialize with data from provider
@@ -158,7 +144,6 @@ class _PageOneState extends ConsumerState<PageOne> {
                         LabeledTextField(
                           label: 'Cabang Inspeksi',
                           hintText: 'Contoh: Yogyakarta / Semarang',
-                          focusNode: _cabangInspeksiFocusNode,
                           initialValue:
                               formData
                                   .cabangInspeksi, // Initialize with data from provider
@@ -189,7 +174,6 @@ class _PageOneState extends ConsumerState<PageOne> {
                               date,
                             ); // Update data in provider
                           },
-                          focusNode: _tanggalInspeksiFocusNode,
                           validator: (date) {
                             if (_formSubmitted && date == null) {
                               return 'Tanggal Inspeksi belum terisi'; // Validation message

--- a/lib/pages/page_two.dart
+++ b/lib/pages/page_two.dart
@@ -19,17 +19,6 @@ class PageTwo extends ConsumerStatefulWidget {
 
 class _PageTwoState extends ConsumerState<PageTwo> {
   late FocusScopeNode _focusScopeNode;
-  late FocusNode _merekKendaraanFocusNode;
-  late FocusNode _tipeKendaraanFocusNode;
-  late FocusNode _tahunFocusNode;
-  late FocusNode _transmisiFocusNode;
-  late FocusNode _warnaKendaraanFocusNode;
-  late FocusNode _odometerFocusNode;
-  late FocusNode _kepemilikanFocusNode;
-  late FocusNode _platNomorFocusNode;
-  late FocusNode _pajak1TahunFocusNode;
-  late FocusNode _pajak5TahunFocusNode;
-  late FocusNode _biayaPajakFocusNode;
 
   final _formKey = GlobalKey<FormState>(); // GlobalKey for the form
   bool _formSubmitted = false; // Track if the form has been submitted
@@ -38,33 +27,11 @@ class _PageTwoState extends ConsumerState<PageTwo> {
   void initState() {
     super.initState();
     _focusScopeNode = FocusScopeNode();
-    _merekKendaraanFocusNode = FocusNode();
-    _tipeKendaraanFocusNode = FocusNode();
-    _tahunFocusNode = FocusNode();
-    _transmisiFocusNode = FocusNode();
-    _warnaKendaraanFocusNode = FocusNode();
-    _odometerFocusNode = FocusNode();
-    _kepemilikanFocusNode = FocusNode();
-    _platNomorFocusNode = FocusNode();
-    _pajak1TahunFocusNode = FocusNode();
-    _pajak5TahunFocusNode = FocusNode();
-    _biayaPajakFocusNode = FocusNode();
   }
 
   @override
   void dispose() {
     _focusScopeNode.dispose();
-    _merekKendaraanFocusNode.dispose();
-    _tipeKendaraanFocusNode.dispose();
-    _tahunFocusNode.dispose();
-    _transmisiFocusNode.dispose();
-    _warnaKendaraanFocusNode.dispose();
-    _odometerFocusNode.dispose();
-    _kepemilikanFocusNode.dispose();
-    _platNomorFocusNode.dispose();
-    _pajak1TahunFocusNode.dispose();
-    _pajak5TahunFocusNode.dispose();
-    _biayaPajakFocusNode.dispose();
     super.dispose();
   }
 
@@ -135,7 +102,6 @@ class _PageTwoState extends ConsumerState<PageTwo> {
                         LabeledTextField(
                           label: 'Merek Kendaraan',
                           hintText: 'Masukkan merek kendaraan',
-                          focusNode: _merekKendaraanFocusNode,
                           initialValue:
                               formData
                                   .merekKendaraan, // Initialize with data from provider
@@ -157,7 +123,6 @@ class _PageTwoState extends ConsumerState<PageTwo> {
                         LabeledTextField(
                           label: 'Tipe Kendaraan',
                           hintText: 'Masukkan tipe kendaraan',
-                          focusNode: _tipeKendaraanFocusNode,
                           initialValue:
                               formData
                                   .tipeKendaraan, // Initialize with data from provider
@@ -183,7 +148,6 @@ class _PageTwoState extends ConsumerState<PageTwo> {
                               TextInputType.number, // Use number keyboard
                           useThousandsSeparator:
                               false, // Disable thousands separator for Tahun
-                          focusNode: _tahunFocusNode,
                           initialValue:
                               formData
                                   .tahun, // Initialize with data from provider
@@ -205,7 +169,6 @@ class _PageTwoState extends ConsumerState<PageTwo> {
                         LabeledTextField(
                           label: 'Transmisi',
                           hintText: 'Contoh: Otomatis / Manual',
-                          focusNode: _transmisiFocusNode,
                           initialValue:
                               formData
                                   .transmisi, // Initialize with data from provider
@@ -226,7 +189,6 @@ class _PageTwoState extends ConsumerState<PageTwo> {
                         LabeledTextField(
                           label: 'Warna Kendaraan',
                           hintText: 'Masukkan warna kendaraan',
-                          focusNode: _warnaKendaraanFocusNode,
                           initialValue:
                               formData
                                   .warnaKendaraan, // Initialize with data from provider
@@ -250,7 +212,6 @@ class _PageTwoState extends ConsumerState<PageTwo> {
                           keyboardType:
                               TextInputType.number, // Use number keyboard
                           suffixText: 'km', // Add suffix text for km
-                          focusNode: _odometerFocusNode,
                           initialValue:
                               formData
                                   .odometer, // Initialize with data from provider
@@ -271,7 +232,6 @@ class _PageTwoState extends ConsumerState<PageTwo> {
                         LabeledTextField(
                           label: 'Kepemilikan',
                           hintText: 'Contoh: Pribadi / Perusahaan',
-                          focusNode: _kepemilikanFocusNode,
                           initialValue:
                               formData
                                   .kepemilikan, // Initialize with data from provider
@@ -292,7 +252,6 @@ class _PageTwoState extends ConsumerState<PageTwo> {
                         LabeledTextField(
                           label: 'Plat Nomor',
                           hintText: 'Masukkan plat nomor',
-                          focusNode: _platNomorFocusNode,
                           initialValue:
                               formData
                                   .platNomor, // Initialize with data from provider
@@ -321,7 +280,6 @@ class _PageTwoState extends ConsumerState<PageTwo> {
                               date,
                             ); // Update data in provider
                           },
-                          focusNode: _pajak1TahunFocusNode,
                           formSubmitted:
                               _formSubmitted, // Pass the formSubmitted flag
                           lastDate: DateTime.now().add(
@@ -346,7 +304,6 @@ class _PageTwoState extends ConsumerState<PageTwo> {
                               date,
                             ); // Update data in provider
                           },
-                          focusNode: _pajak5TahunFocusNode,
                           formSubmitted:
                               _formSubmitted, // Pass the formSubmitted flag
                           lastDate: DateTime.now().add(
@@ -366,7 +323,6 @@ class _PageTwoState extends ConsumerState<PageTwo> {
                           suffixText: 'Rupiah', // Add prefix text for currency
                           keyboardType:
                               TextInputType.number, // Use number keyboard
-                          focusNode: _biayaPajakFocusNode,
                           initialValue:
                               formData
                                   .biayaPajak, // Initialize with data from provider

--- a/lib/providers/form_provider.dart
+++ b/lib/providers/form_provider.dart
@@ -205,8 +205,8 @@ class FormNotifier extends StateNotifier<FormData> {
     state = state.copyWith(sistemAcIsEnabled: enabled);
   }
 
-  void updateFiturCatatan(String? text) {
-    state = state.copyWith(fiturCatatan: text);
+  void updateFiturCatatanList(List<String> lines) {
+    state = state.copyWith(fiturCatatanList: lines);
   }
 
   // New update methods for Page Five Two
@@ -933,7 +933,7 @@ extension on FormData {
     bool? powerWindowIsEnabled,
     int? sistemAcSelectedIndex,
     bool? sistemAcIsEnabled,
-    String? fiturCatatan,
+    List<String>? fiturCatatanList,
     int? getaranMesinSelectedIndex,
     bool? getaranMesinIsEnabled,
     int? suaraMesinSelectedIndex,
@@ -1151,7 +1151,7 @@ extension on FormData {
       powerWindowIsEnabled: powerWindowIsEnabled ?? this.powerWindowIsEnabled,
       sistemAcSelectedIndex: sistemAcSelectedIndex ?? this.sistemAcSelectedIndex,
       sistemAcIsEnabled: sistemAcIsEnabled ?? this.sistemAcIsEnabled,
-      fiturCatatan: fiturCatatan ?? this.fiturCatatan,
+      fiturCatatanList: fiturCatatanList ?? this.fiturCatatanList,
       getaranMesinSelectedIndex: getaranMesinSelectedIndex ?? this.getaranMesinSelectedIndex,
       getaranMesinIsEnabled: getaranMesinIsEnabled ?? this.getaranMesinIsEnabled,
       suaraMesinSelectedIndex: suaraMesinSelectedIndex ?? this.suaraMesinSelectedIndex,

--- a/lib/providers/form_provider.dart
+++ b/lib/providers/form_provider.dart
@@ -426,8 +426,8 @@ class FormNotifier extends StateNotifier<FormData> {
     state = state.copyWith(tutupRadiatorIsEnabled: enabled);
   }
 
-  void updateMesinCatatan(String? text) {
-    state = state.copyWith(mesinCatatan: text);
+  void updateMesinCatatanList(List<String> lines) {
+    state = state.copyWith(mesinCatatanList: lines);
   }
 
   // New update methods for Page Five Three
@@ -623,8 +623,8 @@ class FormNotifier extends StateNotifier<FormData> {
     state = state.copyWith(plafonIsEnabled: enabled);
   }
 
-  void updateInteriorCatatan(String? catatan) {
-    state = state.copyWith(interiorCatatan: catatan);
+  void updateInteriorCatatanList(List<String> lines) {
+    state = state.copyWith(interiorCatatanList: lines);
   }
 
   // New update methods for Page Five Four
@@ -868,8 +868,8 @@ class FormNotifier extends StateNotifier<FormData> {
     state = state.copyWith(sideSkirtKiriIsEnabled: enabled);
   }
 
-  void updateEksteriorCatatan(String? catatan) {
-    state = state.copyWith(eksteriorCatatan: catatan);
+  void updateEksteriorCatatanList(List<String> lines) {
+    state = state.copyWith(eksteriorCatatanList: lines);
   }
 
   void updateRepairEstimations(List<Map<String, String>> estimations) {
@@ -988,7 +988,7 @@ extension on FormData {
     bool? bushingKecilIsEnabled,
     int? tutupRadiatorSelectedIndex,
     bool? tutupRadiatorIsEnabled,
-    String? mesinCatatan,
+    List<String>? mesinCatatanList,
     int? stirSelectedIndex,
     bool? stirIsEnabled,
     int? remTonganSelectedIndex,
@@ -1037,7 +1037,7 @@ extension on FormData {
     bool? trimInteriorIsEnabled,
     int? plafonSelectedIndex,
     bool? plafonIsEnabled,
-    String? interiorCatatan,
+    List<String>? interiorCatatanList,
     int? bumperDepanSelectedIndex,
     bool? bumperDepanIsEnabled,
     int? kapMesinSelectedIndex,
@@ -1098,7 +1098,7 @@ extension on FormData {
     bool? lisplangKiriIsEnabled,
     int? sideSkirtKiriSelectedIndex,
     bool? sideSkirtKiriIsEnabled,
-    String? eksteriorCatatan,
+    List<String>? eksteriorCatatanList,
   }) {
     return FormData(
       namaInspektor: namaInspektor ?? this.namaInspektor,
@@ -1206,7 +1206,7 @@ extension on FormData {
       bushingKecilIsEnabled: bushingKecilIsEnabled ?? this.bushingKecilIsEnabled,
       tutupRadiatorSelectedIndex: tutupRadiatorSelectedIndex ?? this.tutupRadiatorSelectedIndex,
       tutupRadiatorIsEnabled: tutupRadiatorIsEnabled ?? this.tutupRadiatorIsEnabled,
-      mesinCatatan: mesinCatatan ?? this.mesinCatatan,
+      mesinCatatanList: mesinCatatanList ?? this.mesinCatatanList,
       stirSelectedIndex: stirSelectedIndex ?? this.stirSelectedIndex,
       stirIsEnabled: stirIsEnabled ?? this.stirIsEnabled,
       remTonganSelectedIndex: remTonganSelectedIndex ?? this.remTonganSelectedIndex,
@@ -1255,7 +1255,7 @@ extension on FormData {
       trimInteriorIsEnabled: trimInteriorIsEnabled ?? this.trimInteriorIsEnabled,
       plafonSelectedIndex: plafonSelectedIndex ?? this.plafonSelectedIndex,
       plafonIsEnabled: plafonIsEnabled ?? this.plafonIsEnabled,
-      interiorCatatan: interiorCatatan ?? this.interiorCatatan,
+      interiorCatatanList: interiorCatatanList ?? this.interiorCatatanList,
       bumperDepanSelectedIndex: bumperDepanSelectedIndex ?? this.bumperDepanSelectedIndex,
       bumperDepanIsEnabled: bumperDepanIsEnabled ?? this.bumperDepanIsEnabled,
       kapMesinSelectedIndex: kapMesinSelectedIndex ?? this.kapMesinSelectedIndex,
@@ -1316,7 +1316,7 @@ extension on FormData {
       lisplangKiriIsEnabled: lisplangKiriIsEnabled ?? this.lisplangKiriIsEnabled,
       sideSkirtKiriSelectedIndex: sideSkirtKiriSelectedIndex ?? this.sideSkirtKiriSelectedIndex,
       sideSkirtKiriIsEnabled: sideSkirtKiriIsEnabled ?? this.sideSkirtKiriIsEnabled,
-      eksteriorCatatan: eksteriorCatatan ?? this.eksteriorCatatan,
+      eksteriorCatatanList: eksteriorCatatanList ?? this.eksteriorCatatanList,
     );
   }
 }

--- a/lib/providers/form_provider.dart
+++ b/lib/providers/form_provider.dart
@@ -627,6 +627,251 @@ class FormNotifier extends StateNotifier<FormData> {
     state = state.copyWith(interiorCatatan: catatan);
   }
 
+  // New update methods for Page Five Four
+  void updateBumperDepanSelectedIndex(int? index) {
+    state = state.copyWith(bumperDepanSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  }
+
+  void updateBumperDepanIsEnabled(bool? enabled) {
+    state = state.copyWith(bumperDepanIsEnabled: enabled);
+  }
+
+  void updateKapMesinSelectedIndex(int? index) {
+    state = state.copyWith(kapMesinSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  }
+
+  void updateKapMesinIsEnabled(bool? enabled) {
+    state = state.copyWith(kapMesinIsEnabled: enabled);
+  }
+
+  void updateLampuUtamaSelectedIndex(int? index) {
+    state = state.copyWith(lampuUtamaSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  }
+
+  void updateLampuUtamaIsEnabled(bool? enabled) {
+    state = state.copyWith(lampuUtamaIsEnabled: enabled);
+  }
+
+  void updatePanelAtapSelectedIndex(int? index) {
+    state = state.copyWith(panelAtapSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  }
+
+  void updatePanelAtapIsEnabled(bool? enabled) {
+    state = state.copyWith(panelAtapIsEnabled: enabled);
+  }
+
+  void updateGrillSelectedIndex(int? index) {
+    state = state.copyWith(grillSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  }
+
+  void updateGrillIsEnabled(bool? enabled) {
+    state = state.copyWith(grillIsEnabled: enabled);
+  }
+
+  void updateLampuFoglampSelectedIndex(int? index) {
+    state = state.copyWith(lampuFoglampSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  }
+
+  void updateLampuFoglampIsEnabled(bool? enabled) {
+    state = state.copyWith(lampuFoglampIsEnabled: enabled);
+  }
+
+  void updateKacaBeningSelectedIndex(int? index) {
+    state = state.copyWith(kacaBeningSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  }
+
+  void updateKacaBeningIsEnabled(bool? enabled) {
+    state = state.copyWith(kacaBeningIsEnabled: enabled);
+  }
+
+  void updateWiperBelakangSelectedIndex(int? index) {
+    state = state.copyWith(wiperBelakangSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  }
+
+  void updateWiperBelakangIsEnabled(bool? enabled) {
+    state = state.copyWith(wiperBelakangIsEnabled: enabled);
+  }
+
+  void updateBumperBelakangSelectedIndex(int? index) {
+    state = state.copyWith(bumperBelakangSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  }
+
+  void updateBumperBelakangIsEnabled(bool? enabled) {
+    state = state.copyWith(bumperBelakangIsEnabled: enabled);
+  }
+
+  void updateLampuBelakangSelectedIndex(int? index) {
+    state = state.copyWith(lampuBelakangSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  }
+
+  void updateLampuBelakangIsEnabled(bool? enabled) {
+    state = state.copyWith(lampuBelakangIsEnabled: enabled);
+  }
+
+  void updateTrunklidSelectedIndex(int? index) {
+    state = state.copyWith(trunklidSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  }
+
+  void updateTrunklidIsEnabled(bool? enabled) {
+    state = state.copyWith(trunklidIsEnabled: enabled);
+  }
+
+  void updateKacaDepanSelectedIndex(int? index) {
+    state = state.copyWith(kacaDepanSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  }
+
+  void updateKacaDepanIsEnabled(bool? enabled) {
+    state = state.copyWith(kacaDepanIsEnabled: enabled);
+  }
+
+  void updateFenderKananSelectedIndex(int? index) {
+    state = state.copyWith(fenderKananSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  }
+
+  void updateFenderKananIsEnabled(bool? enabled) {
+    state = state.copyWith(fenderKananIsEnabled: enabled);
+  }
+
+  void updateQuarterPanelKananSelectedIndex(int? index) {
+    state = state.copyWith(quarterPanelKananSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  }
+
+  void updateQuarterPanelKananIsEnabled(bool? enabled) {
+    state = state.copyWith(quarterPanelKananIsEnabled: enabled);
+  }
+
+  void updatePintuBelakangKananSelectedIndex(int? index) {
+    state = state.copyWith(pintuBelakangKananSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  }
+
+  void updatePintuBelakangKananIsEnabled(bool? enabled) {
+    state = state.copyWith(pintuBelakangKananIsEnabled: enabled);
+  }
+
+  void updateSpionKananSelectedIndex(int? index) {
+    state = state.copyWith(spionKananSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  }
+
+  void updateSpionKananIsEnabled(bool? enabled) {
+    state = state.copyWith(spionKananIsEnabled: enabled);
+  }
+
+  void updateLisplangKananSelectedIndex(int? index) {
+    state = state.copyWith(lisplangKananSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  }
+
+  void updateLisplangKananIsEnabled(bool? enabled) {
+    state = state.copyWith(lisplangKananIsEnabled: enabled);
+  }
+
+  void updateSideSkirtKananSelectedIndex(int? index) {
+    state = state.copyWith(sideSkirtKananSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  }
+
+  void updateSideSkirtKananIsEnabled(bool? enabled) {
+    state = state.copyWith(sideSkirtKananIsEnabled: enabled);
+  }
+
+  void updateDaunWiperSelectedIndex(int? index) {
+    state = state.copyWith(daunWiperSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  }
+
+  void updateDaunWiperIsEnabled(bool? enabled) {
+    state = state.copyWith(daunWiperIsEnabled: enabled);
+  }
+
+  void updatePintuBelakangSelectedIndex(int? index) {
+    state = state.copyWith(pintuBelakangSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  }
+
+  void updatePintuBelakangIsEnabled(bool? enabled) {
+    state = state.copyWith(pintuBelakangIsEnabled: enabled);
+  }
+
+  void updateFenderKiriSelectedIndex(int? index) {
+    state = state.copyWith(fenderKiriSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  }
+
+  void updateFenderKiriIsEnabled(bool? enabled) {
+    state = state.copyWith(fenderKiriIsEnabled: enabled);
+  }
+
+  void updateQuarterPanelKiriSelectedIndex(int? index) {
+    state = state.copyWith(quarterPanelKiriSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  }
+
+  void updateQuarterPanelKiriIsEnabled(bool? enabled) {
+    state = state.copyWith(quarterPanelKiriIsEnabled: enabled);
+  }
+
+  void updatePintuDepanSelectedIndex(int? index) {
+    state = state.copyWith(pintuDepanSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  }
+
+  void updatePintuDepanIsEnabled(bool? enabled) {
+    state = state.copyWith(pintuDepanIsEnabled: enabled);
+  }
+
+  void updateKacaJendelaKananSelectedIndex(int? index) {
+    state = state.copyWith(kacaJendelaKananSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  }
+
+  void updateKacaJendelaKananIsEnabled(bool? enabled) {
+    state = state.copyWith(kacaJendelaKananIsEnabled: enabled);
+  }
+
+  void updatePintuBelakangKiriSelectedIndex(int? index) {
+    state = state.copyWith(pintuBelakangKiriSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  }
+
+  void updatePintuBelakangKiriIsEnabled(bool? enabled) {
+    state = state.copyWith(pintuBelakangKiriIsEnabled: enabled);
+  }
+
+  void updateSpionKiriSelectedIndex(int? index) {
+    state = state.copyWith(spionKiriSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  }
+
+  void updateSpionKiriIsEnabled(bool? enabled) {
+    state = state.copyWith(spionKiriIsEnabled: enabled);
+  }
+
+  void updatePintuDepanKiriSelectedIndex(int? index) {
+    state = state.copyWith(pintuDepanKiriSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  }
+
+  void updatePintuDepanKiriIsEnabled(bool? enabled) {
+    state = state.copyWith(pintuDepanKiriIsEnabled: enabled);
+  }
+
+  void updateKacaJendelaKiriSelectedIndex(int? index) {
+    state = state.copyWith(kacaJendelaKiriSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  }
+
+  void updateKacaJendelaKiriIsEnabled(bool? enabled) {
+    state = state.copyWith(kacaJendelaKiriIsEnabled: enabled);
+  }
+
+  void updateLisplangKiriSelectedIndex(int? index) {
+    state = state.copyWith(lisplangKiriSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  }
+
+  void updateLisplangKiriIsEnabled(bool? enabled) {
+    state = state.copyWith(lisplangKiriIsEnabled: enabled);
+  }
+
+  void updateSideSkirtKiriSelectedIndex(int? index) {
+    state = state.copyWith(sideSkirtKiriSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  }
+
+  void updateSideSkirtKiriIsEnabled(bool? enabled) {
+    state = state.copyWith(sideSkirtKiriIsEnabled: enabled);
+  }
+
+  void updateEksteriorCatatan(String? catatan) {
+    state = state.copyWith(eksteriorCatatan: catatan);
+  }
+
   void updateRepairEstimations(List<Map<String, String>> estimations) {
     state = state.copyWith(repairEstimations: estimations);
   }
@@ -793,6 +1038,67 @@ extension on FormData {
     int? plafonSelectedIndex,
     bool? plafonIsEnabled,
     String? interiorCatatan,
+    int? bumperDepanSelectedIndex,
+    bool? bumperDepanIsEnabled,
+    int? kapMesinSelectedIndex,
+    bool? kapMesinIsEnabled,
+    int? lampuUtamaSelectedIndex,
+    bool? lampuUtamaIsEnabled,
+    int? panelAtapSelectedIndex,
+    bool? panelAtapIsEnabled,
+    int? grillSelectedIndex,
+    bool? grillIsEnabled,
+    int? lampuFoglampSelectedIndex,
+    bool? lampuFoglampIsEnabled,
+    int? kacaBeningSelectedIndex,
+    bool? kacaBeningIsEnabled,
+    int? wiperBelakangSelectedIndex,
+    bool? wiperBelakangIsEnabled,
+    int? bumperBelakangSelectedIndex,
+    bool? bumperBelakangIsEnabled,
+    int? lampuBelakangSelectedIndex,
+    bool? lampuBelakangIsEnabled,
+    int? trunklidSelectedIndex,
+    bool? trunklidIsEnabled,
+    int? kacaDepanSelectedIndex,
+    bool? kacaDepanIsEnabled,
+    int? fenderKananSelectedIndex,
+    bool? fenderKananIsEnabled,
+    int? quarterPanelKananSelectedIndex,
+    bool? quarterPanelKananIsEnabled,
+    int? pintuBelakangKananSelectedIndex,
+    bool? pintuBelakangKananIsEnabled,
+    int? spionKananSelectedIndex,
+    bool? spionKananIsEnabled,
+    int? lisplangKananSelectedIndex,
+    bool? lisplangKananIsEnabled,
+    int? sideSkirtKananSelectedIndex,
+    bool? sideSkirtKananIsEnabled,
+    int? daunWiperSelectedIndex,
+    bool? daunWiperIsEnabled,
+    int? pintuBelakangSelectedIndex,
+    bool? pintuBelakangIsEnabled,
+    int? fenderKiriSelectedIndex,
+    bool? fenderKiriIsEnabled,
+    int? quarterPanelKiriSelectedIndex,
+    bool? quarterPanelKiriIsEnabled,
+    int? pintuDepanSelectedIndex,
+    bool? pintuDepanIsEnabled,
+    int? kacaJendelaKananSelectedIndex,
+    bool? kacaJendelaKananIsEnabled,
+    int? pintuBelakangKiriSelectedIndex,
+    bool? pintuBelakangKiriIsEnabled,
+    int? spionKiriSelectedIndex,
+    bool? spionKiriIsEnabled,
+    int? pintuDepanKiriSelectedIndex,
+    bool? pintuDepanKiriIsEnabled,
+    int? kacaJendelaKiriSelectedIndex,
+    bool? kacaJendelaKiriIsEnabled,
+    int? lisplangKiriSelectedIndex,
+    bool? lisplangKiriIsEnabled,
+    int? sideSkirtKiriSelectedIndex,
+    bool? sideSkirtKiriIsEnabled,
+    String? eksteriorCatatan,
   }) {
     return FormData(
       namaInspektor: namaInspektor ?? this.namaInspektor,
@@ -950,6 +1256,67 @@ extension on FormData {
       plafonSelectedIndex: plafonSelectedIndex ?? this.plafonSelectedIndex,
       plafonIsEnabled: plafonIsEnabled ?? this.plafonIsEnabled,
       interiorCatatan: interiorCatatan ?? this.interiorCatatan,
+      bumperDepanSelectedIndex: bumperDepanSelectedIndex ?? this.bumperDepanSelectedIndex,
+      bumperDepanIsEnabled: bumperDepanIsEnabled ?? this.bumperDepanIsEnabled,
+      kapMesinSelectedIndex: kapMesinSelectedIndex ?? this.kapMesinSelectedIndex,
+      kapMesinIsEnabled: kapMesinIsEnabled ?? this.kapMesinIsEnabled,
+      lampuUtamaSelectedIndex: lampuUtamaSelectedIndex ?? this.lampuUtamaSelectedIndex,
+      lampuUtamaIsEnabled: lampuUtamaIsEnabled ?? this.lampuUtamaIsEnabled,
+      panelAtapSelectedIndex: panelAtapSelectedIndex ?? this.panelAtapSelectedIndex,
+      panelAtapIsEnabled: panelAtapIsEnabled ?? this.panelAtapIsEnabled,
+      grillSelectedIndex: grillSelectedIndex ?? this.grillSelectedIndex,
+      grillIsEnabled: grillIsEnabled ?? this.grillIsEnabled,
+      lampuFoglampSelectedIndex: lampuFoglampSelectedIndex ?? this.lampuFoglampSelectedIndex,
+      lampuFoglampIsEnabled: lampuFoglampIsEnabled ?? this.lampuFoglampIsEnabled,
+      kacaBeningSelectedIndex: kacaBeningSelectedIndex ?? this.kacaBeningSelectedIndex,
+      kacaBeningIsEnabled: kacaBeningIsEnabled ?? this.kacaBeningIsEnabled,
+      wiperBelakangSelectedIndex: wiperBelakangSelectedIndex ?? this.wiperBelakangSelectedIndex,
+      wiperBelakangIsEnabled: wiperBelakangIsEnabled ?? this.wiperBelakangIsEnabled,
+      bumperBelakangSelectedIndex: bumperBelakangSelectedIndex ?? this.bumperBelakangSelectedIndex,
+      bumperBelakangIsEnabled: bumperBelakangIsEnabled ?? this.bumperBelakangIsEnabled,
+      lampuBelakangSelectedIndex: lampuBelakangSelectedIndex ?? this.lampuBelakangSelectedIndex,
+      lampuBelakangIsEnabled: lampuBelakangIsEnabled ?? this.lampuBelakangIsEnabled,
+      trunklidSelectedIndex: trunklidSelectedIndex ?? this.trunklidSelectedIndex,
+      trunklidIsEnabled: trunklidIsEnabled ?? this.trunklidIsEnabled,
+      kacaDepanSelectedIndex: kacaDepanSelectedIndex ?? this.kacaDepanSelectedIndex,
+      kacaDepanIsEnabled: kacaDepanIsEnabled ?? this.kacaDepanIsEnabled,
+      fenderKananSelectedIndex: fenderKananSelectedIndex ?? this.fenderKananSelectedIndex,
+      fenderKananIsEnabled: fenderKananIsEnabled ?? this.fenderKananIsEnabled,
+      quarterPanelKananSelectedIndex: quarterPanelKananSelectedIndex ?? this.quarterPanelKananSelectedIndex,
+      quarterPanelKananIsEnabled: quarterPanelKananIsEnabled ?? this.quarterPanelKananIsEnabled,
+      pintuBelakangKananSelectedIndex: pintuBelakangKananSelectedIndex ?? this.pintuBelakangKananSelectedIndex,
+      pintuBelakangKananIsEnabled: pintuBelakangKananIsEnabled ?? this.pintuBelakangKananIsEnabled,
+      spionKananSelectedIndex: spionKananSelectedIndex ?? this.spionKananSelectedIndex,
+      spionKananIsEnabled: spionKananIsEnabled ?? this.spionKananIsEnabled,
+      lisplangKananSelectedIndex: lisplangKananSelectedIndex ?? this.lisplangKananSelectedIndex,
+      lisplangKananIsEnabled: lisplangKananIsEnabled ?? this.lisplangKananIsEnabled,
+      sideSkirtKananSelectedIndex: sideSkirtKananSelectedIndex ?? this.sideSkirtKananSelectedIndex,
+      sideSkirtKananIsEnabled: sideSkirtKananIsEnabled ?? this.sideSkirtKananIsEnabled,
+      daunWiperSelectedIndex: daunWiperSelectedIndex ?? this.daunWiperSelectedIndex,
+      daunWiperIsEnabled: daunWiperIsEnabled ?? this.daunWiperIsEnabled,
+      pintuBelakangSelectedIndex: pintuBelakangSelectedIndex ?? this.pintuBelakangSelectedIndex,
+      pintuBelakangIsEnabled: pintuBelakangIsEnabled ?? this.pintuBelakangIsEnabled,
+      fenderKiriSelectedIndex: fenderKiriSelectedIndex ?? this.fenderKiriSelectedIndex,
+      fenderKiriIsEnabled: fenderKiriIsEnabled ?? this.fenderKiriIsEnabled,
+      quarterPanelKiriSelectedIndex: quarterPanelKiriSelectedIndex ?? this.quarterPanelKiriSelectedIndex,
+      quarterPanelKiriIsEnabled: quarterPanelKiriIsEnabled ?? this.quarterPanelKiriIsEnabled,
+      pintuDepanSelectedIndex: pintuDepanSelectedIndex ?? this.pintuDepanSelectedIndex,
+      pintuDepanIsEnabled: pintuDepanIsEnabled ?? this.pintuDepanIsEnabled,
+      kacaJendelaKananSelectedIndex: kacaJendelaKananSelectedIndex ?? this.kacaJendelaKananSelectedIndex,
+      kacaJendelaKananIsEnabled: kacaJendelaKananIsEnabled ?? this.kacaJendelaKananIsEnabled,
+      pintuBelakangKiriSelectedIndex: pintuBelakangKiriSelectedIndex ?? this.pintuBelakangKiriSelectedIndex,
+      pintuBelakangKiriIsEnabled: pintuBelakangKiriIsEnabled ?? this.pintuBelakangKiriIsEnabled,
+      spionKiriSelectedIndex: spionKiriSelectedIndex ?? this.spionKiriSelectedIndex,
+      spionKiriIsEnabled: spionKiriIsEnabled ?? this.spionKiriIsEnabled,
+      pintuDepanKiriSelectedIndex: pintuDepanKiriSelectedIndex ?? this.pintuDepanKiriSelectedIndex,
+      pintuDepanKiriIsEnabled: pintuDepanKiriIsEnabled ?? this.pintuDepanKiriIsEnabled,
+      kacaJendelaKiriSelectedIndex: kacaJendelaKiriSelectedIndex ?? this.kacaJendelaKiriSelectedIndex,
+      kacaJendelaKiriIsEnabled: kacaJendelaKiriIsEnabled ?? this.kacaJendelaKiriIsEnabled,
+      lisplangKiriSelectedIndex: lisplangKiriSelectedIndex ?? this.lisplangKiriSelectedIndex,
+      lisplangKiriIsEnabled: lisplangKiriIsEnabled ?? this.lisplangKiriIsEnabled,
+      sideSkirtKiriSelectedIndex: sideSkirtKiriSelectedIndex ?? this.sideSkirtKiriSelectedIndex,
+      sideSkirtKiriIsEnabled: sideSkirtKiriIsEnabled ?? this.sideSkirtKiriIsEnabled,
+      eksteriorCatatan: eksteriorCatatan ?? this.eksteriorCatatan,
     );
   }
 }

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -74,14 +74,14 @@ class ApiService {
       );
 
       if (response.statusCode == 200 || response.statusCode == 201) {
-        print('Form data submitted successfully!');
+        //print('Form data submitted successfully!');
         // TODO: Handle success (e.g., show a success message)
       } else {
-        print('Failed to submit form data: ${response.statusCode}');
+        //print('Failed to submit form data: ${response.statusCode}');
         // TODO: Handle errors (e.g., show an error message)
       }
     } catch (e) {
-      print('Error submitting form data: $e');
+      //print('Error submitting form data: $e');
       // TODO: Handle network errors or exceptions (e.g., show an error message)
     }
   }

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -5,13 +5,6 @@
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -5,26 +5,28 @@
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 
+// This is a basic Flutter widget test.
+//
+// To perform an interaction with a widget in your test, use the WidgetTester
+// utility in the flutter_test package. For example, you can send tap and scroll
+// gestures. You can also use WidgetTester to find child widgets in the widget
+// tree, read text, and verify that the values of widget properties are correct.
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:form_app/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const FormApp());
+  testWidgets('App renders without crashing', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const ProviderScope(
+        child: FormApp(),
+      ),
+    );
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    // Verify that the app renders a MaterialApp
+    expect(find.byType(MaterialApp), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Description

This PR addresses the state management for expandable text fields across the Penilaian pages (PageFiveTwo, PageFiveThree, and PageFiveFour) to ensure consistency with the pattern established in PageFiveOne. Additionally, this PR introduces the new PageFiveFour.

## Changes

### Expandable Text Field State Management Refactor

Previously, PageFiveTwo and PageFiveThree utilized `TextEditingController` and stored the data from expandable text fields as a single string within the `FormData` model. This approach has been updated to align with PageFiveOne, where the data is managed as a `List<String>` in the `FormData` model.

- Modified the `FormData` model (`lib/models/form_data.dart`) to include `List<String>` fields for `mesinCatatanList`, `interiorCatatanList`, and `eksteriorCatatanList`.
- Added corresponding update methods (`updateMesinCatatanList`, `updateInteriorCatatanList`, and `updateEksteriorCatatanList`) to the `FormNotifier` (`lib/providers/form_provider.dart`).
- Updated `PageFiveTwo` (`lib/pages/page_five_two.dart`) and `PageFiveThree` (`lib/pages/page_five_three.dart`) to use the `initialLines` property of `ExpandableTextField` with the new list-based fields and the `onChangedList` callback to call the corresponding list-based update methods in the `FormNotifier`.
- Removed the now unnecessary `TextEditingController` instances and their initialization/disposal logic from `PageFiveTwo` and `PageFiveThree`.

### New Page: PageFiveFour

This PR also includes the addition of a new page, `lib/pages/page_five_four.dart`. This page has been implemented following the established pattern for expandable text fields, utilizing `eksteriorCatatanList` from the `FormData` model and the `updateEksteriorCatatanList` method in the `FormNotifier`.