### PR TITLE
feat: Implement Ban dan Kaki-kaki Assessment Page and API Integration

### DIFF
--- a/lib/models/form_data.dart
+++ b/lib/models/form_data.dart
@@ -236,6 +236,43 @@ class FormData {
   bool? sideSkirtKiriIsEnabled;
   List<String> eksteriorCatatanList;
 
+  // New fields for Page Five Five
+  int? banDepanSelectedValue;
+  bool? banDepanIsEnabled;
+  int? velgDepanSelectedValue;
+  bool? velgDepanIsEnabled;
+  int? discBrakeSelectedValue;
+  bool? discBrakeIsEnabled;
+  int? masterRemSelectedValue;
+  bool? masterRemIsEnabled;
+  int? tieRodSelectedValue;
+  bool? tieRodIsEnabled;
+  int? gardanSelectedValue;
+  bool? gardanIsEnabled;
+  int? banBelakangSelectedValue;
+  bool? banBelakangIsEnabled;
+  int? velgBelakangSelectedValue;
+  bool? velgBelakangIsEnabled;
+  int? brakePadSelectedValue;
+  bool? brakePadIsEnabled;
+  int? crossmemberSelectedValue;
+  bool? crossmemberIsEnabled;
+  int? knalpotSelectedValue;
+  bool? knalpotIsEnabled;
+  int? balljointSelectedValue;
+  bool? balljointIsEnabled;
+  int? rocksteerSelectedValue;
+  bool? rocksteerIsEnabled;
+  int? karetBootSelectedValue;
+  bool? karetBootIsEnabled;
+  int? upperLowerArmSelectedValue;
+  bool? upperLowerArmIsEnabled;
+  int? shockBreakerSelectedValue;
+  bool? shockBreakerIsEnabled;
+  int? linkStabilizerSelectedValue;
+  bool? linkStabilizerIsEnabled;
+  List<String> banDanKakiKakiCatatanList;
+
 
   // New field for repair estimations
   List<Map<String, String>> repairEstimations;
@@ -457,8 +494,43 @@ class FormData {
     this.sideSkirtKiriSelectedValue,
     this.sideSkirtKiriIsEnabled,
     List<String>? eksteriorCatatanList,
+    this.banDepanSelectedValue,
+    this.banDepanIsEnabled,
+    this.velgDepanSelectedValue,
+    this.velgDepanIsEnabled,
+    this.discBrakeSelectedValue,
+    this.discBrakeIsEnabled,
+    this.masterRemSelectedValue,
+    this.masterRemIsEnabled,
+    this.tieRodSelectedValue,
+    this.tieRodIsEnabled,
+    this.gardanSelectedValue,
+    this.gardanIsEnabled,
+    this.banBelakangSelectedValue,
+    this.banBelakangIsEnabled,
+    this.velgBelakangSelectedValue,
+    this.velgBelakangIsEnabled,
+    this.brakePadSelectedValue,
+    this.brakePadIsEnabled,
+    this.crossmemberSelectedValue,
+    this.crossmemberIsEnabled,
+    this.knalpotSelectedValue,
+    this.knalpotIsEnabled,
+    this.balljointSelectedValue,
+    this.balljointIsEnabled,
+    this.rocksteerSelectedValue,
+    this.rocksteerIsEnabled,
+    this.karetBootSelectedValue,
+    this.karetBootIsEnabled,
+    this.upperLowerArmSelectedValue,
+    this.upperLowerArmIsEnabled,
+    this.shockBreakerSelectedValue,
+    this.shockBreakerIsEnabled,
+    this.linkStabilizerSelectedValue,
+    this.linkStabilizerIsEnabled,
+    List<String>? banDanKakiKakiCatatanList,
 
-  }) : keteranganEksterior = keteranganEksterior ?? [],
+  }) : keteranganEksterior = eksteriorCatatanList ?? [],
        keteranganInterior = keteranganInterior ?? [],
        keteranganKakiKaki = keteranganKakiKaki ?? [],
        keteranganMesin = keteranganMesin ?? [],
@@ -466,7 +538,8 @@ class FormData {
        repairEstimations = repairEstimations ?? [],
        mesinCatatanList = mesinCatatanList ?? [],
        interiorCatatanList = interiorCatatanList ?? [],
-       eksteriorCatatanList = eksteriorCatatanList ?? [];
+       eksteriorCatatanList = eksteriorCatatanList ?? [],
+       banDanKakiKakiCatatanList = banDanKakiKakiCatatanList ?? [];
 
   // Add methods to update data if needed, or update directly
 }

--- a/lib/models/form_data.dart
+++ b/lib/models/form_data.dart
@@ -41,11 +41,11 @@ class FormData {
   String? ketebalan;
 
   // New fields for inspection results
-  int? interiorSelectedIndex;
-  int? eksteriorSelectedIndex;
-  int? kakiKakiSelectedIndex;
-  int? mesinSelectedIndex;
-  int? penilaianKeseluruhanSelectedIndex;
+  int? interiorSelectedValue;
+  int? eksteriorSelectedValue;
+  int? kakiKakiSelectedValue;
+  int? mesinSelectedValue;
+  int? penilaianKeseluruhanSelectedValue;
 
   // NEW: Fields for ExpandableTextField data (as List<String>)
   List<String> keteranganInterior;
@@ -55,184 +55,184 @@ class FormData {
   List<String> deskripsiKeseluruhan;
 
   // New fields for Page Five One
-  int? airbagSelectedIndex;
+  int? airbagSelectedValue;
   bool? airbagIsEnabled;
-  int? sistemAudioSelectedIndex;
+  int? sistemAudioSelectedValue;
   bool? sistemAudioIsEnabled;
-  int? powerWindowSelectedIndex;
+  int? powerWindowSelectedValue;
   bool? powerWindowIsEnabled;
-  int? sistemAcSelectedIndex;
+  int? sistemAcSelectedValue;
   bool? sistemAcIsEnabled;
   List<String> fiturCatatanList;
 
   // New fields for Page Five Two
-  int? getaranMesinSelectedIndex;
+  int? getaranMesinSelectedValue;
   bool? getaranMesinIsEnabled;
-  int? suaraMesinSelectedIndex;
+  int? suaraMesinSelectedValue;
   bool? suaraMesinIsEnabled;
-  int? transmisiSelectedIndex;
+  int? transmisiSelectedValue;
   bool? transmisiIsEnabled;
-  int? pompaPowerSteeringSelectedIndex;
+  int? pompaPowerSteeringSelectedValue;
   bool? pompaPowerSteeringIsEnabled;
-  int? coverTimingChainSelectedIndex;
+  int? coverTimingChainSelectedValue;
   bool? coverTimingChainIsEnabled;
-  int? oliPowerSteeringSelectedIndex;
+  int? oliPowerSteeringSelectedValue;
   bool? oliPowerSteeringIsEnabled;
-  int? accuSelectedIndex;
+  int? accuSelectedValue;
   bool? accuIsEnabled;
-  int? kompressorAcSelectedIndex;
+  int? kompressorAcSelectedValue;
   bool? kompressorAcIsEnabled;
-  int? fanSelectedIndex;
+  int? fanSelectedValue;
   bool? fanIsEnabled;
-  int? selangSelectedIndex;
+  int? selangSelectedValue;
   bool? selangIsEnabled;
-  int? karterOliSelectedIndex;
+  int? karterOliSelectedValue;
   bool? karterOliIsEnabled;
-  int? oilRemSelectedIndex;
+  int? oilRemSelectedValue;
   bool? oilRemIsEnabled;
-  int? kabelSelectedIndex;
+  int? kabelSelectedValue;
   bool? kabelIsEnabled;
-  int? kondensorSelectedIndex;
+  int? kondensorSelectedValue;
   bool? kondensorIsEnabled;
-  int? radiatorSelectedIndex;
+  int? radiatorSelectedValue;
   bool? radiatorIsEnabled;
-  int? cylinderHeadSelectedIndex;
+  int? cylinderHeadSelectedValue;
   bool? cylinderHeadIsEnabled;
-  int? oliMesinSelectedIndex;
+  int? oliMesinSelectedValue;
   bool? oliMesinIsEnabled;
-  int? airRadiatorSelectedIndex;
+  int? airRadiatorSelectedValue;
   bool? airRadiatorIsEnabled;
-  int? coverKlepSelectedIndex;
+  int? coverKlepSelectedValue;
   bool? coverKlepIsEnabled;
-  int? alternatorSelectedIndex;
+  int? alternatorSelectedValue;
   bool? alternatorIsEnabled;
-  int? waterPumpSelectedIndex;
+  int? waterPumpSelectedValue;
   bool? waterPumpIsEnabled;
-  int? beltSelectedIndex;
+  int? beltSelectedValue;
   bool? beltIsEnabled;
-  int? oliTransmisiSelectedIndex;
+  int? oliTransmisiSelectedValue;
   bool? oliTransmisiIsEnabled;
-  int? cylinderBlockSelectedIndex;
+  int? cylinderBlockSelectedValue;
   bool? cylinderBlockIsEnabled;
-  int? bushingBesarSelectedIndex;
+  int? bushingBesarSelectedValue;
   bool? bushingBesarIsEnabled;
-  int? bushingKecilSelectedIndex;
+  int? bushingKecilSelectedValue;
   bool? bushingKecilIsEnabled;
-  int? tutupRadiatorSelectedIndex;
+  int? tutupRadiatorSelectedValue;
   bool? tutupRadiatorIsEnabled;
   List<String> mesinCatatanList;
 
   // New fields for Page Five Three
-  int? stirSelectedIndex;
+  int? stirSelectedValue;
   bool? stirIsEnabled;
-  int? remTonganSelectedIndex;
+  int? remTonganSelectedValue;
   bool? remTonganIsEnabled;
-  int? pedalSelectedIndex;
+  int? pedalSelectedValue;
   bool? pedalIsEnabled;
-  int? switchWiperSelectedIndex;
+  int? switchWiperSelectedValue;
   bool? switchWiperIsEnabled;
-  int? lampuHazardSelectedIndex;
+  int? lampuHazardSelectedValue;
   bool? lampuHazardIsEnabled;
-  int? panelDashboardSelectedIndex;
+  int? panelDashboardSelectedValue;
   bool? panelDashboardIsEnabled;
-  int? pembukaKapMesinSelectedIndex;
+  int? pembukaKapMesinSelectedValue;
   bool? pembukaKapMesinIsEnabled;
-  int? pembukaBagasiSelectedIndex;
+  int? pembukaBagasiSelectedValue;
   bool? pembukaBagasiIsEnabled;
-  int? jokDepanSelectedIndex;
+  int? jokDepanSelectedValue;
   bool? jokDepanIsEnabled;
-  int? aromaInteriorSelectedIndex;
+  int? aromaInteriorSelectedValue;
   bool? aromaInteriorIsEnabled;
-  int? handlePintuSelectedIndex;
+  int? handlePintuSelectedValue;
   bool? handlePintuIsEnabled;
-  int? consoleBoxSelectedIndex;
+  int? consoleBoxSelectedValue;
   bool? consoleBoxIsEnabled;
-  int? spionTengahSelectedIndex;
+  int? spionTengahSelectedValue;
   bool? spionTengahIsEnabled;
-  int? tuasPersnelingSelectedIndex;
+  int? tuasPersnelingSelectedValue;
   bool? tuasPersnelingIsEnabled;
-  int? jokBelakangSelectedIndex;
+  int? jokBelakangSelectedValue;
   bool? jokBelakangIsEnabled;
-  int? panelIndikatorSelectedIndex;
+  int? panelIndikatorSelectedValue;
   bool? panelIndikatorIsEnabled;
-  int? switchLampuSelectedIndex;
+  int? switchLampuSelectedValue;
   bool? switchLampuIsEnabled;
-  int? karpetDasarSelectedIndex;
+  int? karpetDasarSelectedValue;
   bool? karpetDasarIsEnabled;
-  int? klaksonSelectedIndex;
+  int? klaksonSelectedValue;
   bool? klaksonIsEnabled;
-  int? sunVisorSelectedIndex;
+  int? sunVisorSelectedValue;
   bool? sunVisorIsEnabled;
-  int? tuasTangkiBensinSelectedIndex;
+  int? tuasTangkiBensinSelectedValue;
   bool? tuasTangkiBensinIsEnabled;
-  int? sabukPengamanSelectedIndex;
+  int? sabukPengamanSelectedValue;
   bool? sabukPengamanIsEnabled;
-  int? trimInteriorSelectedIndex;
+  int? trimInteriorSelectedValue;
   bool? trimInteriorIsEnabled;
-  int? plafonSelectedIndex;
+  int? plafonSelectedValue;
   bool? plafonIsEnabled;
   List<String> interiorCatatanList;
 
   // New fields for Page Five Four
-  int? bumperDepanSelectedIndex;
+  int? bumperDepanSelectedValue;
   bool? bumperDepanIsEnabled;
-  int? kapMesinSelectedIndex;
+  int? kapMesinSelectedValue;
   bool? kapMesinIsEnabled;
-  int? lampuUtamaSelectedIndex;
+  int? lampuUtamaSelectedValue;
   bool? lampuUtamaIsEnabled;
-  int? panelAtapSelectedIndex;
+  int? panelAtapSelectedValue;
   bool? panelAtapIsEnabled;
-  int? grillSelectedIndex;
+  int? grillSelectedValue;
   bool? grillIsEnabled;
-  int? lampuFoglampSelectedIndex;
+  int? lampuFoglampSelectedValue;
   bool? lampuFoglampIsEnabled;
-  int? kacaBeningSelectedIndex;
+  int? kacaBeningSelectedValue;
   bool? kacaBeningIsEnabled;
-  int? wiperBelakangSelectedIndex;
+  int? wiperBelakangSelectedValue;
   bool? wiperBelakangIsEnabled;
-  int? bumperBelakangSelectedIndex;
+  int? bumperBelakangSelectedValue;
   bool? bumperBelakangIsEnabled;
-  int? lampuBelakangSelectedIndex;
+  int? lampuBelakangSelectedValue;
   bool? lampuBelakangIsEnabled;
-  int? trunklidSelectedIndex;
+  int? trunklidSelectedValue;
   bool? trunklidIsEnabled;
-  int? kacaDepanSelectedIndex;
+  int? kacaDepanSelectedValue;
   bool? kacaDepanIsEnabled;
-  int? fenderKananSelectedIndex;
+  int? fenderKananSelectedValue;
   bool? fenderKananIsEnabled;
-  int? quarterPanelKananSelectedIndex;
+  int? quarterPanelKananSelectedValue;
   bool? quarterPanelKananIsEnabled;
-  int? pintuBelakangKananSelectedIndex;
+  int? pintuBelakangKananSelectedValue;
   bool? pintuBelakangKananIsEnabled;
-  int? spionKananSelectedIndex;
+  int? spionKananSelectedValue;
   bool? spionKananIsEnabled;
-  int? lisplangKananSelectedIndex;
+  int? lisplangKananSelectedValue;
   bool? lisplangKananIsEnabled;
-  int? sideSkirtKananSelectedIndex;
+  int? sideSkirtKananSelectedValue;
   bool? sideSkirtKananIsEnabled;
-  int? daunWiperSelectedIndex;
+  int? daunWiperSelectedValue;
   bool? daunWiperIsEnabled;
-  int? pintuBelakangSelectedIndex;
+  int? pintuBelakangSelectedValue;
   bool? pintuBelakangIsEnabled;
-  int? fenderKiriSelectedIndex;
+  int? fenderKiriSelectedValue;
   bool? fenderKiriIsEnabled;
-  int? quarterPanelKiriSelectedIndex;
+  int? quarterPanelKiriSelectedValue;
   bool? quarterPanelKiriIsEnabled;
-  int? pintuDepanSelectedIndex;
+  int? pintuDepanSelectedValue;
   bool? pintuDepanIsEnabled;
-  int? kacaJendelaKananSelectedIndex;
+  int? kacaJendelaKananSelectedValue;
   bool? kacaJendelaKananIsEnabled;
-  int? pintuBelakangKiriSelectedIndex;
+  int? pintuBelakangKiriSelectedValue;
   bool? pintuBelakangKiriIsEnabled;
-  int? spionKiriSelectedIndex;
+  int? spionKiriSelectedValue;
   bool? spionKiriIsEnabled;
-  int? pintuDepanKiriSelectedIndex;
+  int? pintuDepanKiriSelectedValue;
   bool? pintuDepanKiriIsEnabled;
-  int? kacaJendelaKiriSelectedIndex;
+  int? kacaJendelaKiriSelectedValue;
   bool? kacaJendelaKiriIsEnabled;
-  int? lisplangKiriSelectedIndex;
+  int? lisplangKiriSelectedValue;
   bool? lisplangKiriIsEnabled;
-  int? sideSkirtKiriSelectedIndex;
+  int? sideSkirtKiriSelectedValue;
   bool? sideSkirtKiriIsEnabled;
   List<String> eksteriorCatatanList;
 
@@ -272,189 +272,189 @@ class FormData {
     this.merk,
     this.tipeVelg,
     this.ketebalan,
-    this.interiorSelectedIndex,
-    this.eksteriorSelectedIndex,
-    this.kakiKakiSelectedIndex,
-    this.mesinSelectedIndex,
-    this.penilaianKeseluruhanSelectedIndex,
+    this.interiorSelectedValue,
+    this.eksteriorSelectedValue,
+    this.kakiKakiSelectedValue,
+    this.mesinSelectedValue,
+    this.penilaianKeseluruhanSelectedValue,
     List<String>? keteranganInterior,
     List<String>? keteranganEksterior,
     List<String>? keteranganKakiKaki,
     List<String>? keteranganMesin,
     List<String>? deskripsiKeseluruhan,
     List<Map<String, String>>? repairEstimations,
-    this.airbagSelectedIndex,
+    this.airbagSelectedValue,
     this.airbagIsEnabled,
-    this.sistemAudioSelectedIndex,
+    this.sistemAudioSelectedValue,
     this.sistemAudioIsEnabled,
-    this.powerWindowSelectedIndex,
+    this.powerWindowSelectedValue,
     this.powerWindowIsEnabled,
-    this.sistemAcSelectedIndex,
+    this.sistemAcSelectedValue,
     this.sistemAcIsEnabled,
-    this.getaranMesinSelectedIndex,
+    this.getaranMesinSelectedValue,
     this.fiturCatatanList = const [],
     this.getaranMesinIsEnabled,
-    this.suaraMesinSelectedIndex,
+    this.suaraMesinSelectedValue,
     this.suaraMesinIsEnabled,
-    this.transmisiSelectedIndex,
+    this.transmisiSelectedValue,
     this.transmisiIsEnabled,
-    this.pompaPowerSteeringSelectedIndex,
+    this.pompaPowerSteeringSelectedValue,
     this.pompaPowerSteeringIsEnabled,
-    this.coverTimingChainSelectedIndex,
+    this.coverTimingChainSelectedValue,
     this.coverTimingChainIsEnabled,
-    this.oliPowerSteeringSelectedIndex,
+    this.oliPowerSteeringSelectedValue,
     this.oliPowerSteeringIsEnabled,
-    this.accuSelectedIndex,
+    this.accuSelectedValue,
     this.accuIsEnabled,
-    this.kompressorAcSelectedIndex,
+    this.kompressorAcSelectedValue,
     this.kompressorAcIsEnabled,
-    this.fanSelectedIndex,
+    this.fanSelectedValue,
     this.fanIsEnabled,
-    this.selangSelectedIndex,
+    this.selangSelectedValue,
     this.selangIsEnabled,
-    this.karterOliSelectedIndex,
+    this.karterOliSelectedValue,
     this.karterOliIsEnabled,
-    this.oilRemSelectedIndex,
+    this.oilRemSelectedValue,
     this.oilRemIsEnabled,
-    this.kabelSelectedIndex,
+    this.kabelSelectedValue,
     this.kabelIsEnabled,
-    this.kondensorSelectedIndex,
+    this.kondensorSelectedValue,
     this.kondensorIsEnabled,
-    this.radiatorSelectedIndex,
+    this.radiatorSelectedValue,
     this.radiatorIsEnabled,
-    this.cylinderHeadSelectedIndex,
+    this.cylinderHeadSelectedValue,
     this.cylinderHeadIsEnabled,
-    this.oliMesinSelectedIndex,
+    this.oliMesinSelectedValue,
     this.oliMesinIsEnabled,
-    this.airRadiatorSelectedIndex,
+    this.airRadiatorSelectedValue,
     this.airRadiatorIsEnabled,
-    this.coverKlepSelectedIndex,
+    this.coverKlepSelectedValue,
     this.coverKlepIsEnabled,
-    this.alternatorSelectedIndex,
+    this.alternatorSelectedValue,
     this.alternatorIsEnabled,
-    this.waterPumpSelectedIndex,
+    this.waterPumpSelectedValue,
     this.waterPumpIsEnabled,
-    this.beltSelectedIndex,
+    this.beltSelectedValue,
     this.beltIsEnabled,
-    this.oliTransmisiSelectedIndex,
+    this.oliTransmisiSelectedValue,
     this.oliTransmisiIsEnabled,
-    this.cylinderBlockSelectedIndex,
+    this.cylinderBlockSelectedValue,
     this.cylinderBlockIsEnabled,
-    this.bushingBesarSelectedIndex,
+    this.bushingBesarSelectedValue,
     this.bushingBesarIsEnabled,
-    this.bushingKecilSelectedIndex,
+    this.bushingKecilSelectedValue,
     this.bushingKecilIsEnabled,
-    this.tutupRadiatorSelectedIndex,
+    this.tutupRadiatorSelectedValue,
     this.tutupRadiatorIsEnabled,
     List<String>? mesinCatatanList,
-    this.stirSelectedIndex,
+    this.stirSelectedValue,
     this.stirIsEnabled,
-    this.remTonganSelectedIndex,
+    this.remTonganSelectedValue,
     this.remTonganIsEnabled,
-    this.pedalSelectedIndex,
+    this.pedalSelectedValue,
     this.pedalIsEnabled,
-    this.switchWiperSelectedIndex,
+    this.switchWiperSelectedValue,
     this.switchWiperIsEnabled,
-    this.lampuHazardSelectedIndex,
+    this.lampuHazardSelectedValue,
     this.lampuHazardIsEnabled,
-    this.panelDashboardSelectedIndex,
+    this.panelDashboardSelectedValue,
     this.panelDashboardIsEnabled,
-    this.pembukaKapMesinSelectedIndex,
+    this.pembukaKapMesinSelectedValue,
     this.pembukaKapMesinIsEnabled,
-    this.pembukaBagasiSelectedIndex,
+    this.pembukaBagasiSelectedValue,
     this.pembukaBagasiIsEnabled,
-    this.jokDepanSelectedIndex,
+    this.jokDepanSelectedValue,
     this.jokDepanIsEnabled,
-    this.aromaInteriorSelectedIndex,
+    this.aromaInteriorSelectedValue,
     this.aromaInteriorIsEnabled,
-    this.handlePintuSelectedIndex,
+    this.handlePintuSelectedValue,
     this.handlePintuIsEnabled,
-    this.consoleBoxSelectedIndex,
+    this.consoleBoxSelectedValue,
     this.consoleBoxIsEnabled,
-    this.spionTengahSelectedIndex,
+    this.spionTengahSelectedValue,
     this.spionTengahIsEnabled,
-    this.tuasPersnelingSelectedIndex,
+    this.tuasPersnelingSelectedValue,
     this.tuasPersnelingIsEnabled,
-    this.jokBelakangSelectedIndex,
+    this.jokBelakangSelectedValue,
     this.jokBelakangIsEnabled,
-    this.panelIndikatorSelectedIndex,
+    this.panelIndikatorSelectedValue,
     this.panelIndikatorIsEnabled,
-    this.switchLampuSelectedIndex,
+    this.switchLampuSelectedValue,
     this.switchLampuIsEnabled,
-    this.karpetDasarSelectedIndex,
+    this.karpetDasarSelectedValue,
     this.karpetDasarIsEnabled,
-    this.klaksonSelectedIndex,
+    this.klaksonSelectedValue,
     this.klaksonIsEnabled,
-    this.sunVisorSelectedIndex,
+    this.sunVisorSelectedValue,
     this.sunVisorIsEnabled,
-    this.tuasTangkiBensinSelectedIndex,
+    this.tuasTangkiBensinSelectedValue,
     this.tuasTangkiBensinIsEnabled,
-    this.sabukPengamanSelectedIndex,
+    this.sabukPengamanSelectedValue,
     this.sabukPengamanIsEnabled,
-    this.trimInteriorSelectedIndex,
+    this.trimInteriorSelectedValue,
     this.trimInteriorIsEnabled,
-    this.plafonSelectedIndex,
+    this.plafonSelectedValue,
     this.plafonIsEnabled,
     List<String>? interiorCatatanList,
-    this.bumperDepanSelectedIndex,
+    this.bumperDepanSelectedValue,
     this.bumperDepanIsEnabled,
-    this.kapMesinSelectedIndex,
+    this.kapMesinSelectedValue,
     this.kapMesinIsEnabled,
-    this.lampuUtamaSelectedIndex,
+    this.lampuUtamaSelectedValue,
     this.lampuUtamaIsEnabled,
-    this.panelAtapSelectedIndex,
+    this.panelAtapSelectedValue,
     this.panelAtapIsEnabled,
-    this.grillSelectedIndex,
+    this.grillSelectedValue,
     this.grillIsEnabled,
-    this.lampuFoglampSelectedIndex,
+    this.lampuFoglampSelectedValue,
     this.lampuFoglampIsEnabled,
-    this.kacaBeningSelectedIndex,
+    this.kacaBeningSelectedValue,
     this.kacaBeningIsEnabled,
-    this.wiperBelakangSelectedIndex,
+    this.wiperBelakangSelectedValue,
     this.wiperBelakangIsEnabled,
-    this.bumperBelakangSelectedIndex,
+    this.bumperBelakangSelectedValue,
     this.bumperBelakangIsEnabled,
-    this.lampuBelakangSelectedIndex,
+    this.lampuBelakangSelectedValue,
     this.lampuBelakangIsEnabled,
-    this.trunklidSelectedIndex,
+    this.trunklidSelectedValue,
     this.trunklidIsEnabled,
-    this.kacaDepanSelectedIndex,
+    this.kacaDepanSelectedValue,
     this.kacaDepanIsEnabled,
-    this.fenderKananSelectedIndex,
+    this.fenderKananSelectedValue,
     this.fenderKananIsEnabled,
-    this.quarterPanelKananSelectedIndex,
+    this.quarterPanelKananSelectedValue,
     this.quarterPanelKananIsEnabled,
-    this.pintuBelakangKananSelectedIndex,
+    this.pintuBelakangKananSelectedValue,
     this.pintuBelakangKananIsEnabled,
-    this.spionKananSelectedIndex,
+    this.spionKananSelectedValue,
     this.spionKananIsEnabled,
-    this.lisplangKananSelectedIndex,
+    this.lisplangKananSelectedValue,
     this.lisplangKananIsEnabled,
-    this.sideSkirtKananSelectedIndex,
+    this.sideSkirtKananSelectedValue,
     this.sideSkirtKananIsEnabled,
-    this.daunWiperSelectedIndex,
+    this.daunWiperSelectedValue,
     this.daunWiperIsEnabled,
-    this.pintuBelakangSelectedIndex,
+    this.pintuBelakangSelectedValue,
     this.pintuBelakangIsEnabled,
-    this.fenderKiriSelectedIndex,
+    this.fenderKiriSelectedValue,
     this.fenderKiriIsEnabled,
-    this.quarterPanelKiriSelectedIndex,
+    this.quarterPanelKiriSelectedValue,
     this.quarterPanelKiriIsEnabled,
-    this.pintuDepanSelectedIndex,
+    this.pintuDepanSelectedValue,
     this.pintuDepanIsEnabled,
-    this.kacaJendelaKananSelectedIndex,
+    this.kacaJendelaKananSelectedValue,
     this.kacaJendelaKananIsEnabled,
-    this.pintuBelakangKiriSelectedIndex,
+    this.pintuBelakangKiriSelectedValue,
     this.pintuBelakangKiriIsEnabled,
-    this.spionKiriSelectedIndex,
+    this.spionKiriSelectedValue,
     this.spionKiriIsEnabled,
-    this.pintuDepanKiriSelectedIndex,
+    this.pintuDepanKiriSelectedValue,
     this.pintuDepanKiriIsEnabled,
-    this.kacaJendelaKiriSelectedIndex,
+    this.kacaJendelaKiriSelectedValue,
     this.kacaJendelaKiriIsEnabled,
-    this.lisplangKiriSelectedIndex,
+    this.lisplangKiriSelectedValue,
     this.lisplangKiriIsEnabled,
-    this.sideSkirtKiriSelectedIndex,
+    this.sideSkirtKiriSelectedValue,
     this.sideSkirtKiriIsEnabled,
     List<String>? eksteriorCatatanList,
 

--- a/lib/pages/page_five_five.dart
+++ b/lib/pages/page_five_five.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:form_app/widgets/common_layout.dart';
 import 'package:form_app/widgets/heading_one.dart';
 import 'package:form_app/widgets/navigation_button_row.dart';
@@ -6,43 +7,363 @@ import 'package:form_app/widgets/page_number.dart';
 import 'package:form_app/widgets/page_title.dart';
 import 'package:form_app/widgets/footer.dart';
 import 'package:form_app/pages/page_five_six.dart'; // Import PageFiveSix
+import 'package:form_app/providers/form_provider.dart';
+import 'package:form_app/widgets/toggleable_numbered_button_list.dart';
+import 'package:form_app/widgets/expandable_text_field.dart';
 
-class PageFiveFive extends StatelessWidget {
+class PageFiveFive extends ConsumerStatefulWidget {
   const PageFiveFive({super.key});
 
   @override
+  ConsumerState<PageFiveFive> createState() => _PageFiveFiveState();
+}
+
+class _PageFiveFiveState extends ConsumerState<PageFiveFive> {
+  late FocusScopeNode _focusScopeNode;
+
+  @override
+  void initState() {
+    super.initState();
+    _focusScopeNode = FocusScopeNode();
+  }
+
+  @override
+  void dispose() {
+    _focusScopeNode.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return CommonLayout(
-      child: Column(
-        children: [
-          Expanded(
-            child: SingleChildScrollView(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  PageNumber(data: '5/9'),
-                  const SizedBox(height: 8.0),
-                  PageTitle(data: 'Penilaian (5)'),
-                  const SizedBox(height: 24.0),
-                  const HeadingOne(text: 'Ban dan Kaki-kaki'),
-                  const SizedBox(height: 32.0),
-                  NavigationButtonRow(
-                    onBackPressed: () => Navigator.pop(context),
-                    onNextPressed: () {
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(builder: (context) => const PageFiveSix()),
-                      );
-                    },
+    final formData = ref.watch(formProvider);
+    final formNotifier = ref.read(formProvider.notifier);
+
+    return PopScope(
+      onPopInvokedWithResult: (bool didPop, dynamic result) {
+        if (didPop) {
+          _focusScopeNode.unfocus();
+        }
+      },
+      child: FocusScope(
+        node: _focusScopeNode,
+        child: CommonLayout(
+          child: GestureDetector(
+            onTap: () {
+              _focusScopeNode.unfocus();
+            },
+            child: Column(
+              children: [
+                Expanded(
+                  child: SingleChildScrollView(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        PageNumber(data: '5/9'),
+                        const SizedBox(height: 8.0),
+                        PageTitle(data: 'Penilaian (5)'),
+                        const SizedBox(height: 24.0),
+                        const HeadingOne(text: 'Ban dan Kaki-kaki'),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Ban Depan',
+                          count: 10,
+                          selectedValue: formData.banDepanSelectedValue ?? -1,
+                          onItemSelected: (value) {
+                            formNotifier.updateBanDepanSelectedValue(value);
+                          },
+                          initialEnabled: formData.banDepanIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateBanDepanIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateBanDepanSelectedValue(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Velg Depan',
+                          count: 10,
+                          selectedValue: formData.velgDepanSelectedValue ?? -1,
+                          onItemSelected: (value) {
+                            formNotifier.updateVelgDepanSelectedValue(value);
+                          },
+                          initialEnabled: formData.velgDepanIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateVelgDepanIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateVelgDepanSelectedValue(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Disc Brake',
+                          count: 10,
+                          selectedValue: formData.discBrakeSelectedValue ?? -1,
+                          onItemSelected: (value) {
+                            formNotifier.updateDiscBrakeSelectedValue(value);
+                          },
+                          initialEnabled: formData.discBrakeIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateDiscBrakeIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateDiscBrakeSelectedValue(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Master Rem',
+                          count: 10,
+                          selectedValue: formData.masterRemSelectedValue ?? -1,
+                          onItemSelected: (value) {
+                            formNotifier.updateMasterRemSelectedValue(value);
+                          },
+                          initialEnabled: formData.masterRemIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateMasterRemIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateMasterRemSelectedValue(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Tie Rod',
+                          count: 10,
+                          selectedValue: formData.tieRodSelectedValue ?? -1,
+                          onItemSelected: (value) {
+                            formNotifier.updateTieRodSelectedValue(value);
+                          },
+                          initialEnabled: formData.tieRodIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateTieRodIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateTieRodSelectedValue(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Gardan',
+                          count: 10,
+                          selectedValue: formData.gardanSelectedValue ?? -1,
+                          onItemSelected: (value) {
+                            formNotifier.updateGardanSelectedValue(value);
+                          },
+                          initialEnabled: formData.gardanIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateGardanIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateGardanSelectedValue(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Ban Belakang',
+                          count: 10,
+                          selectedValue: formData.banBelakangSelectedValue ?? -1,
+                          onItemSelected: (value) {
+                            formNotifier.updateBanBelakangSelectedValue(value);
+                          },
+                          initialEnabled: formData.banBelakangIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateBanBelakangIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateBanBelakangSelectedValue(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Velg Belakang',
+                          count: 10,
+                          selectedValue: formData.velgBelakangSelectedValue ?? -1,
+                          onItemSelected: (value) {
+                            formNotifier.updateVelgBelakangSelectedValue(value);
+                          },
+                          initialEnabled: formData.velgBelakangIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateVelgBelakangIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateVelgBelakangSelectedValue(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Brake Pad',
+                          count: 10,
+                          selectedValue: formData.brakePadSelectedValue ?? -1,
+                          onItemSelected: (value) {
+                            formNotifier.updateBrakePadSelectedValue(value);
+                          },
+                          initialEnabled: formData.brakePadIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateBrakePadIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateBrakePadSelectedValue(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Crossmember',
+                          count: 10,
+                          selectedValue: formData.crossmemberSelectedValue ?? -1,
+                          onItemSelected: (value) {
+                            formNotifier.updateCrossmemberSelectedValue(value);
+                          },
+                          initialEnabled: formData.crossmemberIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateCrossmemberIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateCrossmemberSelectedValue(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Knalpot',
+                          count: 10,
+                          selectedValue: formData.knalpotSelectedValue ?? -1,
+                          onItemSelected: (value) {
+                            formNotifier.updateKnalpotSelectedValue(value);
+                          },
+                          initialEnabled: formData.knalpotIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateKnalpotIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateKnalpotSelectedValue(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Balljoint',
+                          count: 10,
+                          selectedValue: formData.balljointSelectedValue ?? -1,
+                          onItemSelected: (value) {
+                            formNotifier.updateBalljointSelectedValue(value);
+                          },
+                          initialEnabled: formData.balljointIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateBalljointIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateBalljointSelectedValue(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Rocksteer',
+                          count: 10,
+                          selectedValue: formData.rocksteerSelectedValue ?? -1,
+                          onItemSelected: (value) {
+                            formNotifier.updateRocksteerSelectedValue(value);
+                          },
+                          initialEnabled: formData.rocksteerIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateRocksteerIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateRocksteerSelectedValue(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Karet Boot',
+                          count: 10,
+                          selectedValue: formData.karetBootSelectedValue ?? -1,
+                          onItemSelected: (value) {
+                            formNotifier.updateKaretBootSelectedValue(value);
+                          },
+                          initialEnabled: formData.karetBootIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateKaretBootIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateKaretBootSelectedValue(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Upper-Lower Arm',
+                          count: 10,
+                          selectedValue: formData.upperLowerArmSelectedValue ?? -1,
+                          onItemSelected: (value) {
+                            formNotifier.updateUpperLowerArmSelectedValue(value);
+                          },
+                          initialEnabled: formData.upperLowerArmIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateUpperLowerArmIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateUpperLowerArmSelectedValue(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Shock Breaker',
+                          count: 10,
+                          selectedValue: formData.shockBreakerSelectedValue ?? -1,
+                          onItemSelected: (value) {
+                            formNotifier.updateShockBreakerSelectedValue(value);
+                          },
+                          initialEnabled: formData.shockBreakerIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateShockBreakerIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateShockBreakerSelectedValue(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ToggleableNumberedButtonList(
+                          label: 'Link Stabilizer',
+                          count: 10,
+                          selectedValue: formData.linkStabilizerSelectedValue ?? -1,
+                          onItemSelected: (value) {
+                            formNotifier.updateLinkStabilizerSelectedValue(value);
+                          },
+                          initialEnabled: formData.linkStabilizerIsEnabled ?? true,
+                          onEnabledChanged: (enabled) {
+                            formNotifier.updateLinkStabilizerIsEnabled(enabled);
+                            if (!enabled) {
+                              formNotifier.updateLinkStabilizerSelectedValue(-1);
+                            }
+                          },
+                        ),
+                        const SizedBox(height: 16.0),
+                        ExpandableTextField(
+                          label: 'Catatan',
+                          hintText: 'Masukkan catatan di sini',
+                          initialLines: formData.banDanKakiKakiCatatanList,
+                          onChangedList: (lines) {
+                            formNotifier.updateBanDanKakiKakiCatatanList(lines);
+                          },
+                        ),
+                        const SizedBox(height: 32.0),
+                        NavigationButtonRow(
+                          onBackPressed: () => Navigator.pop(context),
+                          onNextPressed: () {
+                            Navigator.push(
+                              context,
+                              MaterialPageRoute(builder: (context) => const PageFiveSix()),
+                            );
+                          },
+                        ),
+                        const SizedBox(height: 32.0),
+                        Footer(),
+                      ],
+                    ),
                   ),
-                  const SizedBox(height: 32.0), // Optional spacing below the content
-                  // Footer
-                  Footer(),
-                ],
-              ),
+                ),
+              ],
             ),
           ),
-        ],
+        ),
       ),
     );
   }

--- a/lib/pages/page_five_four.dart
+++ b/lib/pages/page_five_four.dart
@@ -70,15 +70,15 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Bumper Depan',
                           count: 10,
-                          selectedValue: formData.bumperDepanSelectedIndex ?? -1,
+                          selectedValue: formData.bumperDepanSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateBumperDepanSelectedIndex(value);
+                            formNotifier.updateBumperDepanSelectedValue(value);
                           },
                           initialEnabled: formData.bumperDepanIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateBumperDepanIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateBumperDepanSelectedIndex(-1);
+                              formNotifier.updateBumperDepanSelectedValue(-1);
                             }
                           },
                         ),
@@ -86,15 +86,15 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Kap Mesin',
                           count: 10,
-                          selectedValue: formData.kapMesinSelectedIndex ?? -1,
+                          selectedValue: formData.kapMesinSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateKapMesinSelectedIndex(value);
+                            formNotifier.updateKapMesinSelectedValue(value);
                           },
                           initialEnabled: formData.kapMesinIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateKapMesinIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateKapMesinSelectedIndex(-1);
+                              formNotifier.updateKapMesinSelectedValue(-1);
                             }
                           },
                         ),
@@ -102,15 +102,15 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Lampu Utama',
                           count: 10,
-                          selectedValue: formData.lampuUtamaSelectedIndex ?? -1,
+                          selectedValue: formData.lampuUtamaSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateLampuUtamaSelectedIndex(value);
+                            formNotifier.updateLampuUtamaSelectedValue(value);
                           },
                           initialEnabled: formData.lampuUtamaIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateLampuUtamaIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateLampuUtamaSelectedIndex(-1);
+                              formNotifier.updateLampuUtamaSelectedValue(-1);
                             }
                           },
                         ),
@@ -118,15 +118,15 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Panel Atap',
                           count: 10,
-                          selectedValue: formData.panelAtapSelectedIndex ?? -1,
+                          selectedValue: formData.panelAtapSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updatePanelAtapSelectedIndex(value);
+                            formNotifier.updatePanelAtapSelectedValue(value);
                           },
                           initialEnabled: formData.panelAtapIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updatePanelAtapIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updatePanelAtapSelectedIndex(-1);
+                              formNotifier.updatePanelAtapSelectedValue(-1);
                             }
                           },
                         ),
@@ -134,15 +134,15 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Grill',
                           count: 10,
-                          selectedValue: formData.grillSelectedIndex ?? -1,
+                          selectedValue: formData.grillSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateGrillSelectedIndex(value);
+                            formNotifier.updateGrillSelectedValue(value);
                           },
                           initialEnabled: formData.grillIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateGrillIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateGrillSelectedIndex(-1);
+                              formNotifier.updateGrillSelectedValue(-1);
                             }
                           },
                         ),
@@ -150,15 +150,15 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Lampu Foglamp',
                           count: 10,
-                          selectedValue: formData.lampuFoglampSelectedIndex ?? -1,
+                          selectedValue: formData.lampuFoglampSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateLampuFoglampSelectedIndex(value);
+                            formNotifier.updateLampuFoglampSelectedValue(value);
                           },
                           initialEnabled: formData.lampuFoglampIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateLampuFoglampIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateLampuFoglampSelectedIndex(-1);
+                              formNotifier.updateLampuFoglampSelectedValue(-1);
                             }
                           },
                         ),
@@ -166,15 +166,15 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Kaca Bening',
                           count: 10,
-                          selectedValue: formData.kacaBeningSelectedIndex ?? -1,
+                          selectedValue: formData.kacaBeningSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateKacaBeningSelectedIndex(value);
+                            formNotifier.updateKacaBeningSelectedValue(value);
                           },
                           initialEnabled: formData.kacaBeningIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateKacaBeningIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateKacaBeningSelectedIndex(-1);
+                              formNotifier.updateKacaBeningSelectedValue(-1);
                             }
                           },
                         ),
@@ -182,15 +182,15 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Wiper Belakang',
                           count: 10,
-                          selectedValue: formData.wiperBelakangSelectedIndex ?? -1,
+                          selectedValue: formData.wiperBelakangSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateWiperBelakangSelectedIndex(value);
+                            formNotifier.updateWiperBelakangSelectedValue(value);
                           },
                           initialEnabled: formData.wiperBelakangIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateWiperBelakangIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateWiperBelakangSelectedIndex(-1);
+                              formNotifier.updateWiperBelakangSelectedValue(-1);
                             }
                           },
                         ),
@@ -198,15 +198,15 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Bumper Belakang',
                           count: 10,
-                          selectedValue: formData.bumperBelakangSelectedIndex ?? -1,
+                          selectedValue: formData.bumperBelakangSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateBumperBelakangSelectedIndex(value);
+                            formNotifier.updateBumperBelakangSelectedValue(value);
                           },
                           initialEnabled: formData.bumperBelakangIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateBumperBelakangIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateBumperBelakangSelectedIndex(-1);
+                              formNotifier.updateBumperBelakangSelectedValue(-1);
                             }
                           },
                         ),
@@ -214,15 +214,15 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Lampu Belakang',
                           count: 10,
-                          selectedValue: formData.lampuBelakangSelectedIndex ?? -1,
+                          selectedValue: formData.lampuBelakangSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateLampuBelakangSelectedIndex(value);
+                            formNotifier.updateLampuBelakangSelectedValue(value);
                           },
                           initialEnabled: formData.lampuBelakangIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateLampuBelakangIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateLampuBelakangSelectedIndex(-1);
+                              formNotifier.updateLampuBelakangSelectedValue(-1);
                             }
                           },
                         ),
@@ -230,15 +230,15 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Trunklid',
                           count: 10,
-                          selectedValue: formData.trunklidSelectedIndex ?? -1,
+                          selectedValue: formData.trunklidSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateTrunklidSelectedIndex(value);
+                            formNotifier.updateTrunklidSelectedValue(value);
                           },
                           initialEnabled: formData.trunklidIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateTrunklidIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateTrunklidSelectedIndex(-1);
+                              formNotifier.updateTrunklidSelectedValue(-1);
                             }
                           },
                         ),
@@ -246,15 +246,15 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Kaca Depan',
                           count: 10,
-                          selectedValue: formData.kacaDepanSelectedIndex ?? -1,
+                          selectedValue: formData.kacaDepanSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateKacaDepanSelectedIndex(value);
+                            formNotifier.updateKacaDepanSelectedValue(value);
                           },
                           initialEnabled: formData.kacaDepanIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateKacaDepanIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateKacaDepanSelectedIndex(-1);
+                              formNotifier.updateKacaDepanSelectedValue(-1);
                             }
                           },
                         ),
@@ -262,15 +262,15 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Fender Kanan',
                           count: 10,
-                          selectedValue: formData.fenderKananSelectedIndex ?? -1,
+                          selectedValue: formData.fenderKananSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateFenderKananSelectedIndex(value);
+                            formNotifier.updateFenderKananSelectedValue(value);
                           },
                           initialEnabled: formData.fenderKananIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateFenderKananIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateFenderKananSelectedIndex(-1);
+                              formNotifier.updateFenderKananSelectedValue(-1);
                             }
                           },
                         ),
@@ -278,15 +278,15 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Quarter Panel Kanan',
                           count: 10,
-                          selectedValue: formData.quarterPanelKananSelectedIndex ?? -1,
+                          selectedValue: formData.quarterPanelKananSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateQuarterPanelKananSelectedIndex(value);
+                            formNotifier.updateQuarterPanelKananSelectedValue(value);
                           },
                           initialEnabled: formData.quarterPanelKananIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateQuarterPanelKananIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateQuarterPanelKananSelectedIndex(-1);
+                              formNotifier.updateQuarterPanelKananSelectedValue(-1);
                             }
                           },
                         ),
@@ -294,15 +294,15 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Pintu Belakang Kanan',
                           count: 10,
-                          selectedValue: formData.pintuBelakangKananSelectedIndex ?? -1,
+                          selectedValue: formData.pintuBelakangKananSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updatePintuBelakangKananSelectedIndex(value);
+                            formNotifier.updatePintuBelakangKananSelectedValue(value);
                           },
                           initialEnabled: formData.pintuBelakangKananIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updatePintuBelakangKananIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updatePintuBelakangKananSelectedIndex(-1);
+                              formNotifier.updatePintuBelakangKananSelectedValue(-1);
                             }
                           },
                         ),
@@ -310,15 +310,15 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Spion Kanan',
                           count: 10,
-                          selectedValue: formData.spionKananSelectedIndex ?? -1,
+                          selectedValue: formData.spionKananSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateSpionKananSelectedIndex(value);
+                            formNotifier.updateSpionKananSelectedValue(value);
                           },
                           initialEnabled: formData.spionKananIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateSpionKananIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateSpionKananSelectedIndex(-1);
+                              formNotifier.updateSpionKananSelectedValue(-1);
                             }
                           },
                         ),
@@ -326,15 +326,15 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Lisplang Kanan',
                           count: 10,
-                          selectedValue: formData.lisplangKananSelectedIndex ?? -1,
+                          selectedValue: formData.lisplangKananSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateLisplangKananSelectedIndex(value);
+                            formNotifier.updateLisplangKananSelectedValue(value);
                           },
                           initialEnabled: formData.lisplangKananIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateLisplangKananIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateLisplangKananSelectedIndex(-1);
+                              formNotifier.updateLisplangKananSelectedValue(-1);
                             }
                           },
                         ),
@@ -342,15 +342,15 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Side Skirt Kanan',
                           count: 10,
-                          selectedValue: formData.sideSkirtKananSelectedIndex ?? -1,
+                          selectedValue: formData.sideSkirtKananSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateSideSkirtKananSelectedIndex(value);
+                            formNotifier.updateSideSkirtKananSelectedValue(value);
                           },
                           initialEnabled: formData.sideSkirtKananIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateSideSkirtKananIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateSideSkirtKananSelectedIndex(-1);
+                              formNotifier.updateSideSkirtKananSelectedValue(-1);
                             }
                           },
                         ),
@@ -358,15 +358,15 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Daun Wiper',
                           count: 10,
-                          selectedValue: formData.daunWiperSelectedIndex ?? -1,
+                          selectedValue: formData.daunWiperSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateDaunWiperSelectedIndex(value);
+                            formNotifier.updateDaunWiperSelectedValue(value);
                           },
                           initialEnabled: formData.daunWiperIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateDaunWiperIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateDaunWiperSelectedIndex(-1);
+                              formNotifier.updateDaunWiperSelectedValue(-1);
                             }
                           },
                         ),
@@ -374,15 +374,15 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Pintu Belakang',
                           count: 10,
-                          selectedValue: formData.pintuBelakangSelectedIndex ?? -1,
+                          selectedValue: formData.pintuBelakangSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updatePintuBelakangSelectedIndex(value);
+                            formNotifier.updatePintuBelakangSelectedValue(value);
                           },
                           initialEnabled: formData.pintuBelakangIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updatePintuBelakangIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updatePintuBelakangSelectedIndex(-1);
+                              formNotifier.updatePintuBelakangSelectedValue(-1);
                             }
                           },
                         ),
@@ -390,15 +390,15 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Fender Kiri',
                           count: 10,
-                          selectedValue: formData.fenderKiriSelectedIndex ?? -1,
+                          selectedValue: formData.fenderKiriSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateFenderKiriSelectedIndex(value);
+                            formNotifier.updateFenderKiriSelectedValue(value);
                           },
                           initialEnabled: formData.fenderKiriIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateFenderKiriIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateFenderKiriSelectedIndex(-1);
+                              formNotifier.updateFenderKiriSelectedValue(-1);
                             }
                           },
                         ),
@@ -406,15 +406,15 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Quarter Panel Kiri',
                           count: 10,
-                          selectedValue: formData.quarterPanelKiriSelectedIndex ?? -1,
+                          selectedValue: formData.quarterPanelKiriSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateQuarterPanelKiriSelectedIndex(value);
+                            formNotifier.updateQuarterPanelKiriSelectedValue(value);
                           },
                           initialEnabled: formData.quarterPanelKiriIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateQuarterPanelKiriIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateQuarterPanelKiriSelectedIndex(-1);
+                              formNotifier.updateQuarterPanelKiriSelectedValue(-1);
                             }
                           },
                         ),
@@ -422,15 +422,15 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Pintu Depan',
                           count: 10,
-                          selectedValue: formData.pintuDepanSelectedIndex ?? -1,
+                          selectedValue: formData.pintuDepanSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updatePintuDepanSelectedIndex(value);
+                            formNotifier.updatePintuDepanSelectedValue(value);
                           },
                           initialEnabled: formData.pintuDepanIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updatePintuDepanIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updatePintuDepanSelectedIndex(-1);
+                              formNotifier.updatePintuDepanSelectedValue(-1);
                             }
                           },
                         ),
@@ -438,15 +438,15 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Kaca Jendela Kanan',
                           count: 10,
-                          selectedValue: formData.kacaJendelaKananSelectedIndex ?? -1,
+                          selectedValue: formData.kacaJendelaKananSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateKacaJendelaKananSelectedIndex(value);
+                            formNotifier.updateKacaJendelaKananSelectedValue(value);
                           },
                           initialEnabled: formData.kacaJendelaKananIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateKacaJendelaKananIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateKacaJendelaKananSelectedIndex(-1);
+                              formNotifier.updateKacaJendelaKananSelectedValue(-1);
                             }
                           },
                         ),
@@ -454,15 +454,15 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Pintu Belakang Kiri',
                           count: 10,
-                          selectedValue: formData.pintuBelakangKiriSelectedIndex ?? -1,
+                          selectedValue: formData.pintuBelakangKiriSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updatePintuBelakangKiriSelectedIndex(value);
+                            formNotifier.updatePintuBelakangKiriSelectedValue(value);
                           },
                           initialEnabled: formData.pintuBelakangKiriIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updatePintuBelakangKiriIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updatePintuBelakangKiriSelectedIndex(-1);
+                              formNotifier.updatePintuBelakangKiriSelectedValue(-1);
                             }
                           },
                         ),
@@ -470,15 +470,15 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Spion Kiri',
                           count: 10,
-                          selectedValue: formData.spionKiriSelectedIndex ?? -1,
+                          selectedValue: formData.spionKiriSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateSpionKiriSelectedIndex(value);
+                            formNotifier.updateSpionKiriSelectedValue(value);
                           },
                           initialEnabled: formData.spionKiriIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateSpionKiriIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateSpionKiriSelectedIndex(-1);
+                              formNotifier.updateSpionKiriSelectedValue(-1);
                             }
                           },
                         ),
@@ -486,15 +486,15 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Pintu Depan Kiri',
                           count: 10,
-                          selectedValue: formData.pintuDepanKiriSelectedIndex ?? -1,
+                          selectedValue: formData.pintuDepanKiriSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updatePintuDepanKiriSelectedIndex(value);
+                            formNotifier.updatePintuDepanKiriSelectedValue(value);
                           },
                           initialEnabled: formData.pintuDepanKiriIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updatePintuDepanKiriIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updatePintuDepanKiriSelectedIndex(-1);
+                              formNotifier.updatePintuDepanKiriSelectedValue(-1);
                             }
                           },
                         ),
@@ -502,15 +502,15 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Kaca Jendela Kiri',
                           count: 10,
-                          selectedValue: formData.kacaJendelaKiriSelectedIndex ?? -1,
+                          selectedValue: formData.kacaJendelaKiriSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateKacaJendelaKiriSelectedIndex(value);
+                            formNotifier.updateKacaJendelaKiriSelectedValue(value);
                           },
                           initialEnabled: formData.kacaJendelaKiriIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateKacaJendelaKiriIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateKacaJendelaKiriSelectedIndex(-1);
+                              formNotifier.updateKacaJendelaKiriSelectedValue(-1);
                             }
                           },
                         ),
@@ -518,15 +518,15 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Lisplang Kiri',
                           count: 10,
-                          selectedValue: formData.lisplangKiriSelectedIndex ?? -1,
+                          selectedValue: formData.lisplangKiriSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateLisplangKiriSelectedIndex(value);
+                            formNotifier.updateLisplangKiriSelectedValue(value);
                           },
                           initialEnabled: formData.lisplangKiriIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateLisplangKiriIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateLisplangKiriSelectedIndex(-1);
+                              formNotifier.updateLisplangKiriSelectedValue(-1);
                             }
                           },
                         ),
@@ -534,15 +534,15 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Side Skirt Kiri',
                           count: 10,
-                          selectedValue: formData.sideSkirtKiriSelectedIndex ?? -1,
+                          selectedValue: formData.sideSkirtKiriSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateSideSkirtKiriSelectedIndex(value);
+                            formNotifier.updateSideSkirtKiriSelectedValue(value);
                           },
                           initialEnabled: formData.sideSkirtKiriIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateSideSkirtKiriIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateSideSkirtKiriSelectedIndex(-1);
+                              formNotifier.updateSideSkirtKiriSelectedValue(-1);
                             }
                           },
                         ),

--- a/lib/pages/page_five_four.dart
+++ b/lib/pages/page_five_four.dart
@@ -71,8 +71,8 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                           label: 'Bumper Depan',
                           count: 10,
                           selectedValue: formData.bumperDepanSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateBumperDepanSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateBumperDepanSelectedIndex(value);
                           },
                           initialEnabled: formData.bumperDepanIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -87,8 +87,8 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                           label: 'Kap Mesin',
                           count: 10,
                           selectedValue: formData.kapMesinSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateKapMesinSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateKapMesinSelectedIndex(value);
                           },
                           initialEnabled: formData.kapMesinIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -103,8 +103,8 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                           label: 'Lampu Utama',
                           count: 10,
                           selectedValue: formData.lampuUtamaSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateLampuUtamaSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateLampuUtamaSelectedIndex(value);
                           },
                           initialEnabled: formData.lampuUtamaIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -119,8 +119,8 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                           label: 'Panel Atap',
                           count: 10,
                           selectedValue: formData.panelAtapSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updatePanelAtapSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updatePanelAtapSelectedIndex(value);
                           },
                           initialEnabled: formData.panelAtapIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -135,8 +135,8 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                           label: 'Grill',
                           count: 10,
                           selectedValue: formData.grillSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateGrillSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateGrillSelectedIndex(value);
                           },
                           initialEnabled: formData.grillIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -151,8 +151,8 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                           label: 'Lampu Foglamp',
                           count: 10,
                           selectedValue: formData.lampuFoglampSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateLampuFoglampSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateLampuFoglampSelectedIndex(value);
                           },
                           initialEnabled: formData.lampuFoglampIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -167,8 +167,8 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                           label: 'Kaca Bening',
                           count: 10,
                           selectedValue: formData.kacaBeningSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateKacaBeningSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateKacaBeningSelectedIndex(value);
                           },
                           initialEnabled: formData.kacaBeningIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -183,8 +183,8 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                           label: 'Wiper Belakang',
                           count: 10,
                           selectedValue: formData.wiperBelakangSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateWiperBelakangSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateWiperBelakangSelectedIndex(value);
                           },
                           initialEnabled: formData.wiperBelakangIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -199,8 +199,8 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                           label: 'Bumper Belakang',
                           count: 10,
                           selectedValue: formData.bumperBelakangSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateBumperBelakangSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateBumperBelakangSelectedIndex(value);
                           },
                           initialEnabled: formData.bumperBelakangIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -215,8 +215,8 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                           label: 'Lampu Belakang',
                           count: 10,
                           selectedValue: formData.lampuBelakangSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateLampuBelakangSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateLampuBelakangSelectedIndex(value);
                           },
                           initialEnabled: formData.lampuBelakangIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -231,8 +231,8 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                           label: 'Trunklid',
                           count: 10,
                           selectedValue: formData.trunklidSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateTrunklidSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateTrunklidSelectedIndex(value);
                           },
                           initialEnabled: formData.trunklidIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -247,8 +247,8 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                           label: 'Kaca Depan',
                           count: 10,
                           selectedValue: formData.kacaDepanSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateKacaDepanSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateKacaDepanSelectedIndex(value);
                           },
                           initialEnabled: formData.kacaDepanIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -263,8 +263,8 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                           label: 'Fender Kanan',
                           count: 10,
                           selectedValue: formData.fenderKananSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateFenderKananSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateFenderKananSelectedIndex(value);
                           },
                           initialEnabled: formData.fenderKananIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -279,8 +279,8 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                           label: 'Quarter Panel Kanan',
                           count: 10,
                           selectedValue: formData.quarterPanelKananSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateQuarterPanelKananSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateQuarterPanelKananSelectedIndex(value);
                           },
                           initialEnabled: formData.quarterPanelKananIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -295,8 +295,8 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                           label: 'Pintu Belakang Kanan',
                           count: 10,
                           selectedValue: formData.pintuBelakangKananSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updatePintuBelakangKananSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updatePintuBelakangKananSelectedIndex(value);
                           },
                           initialEnabled: formData.pintuBelakangKananIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -311,8 +311,8 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                           label: 'Spion Kanan',
                           count: 10,
                           selectedValue: formData.spionKananSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateSpionKananSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateSpionKananSelectedIndex(value);
                           },
                           initialEnabled: formData.spionKananIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -327,8 +327,8 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                           label: 'Lisplang Kanan',
                           count: 10,
                           selectedValue: formData.lisplangKananSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateLisplangKananSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateLisplangKananSelectedIndex(value);
                           },
                           initialEnabled: formData.lisplangKananIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -343,8 +343,8 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                           label: 'Side Skirt Kanan',
                           count: 10,
                           selectedValue: formData.sideSkirtKananSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateSideSkirtKananSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateSideSkirtKananSelectedIndex(value);
                           },
                           initialEnabled: formData.sideSkirtKananIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -359,8 +359,8 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                           label: 'Daun Wiper',
                           count: 10,
                           selectedValue: formData.daunWiperSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateDaunWiperSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateDaunWiperSelectedIndex(value);
                           },
                           initialEnabled: formData.daunWiperIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -375,8 +375,8 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                           label: 'Pintu Belakang',
                           count: 10,
                           selectedValue: formData.pintuBelakangSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updatePintuBelakangSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updatePintuBelakangSelectedIndex(value);
                           },
                           initialEnabled: formData.pintuBelakangIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -391,8 +391,8 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                           label: 'Fender Kiri',
                           count: 10,
                           selectedValue: formData.fenderKiriSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateFenderKiriSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateFenderKiriSelectedIndex(value);
                           },
                           initialEnabled: formData.fenderKiriIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -407,8 +407,8 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                           label: 'Quarter Panel Kiri',
                           count: 10,
                           selectedValue: formData.quarterPanelKiriSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateQuarterPanelKiriSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateQuarterPanelKiriSelectedIndex(value);
                           },
                           initialEnabled: formData.quarterPanelKiriIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -423,8 +423,8 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                           label: 'Pintu Depan',
                           count: 10,
                           selectedValue: formData.pintuDepanSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updatePintuDepanSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updatePintuDepanSelectedIndex(value);
                           },
                           initialEnabled: formData.pintuDepanIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -439,8 +439,8 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                           label: 'Kaca Jendela Kanan',
                           count: 10,
                           selectedValue: formData.kacaJendelaKananSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateKacaJendelaKananSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateKacaJendelaKananSelectedIndex(value);
                           },
                           initialEnabled: formData.kacaJendelaKananIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -455,8 +455,8 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                           label: 'Pintu Belakang Kiri',
                           count: 10,
                           selectedValue: formData.pintuBelakangKiriSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updatePintuBelakangKiriSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updatePintuBelakangKiriSelectedIndex(value);
                           },
                           initialEnabled: formData.pintuBelakangKiriIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -471,8 +471,8 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                           label: 'Spion Kiri',
                           count: 10,
                           selectedValue: formData.spionKiriSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateSpionKiriSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateSpionKiriSelectedIndex(value);
                           },
                           initialEnabled: formData.spionKiriIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -487,8 +487,8 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                           label: 'Pintu Depan Kiri',
                           count: 10,
                           selectedValue: formData.pintuDepanKiriSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updatePintuDepanKiriSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updatePintuDepanKiriSelectedIndex(value);
                           },
                           initialEnabled: formData.pintuDepanKiriIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -503,8 +503,8 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                           label: 'Kaca Jendela Kiri',
                           count: 10,
                           selectedValue: formData.kacaJendelaKiriSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateKacaJendelaKiriSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateKacaJendelaKiriSelectedIndex(value);
                           },
                           initialEnabled: formData.kacaJendelaKiriIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -519,8 +519,8 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                           label: 'Lisplang Kiri',
                           count: 10,
                           selectedValue: formData.lisplangKiriSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateLisplangKiriSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateLisplangKiriSelectedIndex(value);
                           },
                           initialEnabled: formData.lisplangKiriIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -535,8 +535,8 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                           label: 'Side Skirt Kiri',
                           count: 10,
                           selectedValue: formData.sideSkirtKiriSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateSideSkirtKiriSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateSideSkirtKiriSelectedIndex(value);
                           },
                           initialEnabled: formData.sideSkirtKiriIsEnabled ?? true,
                           onEnabledChanged: (enabled) {

--- a/lib/pages/page_five_four.dart
+++ b/lib/pages/page_five_four.dart
@@ -70,7 +70,7 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Bumper Depan',
                           count: 10,
-                          selectedIndex: formData.bumperDepanSelectedIndex ?? -1,
+                          selectedValue: formData.bumperDepanSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateBumperDepanSelectedIndex(index);
                           },
@@ -86,7 +86,7 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Kap Mesin',
                           count: 10,
-                          selectedIndex: formData.kapMesinSelectedIndex ?? -1,
+                          selectedValue: formData.kapMesinSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateKapMesinSelectedIndex(index);
                           },
@@ -102,7 +102,7 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Lampu Utama',
                           count: 10,
-                          selectedIndex: formData.lampuUtamaSelectedIndex ?? -1,
+                          selectedValue: formData.lampuUtamaSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateLampuUtamaSelectedIndex(index);
                           },
@@ -118,7 +118,7 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Panel Atap',
                           count: 10,
-                          selectedIndex: formData.panelAtapSelectedIndex ?? -1,
+                          selectedValue: formData.panelAtapSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updatePanelAtapSelectedIndex(index);
                           },
@@ -134,7 +134,7 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Grill',
                           count: 10,
-                          selectedIndex: formData.grillSelectedIndex ?? -1,
+                          selectedValue: formData.grillSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateGrillSelectedIndex(index);
                           },
@@ -150,7 +150,7 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Lampu Foglamp',
                           count: 10,
-                          selectedIndex: formData.lampuFoglampSelectedIndex ?? -1,
+                          selectedValue: formData.lampuFoglampSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateLampuFoglampSelectedIndex(index);
                           },
@@ -166,7 +166,7 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Kaca Bening',
                           count: 10,
-                          selectedIndex: formData.kacaBeningSelectedIndex ?? -1,
+                          selectedValue: formData.kacaBeningSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateKacaBeningSelectedIndex(index);
                           },
@@ -182,7 +182,7 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Wiper Belakang',
                           count: 10,
-                          selectedIndex: formData.wiperBelakangSelectedIndex ?? -1,
+                          selectedValue: formData.wiperBelakangSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateWiperBelakangSelectedIndex(index);
                           },
@@ -198,7 +198,7 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Bumper Belakang',
                           count: 10,
-                          selectedIndex: formData.bumperBelakangSelectedIndex ?? -1,
+                          selectedValue: formData.bumperBelakangSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateBumperBelakangSelectedIndex(index);
                           },
@@ -214,7 +214,7 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Lampu Belakang',
                           count: 10,
-                          selectedIndex: formData.lampuBelakangSelectedIndex ?? -1,
+                          selectedValue: formData.lampuBelakangSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateLampuBelakangSelectedIndex(index);
                           },
@@ -230,7 +230,7 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Trunklid',
                           count: 10,
-                          selectedIndex: formData.trunklidSelectedIndex ?? -1,
+                          selectedValue: formData.trunklidSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateTrunklidSelectedIndex(index);
                           },
@@ -246,7 +246,7 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Kaca Depan',
                           count: 10,
-                          selectedIndex: formData.kacaDepanSelectedIndex ?? -1,
+                          selectedValue: formData.kacaDepanSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateKacaDepanSelectedIndex(index);
                           },
@@ -262,7 +262,7 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Fender Kanan',
                           count: 10,
-                          selectedIndex: formData.fenderKananSelectedIndex ?? -1,
+                          selectedValue: formData.fenderKananSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateFenderKananSelectedIndex(index);
                           },
@@ -278,7 +278,7 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Quarter Panel Kanan',
                           count: 10,
-                          selectedIndex: formData.quarterPanelKananSelectedIndex ?? -1,
+                          selectedValue: formData.quarterPanelKananSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateQuarterPanelKananSelectedIndex(index);
                           },
@@ -294,7 +294,7 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Pintu Belakang Kanan',
                           count: 10,
-                          selectedIndex: formData.pintuBelakangKananSelectedIndex ?? -1,
+                          selectedValue: formData.pintuBelakangKananSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updatePintuBelakangKananSelectedIndex(index);
                           },
@@ -310,7 +310,7 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Spion Kanan',
                           count: 10,
-                          selectedIndex: formData.spionKananSelectedIndex ?? -1,
+                          selectedValue: formData.spionKananSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateSpionKananSelectedIndex(index);
                           },
@@ -326,7 +326,7 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Lisplang Kanan',
                           count: 10,
-                          selectedIndex: formData.lisplangKananSelectedIndex ?? -1,
+                          selectedValue: formData.lisplangKananSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateLisplangKananSelectedIndex(index);
                           },
@@ -342,7 +342,7 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Side Skirt Kanan',
                           count: 10,
-                          selectedIndex: formData.sideSkirtKananSelectedIndex ?? -1,
+                          selectedValue: formData.sideSkirtKananSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateSideSkirtKananSelectedIndex(index);
                           },
@@ -358,7 +358,7 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Daun Wiper',
                           count: 10,
-                          selectedIndex: formData.daunWiperSelectedIndex ?? -1,
+                          selectedValue: formData.daunWiperSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateDaunWiperSelectedIndex(index);
                           },
@@ -374,7 +374,7 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Pintu Belakang',
                           count: 10,
-                          selectedIndex: formData.pintuBelakangSelectedIndex ?? -1,
+                          selectedValue: formData.pintuBelakangSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updatePintuBelakangSelectedIndex(index);
                           },
@@ -390,7 +390,7 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Fender Kiri',
                           count: 10,
-                          selectedIndex: formData.fenderKiriSelectedIndex ?? -1,
+                          selectedValue: formData.fenderKiriSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateFenderKiriSelectedIndex(index);
                           },
@@ -406,7 +406,7 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Quarter Panel Kiri',
                           count: 10,
-                          selectedIndex: formData.quarterPanelKiriSelectedIndex ?? -1,
+                          selectedValue: formData.quarterPanelKiriSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateQuarterPanelKiriSelectedIndex(index);
                           },
@@ -422,7 +422,7 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Pintu Depan',
                           count: 10,
-                          selectedIndex: formData.pintuDepanSelectedIndex ?? -1,
+                          selectedValue: formData.pintuDepanSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updatePintuDepanSelectedIndex(index);
                           },
@@ -438,7 +438,7 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Kaca Jendela Kanan',
                           count: 10,
-                          selectedIndex: formData.kacaJendelaKananSelectedIndex ?? -1,
+                          selectedValue: formData.kacaJendelaKananSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateKacaJendelaKananSelectedIndex(index);
                           },
@@ -454,7 +454,7 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Pintu Belakang Kiri',
                           count: 10,
-                          selectedIndex: formData.pintuBelakangKiriSelectedIndex ?? -1,
+                          selectedValue: formData.pintuBelakangKiriSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updatePintuBelakangKiriSelectedIndex(index);
                           },
@@ -470,7 +470,7 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Spion Kiri',
                           count: 10,
-                          selectedIndex: formData.spionKiriSelectedIndex ?? -1,
+                          selectedValue: formData.spionKiriSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateSpionKiriSelectedIndex(index);
                           },
@@ -486,7 +486,7 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Pintu Depan Kiri',
                           count: 10,
-                          selectedIndex: formData.pintuDepanKiriSelectedIndex ?? -1,
+                          selectedValue: formData.pintuDepanKiriSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updatePintuDepanKiriSelectedIndex(index);
                           },
@@ -502,7 +502,7 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Kaca Jendela Kiri',
                           count: 10,
-                          selectedIndex: formData.kacaJendelaKiriSelectedIndex ?? -1,
+                          selectedValue: formData.kacaJendelaKiriSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateKacaJendelaKiriSelectedIndex(index);
                           },
@@ -518,7 +518,7 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Lisplang Kiri',
                           count: 10,
-                          selectedIndex: formData.lisplangKiriSelectedIndex ?? -1,
+                          selectedValue: formData.lisplangKiriSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateLisplangKiriSelectedIndex(index);
                           },
@@ -534,7 +534,7 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                         ToggleableNumberedButtonList(
                           label: 'Side Skirt Kiri',
                           count: 10,
-                          selectedIndex: formData.sideSkirtKiriSelectedIndex ?? -1,
+                          selectedValue: formData.sideSkirtKiriSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateSideSkirtKiriSelectedIndex(index);
                           },

--- a/lib/pages/page_five_one.dart
+++ b/lib/pages/page_five_one.dart
@@ -71,8 +71,8 @@ class _PageFiveOneState extends ConsumerState<PageFiveOne> {
                           label: 'Airbag',
                           count: 10,
                           selectedValue: formData.airbagSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateAirbagSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateAirbagSelectedIndex(value);
                           },
                           initialEnabled: formData.airbagIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -87,8 +87,8 @@ class _PageFiveOneState extends ConsumerState<PageFiveOne> {
                           label: 'Sistem Audio',
                           count: 10,
                           selectedValue: formData.sistemAudioSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateSistemAudioSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateSistemAudioSelectedIndex(value);
                           },
                           initialEnabled: formData.sistemAudioIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -103,8 +103,8 @@ class _PageFiveOneState extends ConsumerState<PageFiveOne> {
                           label: 'Power Window',
                           count: 10,
                           selectedValue: formData.powerWindowSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updatePowerWindowSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updatePowerWindowSelectedIndex(value);
                           },
                           initialEnabled: formData.powerWindowIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -119,8 +119,8 @@ class _PageFiveOneState extends ConsumerState<PageFiveOne> {
                           label: 'Sistem AC',
                           count: 10,
                           selectedValue: formData.sistemAcSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateSistemAcSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateSistemAcSelectedIndex(value);
                           },
                           initialEnabled: formData.sistemAcIsEnabled ?? true,
                           onEnabledChanged: (enabled) {

--- a/lib/pages/page_five_one.dart
+++ b/lib/pages/page_five_one.dart
@@ -70,7 +70,7 @@ class _PageFiveOneState extends ConsumerState<PageFiveOne> {
                         ToggleableNumberedButtonList(
                           label: 'Airbag',
                           count: 10,
-                          selectedIndex: formData.airbagSelectedIndex ?? -1,
+                          selectedValue: formData.airbagSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateAirbagSelectedIndex(index);
                           },
@@ -86,7 +86,7 @@ class _PageFiveOneState extends ConsumerState<PageFiveOne> {
                         ToggleableNumberedButtonList(
                           label: 'Sistem Audio',
                           count: 10,
-                          selectedIndex: formData.sistemAudioSelectedIndex ?? -1,
+                          selectedValue: formData.sistemAudioSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateSistemAudioSelectedIndex(index);
                           },
@@ -102,7 +102,7 @@ class _PageFiveOneState extends ConsumerState<PageFiveOne> {
                         ToggleableNumberedButtonList(
                           label: 'Power Window',
                           count: 10,
-                          selectedIndex: formData.powerWindowSelectedIndex ?? -1,
+                          selectedValue: formData.powerWindowSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updatePowerWindowSelectedIndex(index);
                           },
@@ -118,7 +118,7 @@ class _PageFiveOneState extends ConsumerState<PageFiveOne> {
                         ToggleableNumberedButtonList(
                           label: 'Sistem AC',
                           count: 10,
-                          selectedIndex: formData.sistemAcSelectedIndex ?? -1,
+                          selectedValue: formData.sistemAcSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateSistemAcSelectedIndex(index);
                           },

--- a/lib/pages/page_five_one.dart
+++ b/lib/pages/page_five_one.dart
@@ -70,15 +70,15 @@ class _PageFiveOneState extends ConsumerState<PageFiveOne> {
                         ToggleableNumberedButtonList(
                           label: 'Airbag',
                           count: 10,
-                          selectedValue: formData.airbagSelectedIndex ?? -1,
+                          selectedValue: formData.airbagSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateAirbagSelectedIndex(value);
+                            formNotifier.updateAirbagSelectedValue(value);
                           },
                           initialEnabled: formData.airbagIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateAirbagIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateAirbagSelectedIndex(-1);
+                              formNotifier.updateAirbagSelectedValue(-1);
                             }
                           },
                         ),
@@ -86,15 +86,15 @@ class _PageFiveOneState extends ConsumerState<PageFiveOne> {
                         ToggleableNumberedButtonList(
                           label: 'Sistem Audio',
                           count: 10,
-                          selectedValue: formData.sistemAudioSelectedIndex ?? -1,
+                          selectedValue: formData.sistemAudioSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateSistemAudioSelectedIndex(value);
+                            formNotifier.updateSistemAudioSelectedValue(value);
                           },
                           initialEnabled: formData.sistemAudioIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateSistemAudioIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateSistemAudioSelectedIndex(-1);
+                              formNotifier.updateSistemAudioSelectedValue(-1);
                             }
                           },
                         ),
@@ -102,15 +102,15 @@ class _PageFiveOneState extends ConsumerState<PageFiveOne> {
                         ToggleableNumberedButtonList(
                           label: 'Power Window',
                           count: 10,
-                          selectedValue: formData.powerWindowSelectedIndex ?? -1,
+                          selectedValue: formData.powerWindowSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updatePowerWindowSelectedIndex(value);
+                            formNotifier.updatePowerWindowSelectedValue(value);
                           },
                           initialEnabled: formData.powerWindowIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updatePowerWindowIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updatePowerWindowSelectedIndex(-1);
+                              formNotifier.updatePowerWindowSelectedValue(-1);
                             }
                           },
                         ),
@@ -118,15 +118,15 @@ class _PageFiveOneState extends ConsumerState<PageFiveOne> {
                         ToggleableNumberedButtonList(
                           label: 'Sistem AC',
                           count: 10,
-                          selectedValue: formData.sistemAcSelectedIndex ?? -1,
+                          selectedValue: formData.sistemAcSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateSistemAcSelectedIndex(value);
+                            formNotifier.updateSistemAcSelectedValue(value);
                           },
                           initialEnabled: formData.sistemAcIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateSistemAcIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateSistemAcSelectedIndex(-1);
+                              formNotifier.updateSistemAcSelectedValue(-1);
                             }
                           },
                         ),

--- a/lib/pages/page_five_three.dart
+++ b/lib/pages/page_five_three.dart
@@ -70,15 +70,15 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                         ToggleableNumberedButtonList(
                           label: 'Stir',
                           count: 10,
-                          selectedValue: formData.stirSelectedIndex ?? -1,
+                          selectedValue: formData.stirSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateStirSelectedIndex(value);
+                            formNotifier.updateStirSelectedValue(value);
                           },
                           initialEnabled: formData.stirIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateStirIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateStirSelectedIndex(-1);
+                              formNotifier.updateStirSelectedValue(-1);
                             }
                           },
                         ),
@@ -86,15 +86,15 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                         ToggleableNumberedButtonList(
                           label: 'Rem Tangan',
                           count: 10,
-                          selectedValue: formData.remTonganSelectedIndex ?? -1,
+                          selectedValue: formData.remTonganSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateRemTonganSelectedIndex(value);
+                            formNotifier.updateRemTonganSelectedValue(value);
                           },
                           initialEnabled: formData.remTonganIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateRemTonganIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateRemTonganSelectedIndex(-1);
+                              formNotifier.updateRemTonganSelectedValue(-1);
                             }
                           },
                         ),
@@ -102,15 +102,15 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                         ToggleableNumberedButtonList(
                           label: 'Pedal',
                           count: 10,
-                          selectedValue: formData.pedalSelectedIndex ?? -1,
+                          selectedValue: formData.pedalSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updatePedalSelectedIndex(value);
+                            formNotifier.updatePedalSelectedValue(value);
                           },
                           initialEnabled: formData.pedalIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updatePedalIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updatePedalSelectedIndex(-1);
+                              formNotifier.updatePedalSelectedValue(-1);
                             }
                           },
                         ),
@@ -118,15 +118,15 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                         ToggleableNumberedButtonList(
                           label: 'Switch Wiper',
                           count: 10,
-                          selectedValue: formData.switchWiperSelectedIndex ?? -1,
+                          selectedValue: formData.switchWiperSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateSwitchWiperSelectedIndex(value);
+                            formNotifier.updateSwitchWiperSelectedValue(value);
                           },
                           initialEnabled: formData.switchWiperIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateSwitchWiperIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateSwitchWiperSelectedIndex(-1);
+                              formNotifier.updateSwitchWiperSelectedValue(-1);
                             }
                           },
                         ),
@@ -134,15 +134,15 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                         ToggleableNumberedButtonList(
                           label: 'Lampu Hazard',
                           count: 10,
-                          selectedValue: formData.lampuHazardSelectedIndex ?? -1,
+                          selectedValue: formData.lampuHazardSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateLampuHazardSelectedIndex(value);
+                            formNotifier.updateLampuHazardSelectedValue(value);
                           },
                           initialEnabled: formData.lampuHazardIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateLampuHazardIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateLampuHazardSelectedIndex(-1);
+                              formNotifier.updateLampuHazardSelectedValue(-1);
                             }
                           },
                         ),
@@ -150,15 +150,15 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                         ToggleableNumberedButtonList(
                           label: 'Panel Dashboard',
                           count: 10,
-                          selectedValue: formData.panelDashboardSelectedIndex ?? -1,
+                          selectedValue: formData.panelDashboardSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updatePanelDashboardSelectedIndex(value);
+                            formNotifier.updatePanelDashboardSelectedValue(value);
                           },
                           initialEnabled: formData.panelDashboardIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updatePanelDashboardIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updatePanelDashboardSelectedIndex(-1);
+                              formNotifier.updatePanelDashboardSelectedValue(-1);
                             }
                           },
                         ),
@@ -166,15 +166,15 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                         ToggleableNumberedButtonList(
                           label: 'Pembuka Kap Mesin',
                           count: 10,
-                          selectedValue: formData.pembukaKapMesinSelectedIndex ?? -1,
+                          selectedValue: formData.pembukaKapMesinSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updatePembukaKapMesinSelectedIndex(value);
+                            formNotifier.updatePembukaKapMesinSelectedValue(value);
                           },
                           initialEnabled: formData.pembukaKapMesinIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updatePembukaKapMesinIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updatePembukaKapMesinSelectedIndex(-1);
+                              formNotifier.updatePembukaKapMesinSelectedValue(-1);
                             }
                           },
                         ),
@@ -182,15 +182,15 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                         ToggleableNumberedButtonList(
                           label: 'Pembuka Bagasi',
                           count: 10,
-                          selectedValue: formData.pembukaBagasiSelectedIndex ?? -1,
+                          selectedValue: formData.pembukaBagasiSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updatePembukaBagasiSelectedIndex(value);
+                            formNotifier.updatePembukaBagasiSelectedValue(value);
                           },
                           initialEnabled: formData.pembukaBagasiIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updatePembukaBagasiIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updatePembukaBagasiSelectedIndex(-1);
+                              formNotifier.updatePembukaBagasiSelectedValue(-1);
                             }
                           },
                         ),
@@ -198,15 +198,15 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                         ToggleableNumberedButtonList(
                           label: 'Jok Depan',
                           count: 10,
-                          selectedValue: formData.jokDepanSelectedIndex ?? -1,
+                          selectedValue: formData.jokDepanSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateJokDepanSelectedIndex(value);
+                            formNotifier.updateJokDepanSelectedValue(value);
                           },
                           initialEnabled: formData.jokDepanIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateJokDepanIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateJokDepanSelectedIndex(-1);
+                              formNotifier.updateJokDepanSelectedValue(-1);
                             }
                           },
                         ),
@@ -214,15 +214,15 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                         ToggleableNumberedButtonList(
                           label: 'Aroma Interior',
                           count: 10,
-                          selectedValue: formData.aromaInteriorSelectedIndex ?? -1,
+                          selectedValue: formData.aromaInteriorSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateAromaInteriorSelectedIndex(value);
+                            formNotifier.updateAromaInteriorSelectedValue(value);
                           },
                           initialEnabled: formData.aromaInteriorIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateAromaInteriorIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateAromaInteriorSelectedIndex(-1);
+                              formNotifier.updateAromaInteriorSelectedValue(-1);
                             }
                           },
                         ),
@@ -230,15 +230,15 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                         ToggleableNumberedButtonList(
                           label: 'Handle Pintu',
                           count: 10,
-                          selectedValue: formData.handlePintuSelectedIndex ?? -1,
+                          selectedValue: formData.handlePintuSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateHandlePintuSelectedIndex(value);
+                            formNotifier.updateHandlePintuSelectedValue(value);
                           },
                           initialEnabled: formData.handlePintuIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateHandlePintuIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateHandlePintuSelectedIndex(-1);
+                              formNotifier.updateHandlePintuSelectedValue(-1);
                             }
                           },
                         ),
@@ -246,15 +246,15 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                         ToggleableNumberedButtonList(
                           label: 'Console Box',
                           count: 10,
-                          selectedValue: formData.consoleBoxSelectedIndex ?? -1,
+                          selectedValue: formData.consoleBoxSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateConsoleBoxSelectedIndex(value);
+                            formNotifier.updateConsoleBoxSelectedValue(value);
                           },
                           initialEnabled: formData.consoleBoxIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateConsoleBoxIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateConsoleBoxSelectedIndex(-1);
+                              formNotifier.updateConsoleBoxSelectedValue(-1);
                             }
                           },
                         ),
@@ -262,15 +262,15 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                         ToggleableNumberedButtonList(
                           label: 'Spion Tengah',
                           count: 10,
-                          selectedValue: formData.spionTengahSelectedIndex ?? -1,
+                          selectedValue: formData.spionTengahSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateSpionTengahSelectedIndex(value);
+                            formNotifier.updateSpionTengahSelectedValue(value);
                           },
                           initialEnabled: formData.spionTengahIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateSpionTengahIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateSpionTengahSelectedIndex(-1);
+                              formNotifier.updateSpionTengahSelectedValue(-1);
                             }
                           },
                         ),
@@ -278,15 +278,15 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                         ToggleableNumberedButtonList(
                           label: 'Tuas Persneling',
                           count: 10,
-                          selectedValue: formData.tuasPersnelingSelectedIndex ?? -1,
+                          selectedValue: formData.tuasPersnelingSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateTuasPersnelingSelectedIndex(value);
+                            formNotifier.updateTuasPersnelingSelectedValue(value);
                           },
                           initialEnabled: formData.tuasPersnelingIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateTuasPersnelingIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateTuasPersnelingSelectedIndex(-1);
+                              formNotifier.updateTuasPersnelingSelectedValue(-1);
                             }
                           },
                         ),
@@ -294,15 +294,15 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                         ToggleableNumberedButtonList(
                           label: 'Jok Belakang',
                           count: 10,
-                          selectedValue: formData.jokBelakangSelectedIndex ?? -1,
+                          selectedValue: formData.jokBelakangSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateJokBelakangSelectedIndex(value);
+                            formNotifier.updateJokBelakangSelectedValue(value);
                           },
                           initialEnabled: formData.jokBelakangIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateJokBelakangIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateJokBelakangSelectedIndex(-1);
+                              formNotifier.updateJokBelakangSelectedValue(-1);
                             }
                           },
                         ),
@@ -310,15 +310,15 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                         ToggleableNumberedButtonList(
                           label: 'Panel Indikator',
                           count: 10,
-                          selectedValue: formData.panelIndikatorSelectedIndex ?? -1,
+                          selectedValue: formData.panelIndikatorSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updatePanelIndikatorSelectedIndex(value);
+                            formNotifier.updatePanelIndikatorSelectedValue(value);
                           },
                           initialEnabled: formData.panelIndikatorIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updatePanelIndikatorIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updatePanelIndikatorSelectedIndex(-1);
+                              formNotifier.updatePanelIndikatorSelectedValue(-1);
                             }
                           },
                         ),
@@ -326,15 +326,15 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                         ToggleableNumberedButtonList(
                           label: 'Switch Lampu',
                           count: 10,
-                          selectedValue: formData.switchLampuSelectedIndex ?? -1,
+                          selectedValue: formData.switchLampuSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateSwitchLampuSelectedIndex(value);
+                            formNotifier.updateSwitchLampuSelectedValue(value);
                           },
                           initialEnabled: formData.switchLampuIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateSwitchLampuIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateSwitchLampuSelectedIndex(-1);
+                              formNotifier.updateSwitchLampuSelectedValue(-1);
                             }
                           },
                         ),
@@ -342,15 +342,15 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                         ToggleableNumberedButtonList(
                           label: 'Karpet Dasar',
                           count: 10,
-                          selectedValue: formData.karpetDasarSelectedIndex ?? -1,
+                          selectedValue: formData.karpetDasarSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateKarpetDasarSelectedIndex(value);
+                            formNotifier.updateKarpetDasarSelectedValue(value);
                           },
                           initialEnabled: formData.karpetDasarIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateKarpetDasarIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateKarpetDasarSelectedIndex(-1);
+                              formNotifier.updateKarpetDasarSelectedValue(-1);
                             }
                           },
                         ),
@@ -358,15 +358,15 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                         ToggleableNumberedButtonList(
                           label: 'Klakson',
                           count: 10,
-                          selectedValue: formData.klaksonSelectedIndex ?? -1,
+                          selectedValue: formData.klaksonSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateKlaksonSelectedIndex(value);
+                            formNotifier.updateKlaksonSelectedValue(value);
                           },
                           initialEnabled: formData.klaksonIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateKlaksonIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateKlaksonSelectedIndex(-1);
+                              formNotifier.updateKlaksonSelectedValue(-1);
                             }
                           },
                         ),
@@ -374,15 +374,15 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                         ToggleableNumberedButtonList(
                           label: 'Sun Visor',
                           count: 10,
-                          selectedValue: formData.sunVisorSelectedIndex ?? -1,
+                          selectedValue: formData.sunVisorSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateSunVisorSelectedIndex(value);
+                            formNotifier.updateSunVisorSelectedValue(value);
                           },
                           initialEnabled: formData.sunVisorIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateSunVisorIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateSunVisorSelectedIndex(-1);
+                              formNotifier.updateSunVisorSelectedValue(-1);
                             }
                           },
                         ),
@@ -390,15 +390,15 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                         ToggleableNumberedButtonList(
                           label: 'Tuas Tangki Bensin',
                           count: 10,
-                          selectedValue: formData.tuasTangkiBensinSelectedIndex ?? -1,
+                          selectedValue: formData.tuasTangkiBensinSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateTuasTangkiBensinSelectedIndex(value);
+                            formNotifier.updateTuasTangkiBensinSelectedValue(value);
                           },
                           initialEnabled: formData.tuasTangkiBensinIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateTuasTangkiBensinIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateTuasTangkiBensinSelectedIndex(-1);
+                              formNotifier.updateTuasTangkiBensinSelectedValue(-1);
                             }
                           },
                         ),
@@ -406,15 +406,15 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                         ToggleableNumberedButtonList(
                           label: 'Sabuk Pengaman',
                           count: 10,
-                          selectedValue: formData.sabukPengamanSelectedIndex ?? -1,
+                          selectedValue: formData.sabukPengamanSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateSabukPengamanSelectedIndex(value);
+                            formNotifier.updateSabukPengamanSelectedValue(value);
                           },
                           initialEnabled: formData.sabukPengamanIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateSabukPengamanIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateSabukPengamanSelectedIndex(-1);
+                              formNotifier.updateSabukPengamanSelectedValue(-1);
                             }
                           },
                         ),
@@ -422,15 +422,15 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                         ToggleableNumberedButtonList(
                           label: 'Trim Interior',
                           count: 10,
-                          selectedValue: formData.trimInteriorSelectedIndex ?? -1,
+                          selectedValue: formData.trimInteriorSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateTrimInteriorSelectedIndex(value);
+                            formNotifier.updateTrimInteriorSelectedValue(value);
                           },
                           initialEnabled: formData.trimInteriorIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateTrimInteriorIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateTrimInteriorSelectedIndex(-1);
+                              formNotifier.updateTrimInteriorSelectedValue(-1);
                             }
                           },
                         ),
@@ -438,15 +438,15 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                         ToggleableNumberedButtonList(
                           label: 'Plafon',
                           count: 10,
-                          selectedValue: formData.plafonSelectedIndex ?? -1,
+                          selectedValue: formData.plafonSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updatePlafonSelectedIndex(value);
+                            formNotifier.updatePlafonSelectedValue(value);
                           },
                           initialEnabled: formData.plafonIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updatePlafonIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updatePlafonSelectedIndex(-1);
+                              formNotifier.updatePlafonSelectedValue(-1);
                             }
                           },
                         ),

--- a/lib/pages/page_five_three.dart
+++ b/lib/pages/page_five_three.dart
@@ -70,7 +70,7 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                         ToggleableNumberedButtonList(
                           label: 'Stir',
                           count: 10,
-                          selectedIndex: formData.stirSelectedIndex ?? -1,
+                          selectedValue: formData.stirSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateStirSelectedIndex(index);
                           },
@@ -86,7 +86,7 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                         ToggleableNumberedButtonList(
                           label: 'Rem Tangan',
                           count: 10,
-                          selectedIndex: formData.remTonganSelectedIndex ?? -1,
+                          selectedValue: formData.remTonganSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateRemTonganSelectedIndex(index);
                           },
@@ -102,7 +102,7 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                         ToggleableNumberedButtonList(
                           label: 'Pedal',
                           count: 10,
-                          selectedIndex: formData.pedalSelectedIndex ?? -1,
+                          selectedValue: formData.pedalSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updatePedalSelectedIndex(index);
                           },
@@ -118,7 +118,7 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                         ToggleableNumberedButtonList(
                           label: 'Switch Wiper',
                           count: 10,
-                          selectedIndex: formData.switchWiperSelectedIndex ?? -1,
+                          selectedValue: formData.switchWiperSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateSwitchWiperSelectedIndex(index);
                           },
@@ -134,7 +134,7 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                         ToggleableNumberedButtonList(
                           label: 'Lampu Hazard',
                           count: 10,
-                          selectedIndex: formData.lampuHazardSelectedIndex ?? -1,
+                          selectedValue: formData.lampuHazardSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateLampuHazardSelectedIndex(index);
                           },
@@ -150,7 +150,7 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                         ToggleableNumberedButtonList(
                           label: 'Panel Dashboard',
                           count: 10,
-                          selectedIndex: formData.panelDashboardSelectedIndex ?? -1,
+                          selectedValue: formData.panelDashboardSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updatePanelDashboardSelectedIndex(index);
                           },
@@ -166,7 +166,7 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                         ToggleableNumberedButtonList(
                           label: 'Pembuka Kap Mesin',
                           count: 10,
-                          selectedIndex: formData.pembukaKapMesinSelectedIndex ?? -1,
+                          selectedValue: formData.pembukaKapMesinSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updatePembukaKapMesinSelectedIndex(index);
                           },
@@ -182,7 +182,7 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                         ToggleableNumberedButtonList(
                           label: 'Pembuka Bagasi',
                           count: 10,
-                          selectedIndex: formData.pembukaBagasiSelectedIndex ?? -1,
+                          selectedValue: formData.pembukaBagasiSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updatePembukaBagasiSelectedIndex(index);
                           },
@@ -198,7 +198,7 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                         ToggleableNumberedButtonList(
                           label: 'Jok Depan',
                           count: 10,
-                          selectedIndex: formData.jokDepanSelectedIndex ?? -1,
+                          selectedValue: formData.jokDepanSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateJokDepanSelectedIndex(index);
                           },
@@ -214,7 +214,7 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                         ToggleableNumberedButtonList(
                           label: 'Aroma Interior',
                           count: 10,
-                          selectedIndex: formData.aromaInteriorSelectedIndex ?? -1,
+                          selectedValue: formData.aromaInteriorSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateAromaInteriorSelectedIndex(index);
                           },
@@ -230,7 +230,7 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                         ToggleableNumberedButtonList(
                           label: 'Handle Pintu',
                           count: 10,
-                          selectedIndex: formData.handlePintuSelectedIndex ?? -1,
+                          selectedValue: formData.handlePintuSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateHandlePintuSelectedIndex(index);
                           },
@@ -246,7 +246,7 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                         ToggleableNumberedButtonList(
                           label: 'Console Box',
                           count: 10,
-                          selectedIndex: formData.consoleBoxSelectedIndex ?? -1,
+                          selectedValue: formData.consoleBoxSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateConsoleBoxSelectedIndex(index);
                           },
@@ -262,7 +262,7 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                         ToggleableNumberedButtonList(
                           label: 'Spion Tengah',
                           count: 10,
-                          selectedIndex: formData.spionTengahSelectedIndex ?? -1,
+                          selectedValue: formData.spionTengahSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateSpionTengahSelectedIndex(index);
                           },
@@ -278,7 +278,7 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                         ToggleableNumberedButtonList(
                           label: 'Tuas Persneling',
                           count: 10,
-                          selectedIndex: formData.tuasPersnelingSelectedIndex ?? -1,
+                          selectedValue: formData.tuasPersnelingSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateTuasPersnelingSelectedIndex(index);
                           },
@@ -294,7 +294,7 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                         ToggleableNumberedButtonList(
                           label: 'Jok Belakang',
                           count: 10,
-                          selectedIndex: formData.jokBelakangSelectedIndex ?? -1,
+                          selectedValue: formData.jokBelakangSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateJokBelakangSelectedIndex(index);
                           },
@@ -310,7 +310,7 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                         ToggleableNumberedButtonList(
                           label: 'Panel Indikator',
                           count: 10,
-                          selectedIndex: formData.panelIndikatorSelectedIndex ?? -1,
+                          selectedValue: formData.panelIndikatorSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updatePanelIndikatorSelectedIndex(index);
                           },
@@ -326,7 +326,7 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                         ToggleableNumberedButtonList(
                           label: 'Switch Lampu',
                           count: 10,
-                          selectedIndex: formData.switchLampuSelectedIndex ?? -1,
+                          selectedValue: formData.switchLampuSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateSwitchLampuSelectedIndex(index);
                           },
@@ -342,7 +342,7 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                         ToggleableNumberedButtonList(
                           label: 'Karpet Dasar',
                           count: 10,
-                          selectedIndex: formData.karpetDasarSelectedIndex ?? -1,
+                          selectedValue: formData.karpetDasarSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateKarpetDasarSelectedIndex(index);
                           },
@@ -358,7 +358,7 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                         ToggleableNumberedButtonList(
                           label: 'Klakson',
                           count: 10,
-                          selectedIndex: formData.klaksonSelectedIndex ?? -1,
+                          selectedValue: formData.klaksonSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateKlaksonSelectedIndex(index);
                           },
@@ -374,7 +374,7 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                         ToggleableNumberedButtonList(
                           label: 'Sun Visor',
                           count: 10,
-                          selectedIndex: formData.sunVisorSelectedIndex ?? -1,
+                          selectedValue: formData.sunVisorSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateSunVisorSelectedIndex(index);
                           },
@@ -390,7 +390,7 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                         ToggleableNumberedButtonList(
                           label: 'Tuas Tangki Bensin',
                           count: 10,
-                          selectedIndex: formData.tuasTangkiBensinSelectedIndex ?? -1,
+                          selectedValue: formData.tuasTangkiBensinSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateTuasTangkiBensinSelectedIndex(index);
                           },
@@ -406,7 +406,7 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                         ToggleableNumberedButtonList(
                           label: 'Sabuk Pengaman',
                           count: 10,
-                          selectedIndex: formData.sabukPengamanSelectedIndex ?? -1,
+                          selectedValue: formData.sabukPengamanSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateSabukPengamanSelectedIndex(index);
                           },
@@ -422,7 +422,7 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                         ToggleableNumberedButtonList(
                           label: 'Trim Interior',
                           count: 10,
-                          selectedIndex: formData.trimInteriorSelectedIndex ?? -1,
+                          selectedValue: formData.trimInteriorSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateTrimInteriorSelectedIndex(index);
                           },
@@ -438,7 +438,7 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                         ToggleableNumberedButtonList(
                           label: 'Plafon',
                           count: 10,
-                          selectedIndex: formData.plafonSelectedIndex ?? -1,
+                          selectedValue: formData.plafonSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updatePlafonSelectedIndex(index);
                           },

--- a/lib/pages/page_five_three.dart
+++ b/lib/pages/page_five_three.dart
@@ -71,8 +71,8 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                           label: 'Stir',
                           count: 10,
                           selectedValue: formData.stirSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateStirSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateStirSelectedIndex(value);
                           },
                           initialEnabled: formData.stirIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -87,8 +87,8 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                           label: 'Rem Tangan',
                           count: 10,
                           selectedValue: formData.remTonganSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateRemTonganSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateRemTonganSelectedIndex(value);
                           },
                           initialEnabled: formData.remTonganIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -103,8 +103,8 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                           label: 'Pedal',
                           count: 10,
                           selectedValue: formData.pedalSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updatePedalSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updatePedalSelectedIndex(value);
                           },
                           initialEnabled: formData.pedalIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -119,8 +119,8 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                           label: 'Switch Wiper',
                           count: 10,
                           selectedValue: formData.switchWiperSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateSwitchWiperSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateSwitchWiperSelectedIndex(value);
                           },
                           initialEnabled: formData.switchWiperIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -135,8 +135,8 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                           label: 'Lampu Hazard',
                           count: 10,
                           selectedValue: formData.lampuHazardSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateLampuHazardSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateLampuHazardSelectedIndex(value);
                           },
                           initialEnabled: formData.lampuHazardIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -151,8 +151,8 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                           label: 'Panel Dashboard',
                           count: 10,
                           selectedValue: formData.panelDashboardSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updatePanelDashboardSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updatePanelDashboardSelectedIndex(value);
                           },
                           initialEnabled: formData.panelDashboardIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -167,8 +167,8 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                           label: 'Pembuka Kap Mesin',
                           count: 10,
                           selectedValue: formData.pembukaKapMesinSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updatePembukaKapMesinSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updatePembukaKapMesinSelectedIndex(value);
                           },
                           initialEnabled: formData.pembukaKapMesinIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -183,8 +183,8 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                           label: 'Pembuka Bagasi',
                           count: 10,
                           selectedValue: formData.pembukaBagasiSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updatePembukaBagasiSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updatePembukaBagasiSelectedIndex(value);
                           },
                           initialEnabled: formData.pembukaBagasiIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -199,8 +199,8 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                           label: 'Jok Depan',
                           count: 10,
                           selectedValue: formData.jokDepanSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateJokDepanSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateJokDepanSelectedIndex(value);
                           },
                           initialEnabled: formData.jokDepanIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -215,8 +215,8 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                           label: 'Aroma Interior',
                           count: 10,
                           selectedValue: formData.aromaInteriorSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateAromaInteriorSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateAromaInteriorSelectedIndex(value);
                           },
                           initialEnabled: formData.aromaInteriorIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -231,8 +231,8 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                           label: 'Handle Pintu',
                           count: 10,
                           selectedValue: formData.handlePintuSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateHandlePintuSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateHandlePintuSelectedIndex(value);
                           },
                           initialEnabled: formData.handlePintuIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -247,8 +247,8 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                           label: 'Console Box',
                           count: 10,
                           selectedValue: formData.consoleBoxSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateConsoleBoxSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateConsoleBoxSelectedIndex(value);
                           },
                           initialEnabled: formData.consoleBoxIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -263,8 +263,8 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                           label: 'Spion Tengah',
                           count: 10,
                           selectedValue: formData.spionTengahSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateSpionTengahSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateSpionTengahSelectedIndex(value);
                           },
                           initialEnabled: formData.spionTengahIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -279,8 +279,8 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                           label: 'Tuas Persneling',
                           count: 10,
                           selectedValue: formData.tuasPersnelingSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateTuasPersnelingSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateTuasPersnelingSelectedIndex(value);
                           },
                           initialEnabled: formData.tuasPersnelingIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -295,8 +295,8 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                           label: 'Jok Belakang',
                           count: 10,
                           selectedValue: formData.jokBelakangSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateJokBelakangSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateJokBelakangSelectedIndex(value);
                           },
                           initialEnabled: formData.jokBelakangIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -311,8 +311,8 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                           label: 'Panel Indikator',
                           count: 10,
                           selectedValue: formData.panelIndikatorSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updatePanelIndikatorSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updatePanelIndikatorSelectedIndex(value);
                           },
                           initialEnabled: formData.panelIndikatorIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -327,8 +327,8 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                           label: 'Switch Lampu',
                           count: 10,
                           selectedValue: formData.switchLampuSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateSwitchLampuSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateSwitchLampuSelectedIndex(value);
                           },
                           initialEnabled: formData.switchLampuIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -343,8 +343,8 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                           label: 'Karpet Dasar',
                           count: 10,
                           selectedValue: formData.karpetDasarSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateKarpetDasarSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateKarpetDasarSelectedIndex(value);
                           },
                           initialEnabled: formData.karpetDasarIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -359,8 +359,8 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                           label: 'Klakson',
                           count: 10,
                           selectedValue: formData.klaksonSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateKlaksonSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateKlaksonSelectedIndex(value);
                           },
                           initialEnabled: formData.klaksonIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -375,8 +375,8 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                           label: 'Sun Visor',
                           count: 10,
                           selectedValue: formData.sunVisorSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateSunVisorSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateSunVisorSelectedIndex(value);
                           },
                           initialEnabled: formData.sunVisorIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -391,8 +391,8 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                           label: 'Tuas Tangki Bensin',
                           count: 10,
                           selectedValue: formData.tuasTangkiBensinSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateTuasTangkiBensinSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateTuasTangkiBensinSelectedIndex(value);
                           },
                           initialEnabled: formData.tuasTangkiBensinIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -407,8 +407,8 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                           label: 'Sabuk Pengaman',
                           count: 10,
                           selectedValue: formData.sabukPengamanSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateSabukPengamanSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateSabukPengamanSelectedIndex(value);
                           },
                           initialEnabled: formData.sabukPengamanIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -423,8 +423,8 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                           label: 'Trim Interior',
                           count: 10,
                           selectedValue: formData.trimInteriorSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateTrimInteriorSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateTrimInteriorSelectedIndex(value);
                           },
                           initialEnabled: formData.trimInteriorIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -439,8 +439,8 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                           label: 'Plafon',
                           count: 10,
                           selectedValue: formData.plafonSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updatePlafonSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updatePlafonSelectedIndex(value);
                           },
                           initialEnabled: formData.plafonIsEnabled ?? true,
                           onEnabledChanged: (enabled) {

--- a/lib/pages/page_five_two.dart
+++ b/lib/pages/page_five_two.dart
@@ -72,15 +72,15 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                         ToggleableNumberedButtonList(
                           label: 'Getaran Mesin',
                           count: 10,
-                          selectedValue: formData.getaranMesinSelectedIndex ?? -1,
+                          selectedValue: formData.getaranMesinSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateGetaranMesinSelectedIndex(value);
+                            formNotifier.updateGetaranMesinSelectedValue(value);
                           },
                           initialEnabled: formData.getaranMesinIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateGetaranMesinIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateGetaranMesinSelectedIndex(-1);
+                              formNotifier.updateGetaranMesinSelectedValue(-1);
                             }
                           },
                         ),
@@ -88,15 +88,15 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                         ToggleableNumberedButtonList(
                           label: 'Suara Mesin',
                           count: 10,
-                          selectedValue: formData.suaraMesinSelectedIndex ?? -1,
+                          selectedValue: formData.suaraMesinSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateSuaraMesinSelectedIndex(value);
+                            formNotifier.updateSuaraMesinSelectedValue(value);
                           },
                           initialEnabled: formData.suaraMesinIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateSuaraMesinIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateSuaraMesinSelectedIndex(-1);
+                              formNotifier.updateSuaraMesinSelectedValue(-1);
                             }
                           },
                         ),
@@ -104,15 +104,15 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                         ToggleableNumberedButtonList(
                           label: 'Transmisi',
                           count: 10,
-                          selectedValue: formData.transmisiSelectedIndex ?? -1,
+                          selectedValue: formData.transmisiSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateTransmisiSelectedIndex(value);
+                            formNotifier.updateTransmisiSelectedValue(value);
                           },
                           initialEnabled: formData.transmisiIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateTransmisiIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateTransmisiSelectedIndex(-1);
+                              formNotifier.updateTransmisiSelectedValue(-1);
                             }
                           },
                         ),
@@ -120,15 +120,15 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                         ToggleableNumberedButtonList(
                           label: 'Pompa Power Steering',
                           count: 10,
-                          selectedValue: formData.pompaPowerSteeringSelectedIndex ?? -1,
+                          selectedValue: formData.pompaPowerSteeringSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updatePompaPowerSteeringSelectedIndex(value);
+                            formNotifier.updatePompaPowerSteeringSelectedValue(value);
                           },
                           initialEnabled: formData.pompaPowerSteeringIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updatePompaPowerSteeringIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updatePompaPowerSteeringSelectedIndex(-1);
+                              formNotifier.updatePompaPowerSteeringSelectedValue(-1);
                             }
                           },
                         ),
@@ -136,15 +136,15 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                         ToggleableNumberedButtonList(
                           label: 'Cover Timing Chain',
                           count: 10,
-                          selectedValue: formData.coverTimingChainSelectedIndex ?? -1,
+                          selectedValue: formData.coverTimingChainSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateCoverTimingChainSelectedIndex(value);
+                            formNotifier.updateCoverTimingChainSelectedValue(value);
                           },
                           initialEnabled: formData.coverTimingChainIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateCoverTimingChainIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateCoverTimingChainSelectedIndex(-1);
+                              formNotifier.updateCoverTimingChainSelectedValue(-1);
                             }
                           },
                         ),
@@ -152,15 +152,15 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                         ToggleableNumberedButtonList(
                           label: 'Oli Power Steering',
                           count: 10,
-                          selectedValue: formData.oliPowerSteeringSelectedIndex ?? -1,
+                          selectedValue: formData.oliPowerSteeringSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateOliPowerSteeringSelectedIndex(value);
+                            formNotifier.updateOliPowerSteeringSelectedValue(value);
                           },
                           initialEnabled: formData.oliPowerSteeringIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateOliPowerSteeringIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateOliPowerSteeringSelectedIndex(-1);
+                              formNotifier.updateOliPowerSteeringSelectedValue(-1);
                             }
                           },
                         ),
@@ -168,15 +168,15 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                         ToggleableNumberedButtonList(
                           label: 'Accu',
                           count: 10,
-                          selectedValue: formData.accuSelectedIndex ?? -1,
+                          selectedValue: formData.accuSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateAccuSelectedIndex(value);
+                            formNotifier.updateAccuSelectedValue(value);
                           },
                           initialEnabled: formData.accuIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateAccuIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateAccuSelectedIndex(-1);
+                              formNotifier.updateAccuSelectedValue(-1);
                             }
                           },
                         ),
@@ -184,15 +184,15 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                         ToggleableNumberedButtonList(
                           label: 'Kompressor AC',
                           count: 10,
-                          selectedValue: formData.kompressorAcSelectedIndex ?? -1,
+                          selectedValue: formData.kompressorAcSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateKompressorAcSelectedIndex(value);
+                            formNotifier.updateKompressorAcSelectedValue(value);
                           },
                           initialEnabled: formData.kompressorAcIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateKompressorAcIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateKompressorAcSelectedIndex(-1);
+                              formNotifier.updateKompressorAcSelectedValue(-1);
                             }
                           },
                         ),
@@ -200,15 +200,15 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                         ToggleableNumberedButtonList(
                           label: 'Fan',
                           count: 10,
-                          selectedValue: formData.fanSelectedIndex ?? -1,
+                          selectedValue: formData.fanSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateFanSelectedIndex(value);
+                            formNotifier.updateFanSelectedValue(value);
                           },
                           initialEnabled: formData.fanIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateFanIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateFanSelectedIndex(-1);
+                              formNotifier.updateFanSelectedValue(-1);
                             }
                           },
                         ),
@@ -216,15 +216,15 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                         ToggleableNumberedButtonList(
                           label: 'Selang',
                           count: 10,
-                          selectedValue: formData.selangSelectedIndex ?? -1,
+                          selectedValue: formData.selangSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateSelangSelectedIndex(value);
+                            formNotifier.updateSelangSelectedValue(value);
                           },
                           initialEnabled: formData.selangIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateSelangIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateSelangSelectedIndex(-1);
+                              formNotifier.updateSelangSelectedValue(-1);
                             }
                           },
                         ),
@@ -232,15 +232,15 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                         ToggleableNumberedButtonList(
                           label: 'Karter Oli',
                           count: 10,
-                          selectedValue: formData.karterOliSelectedIndex ?? -1,
+                          selectedValue: formData.karterOliSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateKarterOliSelectedIndex(value);
+                            formNotifier.updateKarterOliSelectedValue(value);
                           },
                           initialEnabled: formData.karterOliIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateKarterOliIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateKarterOliSelectedIndex(-1);
+                              formNotifier.updateKarterOliSelectedValue(-1);
                             }
                           },
                         ),
@@ -248,15 +248,15 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                         ToggleableNumberedButtonList(
                           label: 'Oil Rem',
                           count: 10,
-                          selectedValue: formData.oilRemSelectedIndex ?? -1,
+                          selectedValue: formData.oilRemSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateOilRemSelectedIndex(value);
+                            formNotifier.updateOilRemSelectedValue(value);
                           },
                           initialEnabled: formData.oilRemIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateOilRemIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateOilRemSelectedIndex(-1);
+                              formNotifier.updateOilRemSelectedValue(-1);
                             }
                           },
                         ),
@@ -264,15 +264,15 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                         ToggleableNumberedButtonList(
                           label: 'Kabel',
                           count: 10,
-                          selectedValue: formData.kabelSelectedIndex ?? -1,
+                          selectedValue: formData.kabelSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateKabelSelectedIndex(value);
+                            formNotifier.updateKabelSelectedValue(value);
                           },
                           initialEnabled: formData.kabelIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateKabelIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateKabelSelectedIndex(-1);
+                              formNotifier.updateKabelSelectedValue(-1);
                             }
                           },
                         ),
@@ -280,15 +280,15 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                         ToggleableNumberedButtonList(
                           label: 'Kondensor',
                           count: 10,
-                          selectedValue: formData.kondensorSelectedIndex ?? -1,
+                          selectedValue: formData.kondensorSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateKondensorSelectedIndex(value);
+                            formNotifier.updateKondensorSelectedValue(value);
                           },
                           initialEnabled: formData.kondensorIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateKondensorIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateKondensorSelectedIndex(-1);
+                              formNotifier.updateKondensorSelectedValue(-1);
                             }
                           },
                         ),
@@ -296,15 +296,15 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                         ToggleableNumberedButtonList(
                           label: 'Radiator',
                           count: 10,
-                          selectedValue: formData.radiatorSelectedIndex ?? -1,
+                          selectedValue: formData.radiatorSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateRadiatorSelectedIndex(value);
+                            formNotifier.updateRadiatorSelectedValue(value);
                           },
                           initialEnabled: formData.radiatorIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateRadiatorIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateRadiatorSelectedIndex(-1);
+                              formNotifier.updateRadiatorSelectedValue(-1);
                             }
                           },
                         ),
@@ -312,15 +312,15 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                         ToggleableNumberedButtonList(
                           label: 'Cylinder Head',
                           count: 10,
-                          selectedValue: formData.cylinderHeadSelectedIndex ?? -1,
+                          selectedValue: formData.cylinderHeadSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateCylinderHeadSelectedIndex(value);
+                            formNotifier.updateCylinderHeadSelectedValue(value);
                           },
                           initialEnabled: formData.cylinderHeadIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateCylinderHeadIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateCylinderHeadSelectedIndex(-1);
+                              formNotifier.updateCylinderHeadSelectedValue(-1);
                             }
                           },
                         ),
@@ -328,15 +328,15 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                         ToggleableNumberedButtonList(
                           label: 'Oli Mesin',
                           count: 10,
-                          selectedValue: formData.oliMesinSelectedIndex ?? -1,
+                          selectedValue: formData.oliMesinSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateOliMesinSelectedIndex(value);
+                            formNotifier.updateOliMesinSelectedValue(value);
                           },
                           initialEnabled: formData.oliMesinIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateOliMesinIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateOliMesinSelectedIndex(-1);
+                              formNotifier.updateOliMesinSelectedValue(-1);
                             }
                           },
                         ),
@@ -344,15 +344,15 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                         ToggleableNumberedButtonList(
                           label: 'Air Radiator',
                           count: 10,
-                          selectedValue: formData.airRadiatorSelectedIndex ?? -1,
+                          selectedValue: formData.airRadiatorSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateAirRadiatorSelectedIndex(value);
+                            formNotifier.updateAirRadiatorSelectedValue(value);
                           },
                           initialEnabled: formData.airRadiatorIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateAirRadiatorIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateAirRadiatorSelectedIndex(-1);
+                              formNotifier.updateAirRadiatorSelectedValue(-1);
                             }
                           },
                         ),
@@ -360,15 +360,15 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                         ToggleableNumberedButtonList(
                           label: 'Cover Klep',
                           count: 10,
-                          selectedValue: formData.coverKlepSelectedIndex ?? -1,
+                          selectedValue: formData.coverKlepSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateCoverKlepSelectedIndex(value);
+                            formNotifier.updateCoverKlepSelectedValue(value);
                           },
                           initialEnabled: formData.coverKlepIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateCoverKlepIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateCoverKlepSelectedIndex(-1);
+                              formNotifier.updateCoverKlepSelectedValue(-1);
                             }
                           },
                         ),
@@ -376,15 +376,15 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                         ToggleableNumberedButtonList(
                           label: 'Alternator',
                           count: 10,
-                          selectedValue: formData.alternatorSelectedIndex ?? -1,
+                          selectedValue: formData.alternatorSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateAlternatorSelectedIndex(value);
+                            formNotifier.updateAlternatorSelectedValue(value);
                           },
                           initialEnabled: formData.alternatorIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateAlternatorIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateAlternatorSelectedIndex(-1);
+                              formNotifier.updateAlternatorSelectedValue(-1);
                             }
                           },
                         ),
@@ -392,15 +392,15 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                         ToggleableNumberedButtonList(
                           label: 'Water Pump',
                           count: 10,
-                          selectedValue: formData.waterPumpSelectedIndex ?? -1,
+                          selectedValue: formData.waterPumpSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateWaterPumpSelectedIndex(value);
+                            formNotifier.updateWaterPumpSelectedValue(value);
                           },
                           initialEnabled: formData.waterPumpIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateWaterPumpIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateWaterPumpSelectedIndex(-1);
+                              formNotifier.updateWaterPumpSelectedValue(-1);
                             }
                           },
                         ),
@@ -408,15 +408,15 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                         ToggleableNumberedButtonList(
                           label: 'Belt',
                           count: 10,
-                          selectedValue: formData.beltSelectedIndex ?? -1,
+                          selectedValue: formData.beltSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateBeltSelectedIndex(value);
+                            formNotifier.updateBeltSelectedValue(value);
                           },
                           initialEnabled: formData.beltIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateBeltIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateBeltSelectedIndex(-1);
+                              formNotifier.updateBeltSelectedValue(-1);
                             }
                           },
                         ),
@@ -424,15 +424,15 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                         ToggleableNumberedButtonList(
                           label: 'Oli Transmisi',
                           count: 10,
-                          selectedValue: formData.oliTransmisiSelectedIndex ?? -1,
+                          selectedValue: formData.oliTransmisiSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateOliTransmisiSelectedIndex(value);
+                            formNotifier.updateOliTransmisiSelectedValue(value);
                           },
                           initialEnabled: formData.oliTransmisiIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateOliTransmisiIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateOliTransmisiSelectedIndex(-1);
+                              formNotifier.updateOliTransmisiSelectedValue(-1);
                             }
                           },
                         ),
@@ -440,15 +440,15 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                         ToggleableNumberedButtonList(
                           label: 'Cylinder Block',
                           count: 10,
-                          selectedValue: formData.cylinderBlockSelectedIndex ?? -1,
+                          selectedValue: formData.cylinderBlockSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateCylinderBlockSelectedIndex(value);
+                            formNotifier.updateCylinderBlockSelectedValue(value);
                           },
                           initialEnabled: formData.cylinderBlockIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateCylinderBlockIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateCylinderBlockSelectedIndex(-1);
+                              formNotifier.updateCylinderBlockSelectedValue(-1);
                             }
                           },
                         ),
@@ -456,15 +456,15 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                         ToggleableNumberedButtonList(
                           label: 'Bushing Besar',
                           count: 10,
-                          selectedValue: formData.bushingBesarSelectedIndex ?? -1,
+                          selectedValue: formData.bushingBesarSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateBushingBesarSelectedIndex(value);
+                            formNotifier.updateBushingBesarSelectedValue(value);
                           },
                           initialEnabled: formData.bushingBesarIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateBushingBesarIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateBushingBesarSelectedIndex(-1);
+                              formNotifier.updateBushingBesarSelectedValue(-1);
                             }
                           },
                         ),
@@ -472,15 +472,15 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                         ToggleableNumberedButtonList(
                           label: 'Bushing Kecil',
                           count: 10,
-                          selectedValue: formData.bushingKecilSelectedIndex ?? -1,
+                          selectedValue: formData.bushingKecilSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateBushingKecilSelectedIndex(value);
+                            formNotifier.updateBushingKecilSelectedValue(value);
                           },
                           initialEnabled: formData.bushingKecilIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateBushingKecilIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateBushingKecilSelectedIndex(-1);
+                              formNotifier.updateBushingKecilSelectedValue(-1);
                             }
                           },
                         ),
@@ -488,15 +488,15 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                         ToggleableNumberedButtonList(
                           label: 'Tutup Radiator',
                           count: 10,
-                          selectedValue: formData.tutupRadiatorSelectedIndex ?? -1,
+                          selectedValue: formData.tutupRadiatorSelectedValue ?? -1,
                           onItemSelected: (value) {
-                            formNotifier.updateTutupRadiatorSelectedIndex(value);
+                            formNotifier.updateTutupRadiatorSelectedValue(value);
                           },
                           initialEnabled: formData.tutupRadiatorIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
                             formNotifier.updateTutupRadiatorIsEnabled(enabled);
                             if (!enabled) {
-                              formNotifier.updateTutupRadiatorSelectedIndex(-1);
+                              formNotifier.updateTutupRadiatorSelectedValue(-1);
                             }
                           },
                         ),

--- a/lib/pages/page_five_two.dart
+++ b/lib/pages/page_five_two.dart
@@ -72,7 +72,7 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                         ToggleableNumberedButtonList(
                           label: 'Getaran Mesin',
                           count: 10,
-                          selectedIndex: formData.getaranMesinSelectedIndex ?? -1,
+                          selectedValue: formData.getaranMesinSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateGetaranMesinSelectedIndex(index);
                           },
@@ -88,7 +88,7 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                         ToggleableNumberedButtonList(
                           label: 'Suara Mesin',
                           count: 10,
-                          selectedIndex: formData.suaraMesinSelectedIndex ?? -1,
+                          selectedValue: formData.suaraMesinSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateSuaraMesinSelectedIndex(index);
                           },
@@ -104,7 +104,7 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                         ToggleableNumberedButtonList(
                           label: 'Transmisi',
                           count: 10,
-                          selectedIndex: formData.transmisiSelectedIndex ?? -1,
+                          selectedValue: formData.transmisiSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateTransmisiSelectedIndex(index);
                           },
@@ -120,7 +120,7 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                         ToggleableNumberedButtonList(
                           label: 'Pompa Power Steering',
                           count: 10,
-                          selectedIndex: formData.pompaPowerSteeringSelectedIndex ?? -1,
+                          selectedValue: formData.pompaPowerSteeringSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updatePompaPowerSteeringSelectedIndex(index);
                           },
@@ -136,7 +136,7 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                         ToggleableNumberedButtonList(
                           label: 'Cover Timing Chain',
                           count: 10,
-                          selectedIndex: formData.coverTimingChainSelectedIndex ?? -1,
+                          selectedValue: formData.coverTimingChainSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateCoverTimingChainSelectedIndex(index);
                           },
@@ -152,7 +152,7 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                         ToggleableNumberedButtonList(
                           label: 'Oli Power Steering',
                           count: 10,
-                          selectedIndex: formData.oliPowerSteeringSelectedIndex ?? -1,
+                          selectedValue: formData.oliPowerSteeringSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateOliPowerSteeringSelectedIndex(index);
                           },
@@ -168,7 +168,7 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                         ToggleableNumberedButtonList(
                           label: 'Accu',
                           count: 10,
-                          selectedIndex: formData.accuSelectedIndex ?? -1,
+                          selectedValue: formData.accuSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateAccuSelectedIndex(index);
                           },
@@ -184,7 +184,7 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                         ToggleableNumberedButtonList(
                           label: 'Kompressor AC',
                           count: 10,
-                          selectedIndex: formData.kompressorAcSelectedIndex ?? -1,
+                          selectedValue: formData.kompressorAcSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateKompressorAcSelectedIndex(index);
                           },
@@ -200,7 +200,7 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                         ToggleableNumberedButtonList(
                           label: 'Fan',
                           count: 10,
-                          selectedIndex: formData.fanSelectedIndex ?? -1,
+                          selectedValue: formData.fanSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateFanSelectedIndex(index);
                           },
@@ -216,7 +216,7 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                         ToggleableNumberedButtonList(
                           label: 'Selang',
                           count: 10,
-                          selectedIndex: formData.selangSelectedIndex ?? -1,
+                          selectedValue: formData.selangSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateSelangSelectedIndex(index);
                           },
@@ -232,7 +232,7 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                         ToggleableNumberedButtonList(
                           label: 'Karter Oli',
                           count: 10,
-                          selectedIndex: formData.karterOliSelectedIndex ?? -1,
+                          selectedValue: formData.karterOliSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateKarterOliSelectedIndex(index);
                           },
@@ -248,7 +248,7 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                         ToggleableNumberedButtonList(
                           label: 'Oil Rem',
                           count: 10,
-                          selectedIndex: formData.oilRemSelectedIndex ?? -1,
+                          selectedValue: formData.oilRemSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateOilRemSelectedIndex(index);
                           },
@@ -264,7 +264,7 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                         ToggleableNumberedButtonList(
                           label: 'Kabel',
                           count: 10,
-                          selectedIndex: formData.kabelSelectedIndex ?? -1,
+                          selectedValue: formData.kabelSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateKabelSelectedIndex(index);
                           },
@@ -280,7 +280,7 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                         ToggleableNumberedButtonList(
                           label: 'Kondensor',
                           count: 10,
-                          selectedIndex: formData.kondensorSelectedIndex ?? -1,
+                          selectedValue: formData.kondensorSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateKondensorSelectedIndex(index);
                           },
@@ -296,7 +296,7 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                         ToggleableNumberedButtonList(
                           label: 'Radiator',
                           count: 10,
-                          selectedIndex: formData.radiatorSelectedIndex ?? -1,
+                          selectedValue: formData.radiatorSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateRadiatorSelectedIndex(index);
                           },
@@ -312,7 +312,7 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                         ToggleableNumberedButtonList(
                           label: 'Cylinder Head',
                           count: 10,
-                          selectedIndex: formData.cylinderHeadSelectedIndex ?? -1,
+                          selectedValue: formData.cylinderHeadSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateCylinderHeadSelectedIndex(index);
                           },
@@ -328,7 +328,7 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                         ToggleableNumberedButtonList(
                           label: 'Oli Mesin',
                           count: 10,
-                          selectedIndex: formData.oliMesinSelectedIndex ?? -1,
+                          selectedValue: formData.oliMesinSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateOliMesinSelectedIndex(index);
                           },
@@ -344,7 +344,7 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                         ToggleableNumberedButtonList(
                           label: 'Air Radiator',
                           count: 10,
-                          selectedIndex: formData.airRadiatorSelectedIndex ?? -1,
+                          selectedValue: formData.airRadiatorSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateAirRadiatorSelectedIndex(index);
                           },
@@ -360,7 +360,7 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                         ToggleableNumberedButtonList(
                           label: 'Cover Klep',
                           count: 10,
-                          selectedIndex: formData.coverKlepSelectedIndex ?? -1,
+                          selectedValue: formData.coverKlepSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateCoverKlepSelectedIndex(index);
                           },
@@ -376,7 +376,7 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                         ToggleableNumberedButtonList(
                           label: 'Alternator',
                           count: 10,
-                          selectedIndex: formData.alternatorSelectedIndex ?? -1,
+                          selectedValue: formData.alternatorSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateAlternatorSelectedIndex(index);
                           },
@@ -392,7 +392,7 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                         ToggleableNumberedButtonList(
                           label: 'Water Pump',
                           count: 10,
-                          selectedIndex: formData.waterPumpSelectedIndex ?? -1,
+                          selectedValue: formData.waterPumpSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateWaterPumpSelectedIndex(index);
                           },
@@ -408,7 +408,7 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                         ToggleableNumberedButtonList(
                           label: 'Belt',
                           count: 10,
-                          selectedIndex: formData.beltSelectedIndex ?? -1,
+                          selectedValue: formData.beltSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateBeltSelectedIndex(index);
                           },
@@ -424,7 +424,7 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                         ToggleableNumberedButtonList(
                           label: 'Oli Transmisi',
                           count: 10,
-                          selectedIndex: formData.oliTransmisiSelectedIndex ?? -1,
+                          selectedValue: formData.oliTransmisiSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateOliTransmisiSelectedIndex(index);
                           },
@@ -440,7 +440,7 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                         ToggleableNumberedButtonList(
                           label: 'Cylinder Block',
                           count: 10,
-                          selectedIndex: formData.cylinderBlockSelectedIndex ?? -1,
+                          selectedValue: formData.cylinderBlockSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateCylinderBlockSelectedIndex(index);
                           },
@@ -456,7 +456,7 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                         ToggleableNumberedButtonList(
                           label: 'Bushing Besar',
                           count: 10,
-                          selectedIndex: formData.bushingBesarSelectedIndex ?? -1,
+                          selectedValue: formData.bushingBesarSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateBushingBesarSelectedIndex(index);
                           },
@@ -472,7 +472,7 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                         ToggleableNumberedButtonList(
                           label: 'Bushing Kecil',
                           count: 10,
-                          selectedIndex: formData.bushingKecilSelectedIndex ?? -1,
+                          selectedValue: formData.bushingKecilSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateBushingKecilSelectedIndex(index);
                           },
@@ -488,7 +488,7 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                         ToggleableNumberedButtonList(
                           label: 'Tutup Radiator',
                           count: 10,
-                          selectedIndex: formData.tutupRadiatorSelectedIndex ?? -1,
+                          selectedValue: formData.tutupRadiatorSelectedIndex ?? -1,
                           onItemSelected: (index) {
                             formNotifier.updateTutupRadiatorSelectedIndex(index);
                           },

--- a/lib/pages/page_five_two.dart
+++ b/lib/pages/page_five_two.dart
@@ -73,8 +73,8 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                           label: 'Getaran Mesin',
                           count: 10,
                           selectedValue: formData.getaranMesinSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateGetaranMesinSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateGetaranMesinSelectedIndex(value);
                           },
                           initialEnabled: formData.getaranMesinIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -89,8 +89,8 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                           label: 'Suara Mesin',
                           count: 10,
                           selectedValue: formData.suaraMesinSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateSuaraMesinSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateSuaraMesinSelectedIndex(value);
                           },
                           initialEnabled: formData.suaraMesinIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -105,8 +105,8 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                           label: 'Transmisi',
                           count: 10,
                           selectedValue: formData.transmisiSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateTransmisiSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateTransmisiSelectedIndex(value);
                           },
                           initialEnabled: formData.transmisiIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -121,8 +121,8 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                           label: 'Pompa Power Steering',
                           count: 10,
                           selectedValue: formData.pompaPowerSteeringSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updatePompaPowerSteeringSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updatePompaPowerSteeringSelectedIndex(value);
                           },
                           initialEnabled: formData.pompaPowerSteeringIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -137,8 +137,8 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                           label: 'Cover Timing Chain',
                           count: 10,
                           selectedValue: formData.coverTimingChainSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateCoverTimingChainSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateCoverTimingChainSelectedIndex(value);
                           },
                           initialEnabled: formData.coverTimingChainIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -153,8 +153,8 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                           label: 'Oli Power Steering',
                           count: 10,
                           selectedValue: formData.oliPowerSteeringSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateOliPowerSteeringSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateOliPowerSteeringSelectedIndex(value);
                           },
                           initialEnabled: formData.oliPowerSteeringIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -169,8 +169,8 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                           label: 'Accu',
                           count: 10,
                           selectedValue: formData.accuSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateAccuSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateAccuSelectedIndex(value);
                           },
                           initialEnabled: formData.accuIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -185,8 +185,8 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                           label: 'Kompressor AC',
                           count: 10,
                           selectedValue: formData.kompressorAcSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateKompressorAcSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateKompressorAcSelectedIndex(value);
                           },
                           initialEnabled: formData.kompressorAcIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -201,8 +201,8 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                           label: 'Fan',
                           count: 10,
                           selectedValue: formData.fanSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateFanSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateFanSelectedIndex(value);
                           },
                           initialEnabled: formData.fanIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -217,8 +217,8 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                           label: 'Selang',
                           count: 10,
                           selectedValue: formData.selangSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateSelangSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateSelangSelectedIndex(value);
                           },
                           initialEnabled: formData.selangIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -233,8 +233,8 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                           label: 'Karter Oli',
                           count: 10,
                           selectedValue: formData.karterOliSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateKarterOliSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateKarterOliSelectedIndex(value);
                           },
                           initialEnabled: formData.karterOliIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -249,8 +249,8 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                           label: 'Oil Rem',
                           count: 10,
                           selectedValue: formData.oilRemSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateOilRemSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateOilRemSelectedIndex(value);
                           },
                           initialEnabled: formData.oilRemIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -265,8 +265,8 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                           label: 'Kabel',
                           count: 10,
                           selectedValue: formData.kabelSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateKabelSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateKabelSelectedIndex(value);
                           },
                           initialEnabled: formData.kabelIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -281,8 +281,8 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                           label: 'Kondensor',
                           count: 10,
                           selectedValue: formData.kondensorSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateKondensorSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateKondensorSelectedIndex(value);
                           },
                           initialEnabled: formData.kondensorIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -297,8 +297,8 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                           label: 'Radiator',
                           count: 10,
                           selectedValue: formData.radiatorSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateRadiatorSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateRadiatorSelectedIndex(value);
                           },
                           initialEnabled: formData.radiatorIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -313,8 +313,8 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                           label: 'Cylinder Head',
                           count: 10,
                           selectedValue: formData.cylinderHeadSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateCylinderHeadSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateCylinderHeadSelectedIndex(value);
                           },
                           initialEnabled: formData.cylinderHeadIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -329,8 +329,8 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                           label: 'Oli Mesin',
                           count: 10,
                           selectedValue: formData.oliMesinSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateOliMesinSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateOliMesinSelectedIndex(value);
                           },
                           initialEnabled: formData.oliMesinIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -345,8 +345,8 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                           label: 'Air Radiator',
                           count: 10,
                           selectedValue: formData.airRadiatorSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateAirRadiatorSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateAirRadiatorSelectedIndex(value);
                           },
                           initialEnabled: formData.airRadiatorIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -361,8 +361,8 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                           label: 'Cover Klep',
                           count: 10,
                           selectedValue: formData.coverKlepSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateCoverKlepSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateCoverKlepSelectedIndex(value);
                           },
                           initialEnabled: formData.coverKlepIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -377,8 +377,8 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                           label: 'Alternator',
                           count: 10,
                           selectedValue: formData.alternatorSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateAlternatorSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateAlternatorSelectedIndex(value);
                           },
                           initialEnabled: formData.alternatorIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -393,8 +393,8 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                           label: 'Water Pump',
                           count: 10,
                           selectedValue: formData.waterPumpSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateWaterPumpSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateWaterPumpSelectedIndex(value);
                           },
                           initialEnabled: formData.waterPumpIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -409,8 +409,8 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                           label: 'Belt',
                           count: 10,
                           selectedValue: formData.beltSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateBeltSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateBeltSelectedIndex(value);
                           },
                           initialEnabled: formData.beltIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -425,8 +425,8 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                           label: 'Oli Transmisi',
                           count: 10,
                           selectedValue: formData.oliTransmisiSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateOliTransmisiSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateOliTransmisiSelectedIndex(value);
                           },
                           initialEnabled: formData.oliTransmisiIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -441,8 +441,8 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                           label: 'Cylinder Block',
                           count: 10,
                           selectedValue: formData.cylinderBlockSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateCylinderBlockSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateCylinderBlockSelectedIndex(value);
                           },
                           initialEnabled: formData.cylinderBlockIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -457,8 +457,8 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                           label: 'Bushing Besar',
                           count: 10,
                           selectedValue: formData.bushingBesarSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateBushingBesarSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateBushingBesarSelectedIndex(value);
                           },
                           initialEnabled: formData.bushingBesarIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -473,8 +473,8 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                           label: 'Bushing Kecil',
                           count: 10,
                           selectedValue: formData.bushingKecilSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateBushingKecilSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateBushingKecilSelectedIndex(value);
                           },
                           initialEnabled: formData.bushingKecilIsEnabled ?? true,
                           onEnabledChanged: (enabled) {
@@ -489,8 +489,8 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                           label: 'Tutup Radiator',
                           count: 10,
                           selectedValue: formData.tutupRadiatorSelectedIndex ?? -1,
-                          onItemSelected: (index) {
-                            formNotifier.updateTutupRadiatorSelectedIndex(index);
+                          onItemSelected: (value) {
+                            formNotifier.updateTutupRadiatorSelectedIndex(value);
                           },
                           initialEnabled: formData.tutupRadiatorIsEnabled ?? true,
                           onEnabledChanged: (enabled) {

--- a/lib/pages/page_four.dart
+++ b/lib/pages/page_four.dart
@@ -73,10 +73,10 @@ class _PageFourState extends ConsumerState<PageFour> {
                         NumberedButtonList(
                           label: 'Interior',
                           count: 10, // Assuming 10 options based on the image
-                          selectedIndex: formData.interiorSelectedIndex ?? -1,
-                          onItemSelected: (index) {
+                          selectedValue: formData.interiorSelectedValue ?? -1,
+                          onItemSelected: (value) {
                             final formNotifier = ref.read(formProvider.notifier);
-                            formNotifier.updateInteriorSelectedIndex(index == formData.interiorSelectedIndex ? -1 : index);
+                            formNotifier.updateInteriorSelectedValue(value == formData.interiorSelectedValue ? -1 : value);
                           },
                         ),
                         const SizedBox(height: 24.0),
@@ -93,10 +93,10 @@ class _PageFourState extends ConsumerState<PageFour> {
                         NumberedButtonList(
                           label: 'Eksterior',
                           count: 10, // Assuming 10 options based on the image
-                          selectedIndex: formData.eksteriorSelectedIndex ?? -1,
-                          onItemSelected: (index) {
+                          selectedValue: formData.eksteriorSelectedValue ?? -1,
+                          onItemSelected: (value) {
                             final formNotifier = ref.read(formProvider.notifier);
-                            formNotifier.updateEksteriorSelectedIndex(index == formData.eksteriorSelectedIndex ? -1 : index);
+                            formNotifier.updateEksteriorSelectedValue(value == formData.eksteriorSelectedValue ? -1 : value);
                           },
                         ),
                         const SizedBox(height: 24.0),
@@ -113,10 +113,10 @@ class _PageFourState extends ConsumerState<PageFour> {
                         NumberedButtonList(
                           label: 'Kaki-kaki',
                           count: 10, // Assuming 10 options based on the image
-                          selectedIndex: formData.kakiKakiSelectedIndex ?? -1,
-                          onItemSelected: (index) {
+                          selectedValue: formData.kakiKakiSelectedValue ?? -1,
+                          onItemSelected: (value) {
                             final formNotifier = ref.read(formProvider.notifier);
-                            formNotifier.updateKakiKakiSelectedIndex(index == formData.kakiKakiSelectedIndex ? -1 : index);
+                            formNotifier.updateKakiKakiSelectedValue(value == formData.kakiKakiSelectedValue ? -1 : value);
                           },
                         ),
                         const SizedBox(height: 24.0),
@@ -133,10 +133,10 @@ class _PageFourState extends ConsumerState<PageFour> {
                         NumberedButtonList(
                           label: 'Mesin',
                           count: 10, // Assuming 10 options based on the image
-                          selectedIndex: formData.mesinSelectedIndex ?? -1,
-                          onItemSelected: (index) {
+                          selectedValue: formData.mesinSelectedValue ?? -1,
+                          onItemSelected: (value) {
                             final formNotifier = ref.read(formProvider.notifier);
-                            formNotifier.updateMesinSelectedIndex(index == formData.mesinSelectedIndex ? -1 : index);
+                            formNotifier.updateMesinSelectedValue(value == formData.mesinSelectedValue ? -1 : value);
                           },
                         ),
                         const SizedBox(height: 24.0),
@@ -153,10 +153,10 @@ class _PageFourState extends ConsumerState<PageFour> {
                         NumberedButtonList(
                           label: 'Penilaian Keseluruhan',
                           count: 10, // Assuming 10 options based on the image
-                          selectedIndex: formData.penilaianKeseluruhanSelectedIndex ?? -1,
-                          onItemSelected: (index) {
+                          selectedValue: formData.penilaianKeseluruhanSelectedValue ?? -1,
+                          onItemSelected: (value) {
                             final formNotifier = ref.read(formProvider.notifier);
-                            formNotifier.updatePenilaianKeseluruhanSelectedIndex(index == formData.penilaianKeseluruhanSelectedIndex ? -1 : index);
+                            formNotifier.updatePenilaianKeseluruhanSelectedValue(value == formData.penilaianKeseluruhanSelectedValue ? -1 : value);
                           },
                         ),
                         const SizedBox(height: 24.0),

--- a/lib/pages/page_nine.dart
+++ b/lib/pages/page_nine.dart
@@ -1,18 +1,77 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:form_app/models/form_data.dart';
+import 'package:form_app/providers/form_provider.dart';
+import 'package:form_app/services/api_service.dart';
+import 'package:form_app/statics/app_styles.dart';
 import 'package:form_app/widgets/common_layout.dart';
 import 'package:form_app/widgets/navigation_button_row.dart';
 import 'package:form_app/widgets/page_number.dart';
 import 'package:form_app/widgets/page_title.dart';
 import 'package:form_app/widgets/footer.dart';
-// Import other necessary widgets like CommonLayout if you plan to use it here
+import 'package:form_app/widgets/custom_checkbox_tile.dart';
 
 // Placeholder for Page Nine
-class PageNine extends StatelessWidget {
+class PageNine extends ConsumerStatefulWidget {
   const PageNine({super.key});
 
   @override
+  ConsumerState<PageNine> createState() => _PageNineState();
+}
+
+class _PageNineState extends ConsumerState<PageNine> {
+  bool _isChecked = false;
+  bool _isLoading = false;
+
+  Future<void> _submitForm() async {
+    if (!_isChecked) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Harap setujui pernyataan untuk melanjutkan.'),
+          backgroundColor: Colors.red,
+        ),
+      );
+      return;
+    }
+
+    setState(() {
+      _isLoading = true;
+    });
+
+    try {
+      final formData = ref.read(formProvider);
+      final apiService = ApiService(); // Consider providing ApiService via Riverpod as well
+
+      // TODO: Before calling submitFormData, ensure all TODOs within ApiService.submitFormData are addressed
+      // For now, we call it as is.
+      await apiService.submitFormData(formData);
+
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Formulir berhasil dikirim!'),
+          backgroundColor: Colors.green,
+        ),
+      );
+      // Optionally, navigate to a success page or clear the form
+      // Navigator.of(context).popUntil((route) => route.isFirst); // Example: Pop to first page
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('Gagal mengirim formulir: $e'),
+          backgroundColor: Colors.red,
+        ),
+      );
+    } finally {
+      setState(() {
+        _isLoading = false;
+      });
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
-    // Basic structure, replace with actual content later
     return CommonLayout(
       child: Column(
         children: [
@@ -23,18 +82,36 @@ class PageNine extends StatelessWidget {
                 children: [
                   PageNumber(data: '9/9'),
                   const SizedBox(height: 8.0),
-                  PageTitle(data: 'Page Nine Title'), // Placeholder Title
-                  const SizedBox(height: 24.0),
-                  const Center(child: Text('Page Nine Content Goes Here')),
+                  PageTitle(data: 'Finalisasi'), // Placeholder Title
+                  const SizedBox(height: 16.0),
+                  Text(
+                    'Pastikan data yang telah diisi telah sesuai dengan yang sebenarnya dan memenuhi SOP PT Inspeksi Mobil Jogja',
+                    style: labelStyle.copyWith(fontWeight: FontWeight.w300), // Corrected font weight
+                  ),
+                  const SizedBox(height: 16.0), // Added spacing
+                  CustomCheckboxTile(
+                    label: 'Data yang saya isi telah sesuai',
+                    initialValue: _isChecked,
+                    onChanged: (bool newValue) {
+                      setState(() {
+                        _isChecked = newValue;
+                      });
+                    },
+                  ),
                   const SizedBox(height: 32.0),
                   NavigationButtonRow(
                     onBackPressed: () => Navigator.pop(context),
                     isLastPage: true,
-                    onNextPressed: () {
-                      // TODO: Implement final submission or navigation
-                    },
+                    onNextPressed: _isLoading ? () {} : _submitForm, // Disable button when loading
+                    // TODO: Pass _isLoading to NavigationButtonRow if it supports a loading state for the button
                   ),
-                  const SizedBox(height: 32.0), // Optional spacing below the content
+                  if (_isLoading) ...[
+                    const SizedBox(height: 16),
+                    const Center(child: CircularProgressIndicator()),
+                  ],
+                  const SizedBox(
+                    height: 32.0,
+                  ), // Optional spacing below the content
                   // Footer
                   Footer(),
                 ],

--- a/lib/pages/page_nine.dart
+++ b/lib/pages/page_nine.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:form_app/models/form_data.dart';
 import 'package:form_app/providers/form_provider.dart';
 import 'package:form_app/services/api_service.dart';
 import 'package:form_app/statics/app_styles.dart';

--- a/lib/providers/form_provider.dart
+++ b/lib/providers/form_provider.dart
@@ -875,6 +875,147 @@ class FormNotifier extends StateNotifier<FormData> {
   void updateRepairEstimations(List<Map<String, String>> estimations) {
     state = state.copyWith(repairEstimations: estimations);
   }
+
+  // New update methods for Page Five Five
+  void updateBanDepanSelectedValue(int? value) {
+    state = state.copyWith(banDepanSelectedValue: (value == null || value <= 0) ? 0 : value);
+  }
+
+  void updateBanDepanIsEnabled(bool? enabled) {
+    state = state.copyWith(banDepanIsEnabled: enabled);
+  }
+
+  void updateVelgDepanSelectedValue(int? value) {
+    state = state.copyWith(velgDepanSelectedValue: (value == null || value <= 0) ? 0 : value);
+  }
+
+  void updateVelgDepanIsEnabled(bool? enabled) {
+    state = state.copyWith(velgDepanIsEnabled: enabled);
+  }
+
+  void updateDiscBrakeSelectedValue(int? value) {
+    state = state.copyWith(discBrakeSelectedValue: (value == null || value <= 0) ? 0 : value);
+  }
+
+  void updateDiscBrakeIsEnabled(bool? enabled) {
+    state = state.copyWith(discBrakeIsEnabled: enabled);
+  }
+
+  void updateMasterRemSelectedValue(int? value) {
+    state = state.copyWith(masterRemSelectedValue: (value == null || value <= 0) ? 0 : value);
+  }
+
+  void updateMasterRemIsEnabled(bool? enabled) {
+    state = state.copyWith(masterRemIsEnabled: enabled);
+  }
+
+  void updateTieRodSelectedValue(int? value) {
+    state = state.copyWith(tieRodSelectedValue: (value == null || value <= 0) ? 0 : value);
+  }
+
+  void updateTieRodIsEnabled(bool? enabled) {
+    state = state.copyWith(tieRodIsEnabled: enabled);
+  }
+
+  void updateGardanSelectedValue(int? value) {
+    state = state.copyWith(gardanSelectedValue: (value == null || value <= 0) ? 0 : value);
+  }
+
+  void updateGardanIsEnabled(bool? enabled) {
+    state = state.copyWith(gardanIsEnabled: enabled);
+  }
+
+  void updateBanBelakangSelectedValue(int? value) {
+    state = state.copyWith(banBelakangSelectedValue: (value == null || value <= 0) ? 0 : value);
+  }
+
+  void updateBanBelakangIsEnabled(bool? enabled) {
+    state = state.copyWith(banBelakangIsEnabled: enabled);
+  }
+
+  void updateVelgBelakangSelectedValue(int? value) {
+    state = state.copyWith(velgBelakangSelectedValue: (value == null || value <= 0) ? 0 : value);
+  }
+
+  void updateVelgBelakangIsEnabled(bool? enabled) {
+    state = state.copyWith(velgBelakangIsEnabled: enabled);
+  }
+
+  void updateBrakePadSelectedValue(int? value) {
+    state = state.copyWith(brakePadSelectedValue: (value == null || value <= 0) ? 0 : value);
+  }
+
+  void updateBrakePadIsEnabled(bool? enabled) {
+    state = state.copyWith(brakePadIsEnabled: enabled);
+  }
+
+  void updateCrossmemberSelectedValue(int? value) {
+    state = state.copyWith(crossmemberSelectedValue: (value == null || value <= 0) ? 0 : value);
+  }
+
+  void updateCrossmemberIsEnabled(bool? enabled) {
+    state = state.copyWith(crossmemberIsEnabled: enabled);
+  }
+
+  void updateKnalpotSelectedValue(int? value) {
+    state = state.copyWith(knalpotSelectedValue: (value == null || value <= 0) ? 0 : value);
+  }
+
+  void updateKnalpotIsEnabled(bool? enabled) {
+    state = state.copyWith(knalpotIsEnabled: enabled);
+  }
+
+  void updateBalljointSelectedValue(int? value) {
+    state = state.copyWith(balljointSelectedValue: (value == null || value <= 0) ? 0 : value);
+  }
+
+  void updateBalljointIsEnabled(bool? enabled) {
+    state = state.copyWith(balljointIsEnabled: enabled);
+  }
+
+  void updateRocksteerSelectedValue(int? value) {
+    state = state.copyWith(rocksteerSelectedValue: (value == null || value <= 0) ? 0 : value);
+  }
+
+  void updateRocksteerIsEnabled(bool? enabled) {
+    state = state.copyWith(rocksteerIsEnabled: enabled);
+  }
+
+  void updateKaretBootSelectedValue(int? value) {
+    state = state.copyWith(karetBootSelectedValue: (value == null || value <= 0) ? 0 : value);
+  }
+
+  void updateKaretBootIsEnabled(bool? enabled) {
+    state = state.copyWith(karetBootIsEnabled: enabled);
+  }
+
+  void updateUpperLowerArmSelectedValue(int? value) {
+    state = state.copyWith(upperLowerArmSelectedValue: (value == null || value <= 0) ? 0 : value);
+  }
+
+  void updateUpperLowerArmIsEnabled(bool? enabled) {
+    state = state.copyWith(upperLowerArmIsEnabled: enabled);
+  }
+
+  void updateShockBreakerSelectedValue(int? value) {
+    state = state.copyWith(shockBreakerSelectedValue: (value == null || value <= 0) ? 0 : value);
+  }
+
+  void updateShockBreakerIsEnabled(bool? enabled) {
+    state = state.copyWith(shockBreakerIsEnabled: enabled);
+  }
+
+  void updateLinkStabilizerSelectedValue(int? value) {
+    state = state.copyWith(linkStabilizerSelectedValue: (value == null || value <= 0) ? 0 : value);
+  }
+
+  void updateLinkStabilizerIsEnabled(bool? enabled) {
+    state = state.copyWith(linkStabilizerIsEnabled: enabled);
+  }
+
+  void updateBanDanKakiKakiCatatanList(List<String> lines) {
+    state = state.copyWith(banDanKakiKakiCatatanList: lines);
+  }
 }
 
 final formProvider = StateNotifierProvider<FormNotifier, FormData>((ref) {
@@ -1099,6 +1240,41 @@ extension on FormData {
     int? sideSkirtKiriSelectedValue,
     bool? sideSkirtKiriIsEnabled,
     List<String>? eksteriorCatatanList,
+    int? banDepanSelectedValue,
+    bool? banDepanIsEnabled,
+    int? velgDepanSelectedValue,
+    bool? velgDepanIsEnabled,
+    int? discBrakeSelectedValue,
+    bool? discBrakeIsEnabled,
+    int? masterRemSelectedValue,
+    bool? masterRemIsEnabled,
+    int? tieRodSelectedValue,
+    bool? tieRodIsEnabled,
+    int? gardanSelectedValue,
+    bool? gardanIsEnabled,
+    int? banBelakangSelectedValue,
+    bool? banBelakangIsEnabled,
+    int? velgBelakangSelectedValue,
+    bool? velgBelakangIsEnabled,
+    int? brakePadSelectedValue,
+    bool? brakePadIsEnabled,
+    int? crossmemberSelectedValue,
+    bool? crossmemberIsEnabled,
+    int? knalpotSelectedValue,
+    bool? knalpotIsEnabled,
+    int? balljointSelectedValue,
+    bool? balljointIsEnabled,
+    int? rocksteerSelectedValue,
+    bool? rocksteerIsEnabled,
+    int? karetBootSelectedValue,
+    bool? karetBootIsEnabled,
+    int? upperLowerArmSelectedValue,
+    bool? upperLowerArmIsEnabled,
+    int? shockBreakerSelectedValue,
+    bool? shockBreakerIsEnabled,
+    int? linkStabilizerSelectedValue,
+    bool? linkStabilizerIsEnabled,
+    List<String>? banDanKakiKakiCatatanList,
   }) {
     return FormData(
       namaInspektor: namaInspektor ?? this.namaInspektor,
@@ -1317,6 +1493,41 @@ extension on FormData {
       sideSkirtKiriSelectedValue: sideSkirtKiriSelectedValue ?? this.sideSkirtKiriSelectedValue,
       sideSkirtKiriIsEnabled: sideSkirtKiriIsEnabled ?? this.sideSkirtKiriIsEnabled,
       eksteriorCatatanList: eksteriorCatatanList ?? this.eksteriorCatatanList,
+      banDepanSelectedValue: banDepanSelectedValue ?? this.banDepanSelectedValue,
+      banDepanIsEnabled: banDepanIsEnabled ?? this.banDepanIsEnabled,
+      velgDepanSelectedValue: velgDepanSelectedValue ?? this.velgDepanSelectedValue,
+      velgDepanIsEnabled: velgDepanIsEnabled ?? this.velgDepanIsEnabled,
+      discBrakeSelectedValue: discBrakeSelectedValue ?? this.discBrakeSelectedValue,
+      discBrakeIsEnabled: discBrakeIsEnabled ?? this.discBrakeIsEnabled,
+      masterRemSelectedValue: masterRemSelectedValue ?? this.masterRemSelectedValue,
+      masterRemIsEnabled: masterRemIsEnabled ?? this.masterRemIsEnabled,
+      tieRodSelectedValue: tieRodSelectedValue ?? this.tieRodSelectedValue,
+      tieRodIsEnabled: tieRodIsEnabled ?? this.tieRodIsEnabled,
+      gardanSelectedValue: gardanSelectedValue ?? this.gardanSelectedValue,
+      gardanIsEnabled: gardanIsEnabled ?? this.gardanIsEnabled,
+      banBelakangSelectedValue: banBelakangSelectedValue ?? this.banBelakangSelectedValue,
+      banBelakangIsEnabled: banBelakangIsEnabled ?? this.banBelakangIsEnabled,
+      velgBelakangSelectedValue: velgBelakangSelectedValue ?? this.velgBelakangSelectedValue,
+      velgBelakangIsEnabled: velgBelakangIsEnabled ?? this.velgBelakangIsEnabled,
+      brakePadSelectedValue: brakePadSelectedValue ?? this.brakePadSelectedValue,
+      brakePadIsEnabled: brakePadIsEnabled ?? this.brakePadIsEnabled,
+      crossmemberSelectedValue: crossmemberSelectedValue ?? this.crossmemberSelectedValue,
+      crossmemberIsEnabled: crossmemberIsEnabled ?? this.crossmemberIsEnabled,
+      knalpotSelectedValue: knalpotSelectedValue ?? this.knalpotSelectedValue,
+      knalpotIsEnabled: knalpotIsEnabled ?? this.knalpotIsEnabled,
+      balljointSelectedValue: balljointSelectedValue ?? this.balljointSelectedValue,
+      balljointIsEnabled: balljointIsEnabled ?? this.balljointIsEnabled,
+      rocksteerSelectedValue: rocksteerSelectedValue ?? this.rocksteerSelectedValue,
+      rocksteerIsEnabled: rocksteerIsEnabled ?? this.rocksteerIsEnabled,
+      karetBootSelectedValue: karetBootSelectedValue ?? this.karetBootSelectedValue,
+      karetBootIsEnabled: karetBootIsEnabled ?? this.karetBootIsEnabled,
+      upperLowerArmSelectedValue: upperLowerArmSelectedValue ?? this.upperLowerArmSelectedValue,
+      upperLowerArmIsEnabled: upperLowerArmIsEnabled ?? this.upperLowerArmIsEnabled,
+      shockBreakerSelectedValue: shockBreakerSelectedValue ?? this.shockBreakerSelectedValue,
+      shockBreakerIsEnabled: shockBreakerIsEnabled ?? this.shockBreakerIsEnabled,
+      linkStabilizerSelectedValue: linkStabilizerSelectedValue ?? this.linkStabilizerSelectedValue,
+      linkStabilizerIsEnabled: linkStabilizerIsEnabled ?? this.linkStabilizerIsEnabled,
+      banDanKakiKakiCatatanList: banDanKakiKakiCatatanList ?? this.banDanKakiKakiCatatanList,
     );
   }
 }

--- a/lib/providers/form_provider.dart
+++ b/lib/providers/form_provider.dart
@@ -131,24 +131,24 @@ class FormNotifier extends StateNotifier<FormData> {
   }
 
   // New update methods for selected indices
-  void updateInteriorSelectedIndex(int index) {
-    state = state.copyWith(interiorSelectedIndex: index);
+  void updateInteriorSelectedValue(int value) {
+    state = state.copyWith(interiorSelectedValue: value);
   }
 
-  void updateEksteriorSelectedIndex(int index) {
-    state = state.copyWith(eksteriorSelectedIndex: index);
+  void updateEksteriorSelectedValue(int value) {
+    state = state.copyWith(eksteriorSelectedValue: value);
   }
 
-  void updateKakiKakiSelectedIndex(int index) {
-    state = state.copyWith(kakiKakiSelectedIndex: index);
+  void updateKakiKakiSelectedValue(int value) {
+    state = state.copyWith(kakiKakiSelectedValue: value);
   }
 
-  void updateMesinSelectedIndex(int index) {
-    state = state.copyWith(mesinSelectedIndex: index);
+  void updateMesinSelectedValue(int value) {
+    state = state.copyWith(mesinSelectedValue: value);
   }
 
-  void updatePenilaianKeseluruhanSelectedIndex(int index) {
-    state = state.copyWith(penilaianKeseluruhanSelectedIndex: index);
+  void updatePenilaianKeseluruhanSelectedValue(int value) {
+    state = state.copyWith(penilaianKeseluruhanSelectedValue: value);
   }
 
   // NEW: Update methods for ExpandableTextField data
@@ -173,32 +173,32 @@ class FormNotifier extends StateNotifier<FormData> {
   }
 
   // New update methods for Page Five One
-  void updateAirbagSelectedIndex(int? index) {
-    state = state.copyWith(airbagSelectedIndex: index);
+  void updateAirbagSelectedValue(int? value) {
+    state = state.copyWith(airbagSelectedValue: value);
   }
 
   void updateAirbagIsEnabled(bool? enabled) {
     state = state.copyWith(airbagIsEnabled: enabled);
   }
 
-  void updateSistemAudioSelectedIndex(int? index) {
-    state = state.copyWith(sistemAudioSelectedIndex: index);
+  void updateSistemAudioSelectedValue(int? value) {
+    state = state.copyWith(sistemAudioSelectedValue: value);
   }
 
   void updateSistemAudioIsEnabled(bool? enabled) {
     state = state.copyWith(sistemAudioIsEnabled: enabled);
   }
 
-  void updatePowerWindowSelectedIndex(int? index) {
-    state = state.copyWith(powerWindowSelectedIndex: index);
+  void updatePowerWindowSelectedValue(int? value) {
+    state = state.copyWith(powerWindowSelectedValue: value);
   }
 
   void updatePowerWindowIsEnabled(bool? enabled) {
     state = state.copyWith(powerWindowIsEnabled: enabled);
   }
 
-  void updateSistemAcSelectedIndex(int? index) {
-    state = state.copyWith(sistemAcSelectedIndex: index);
+  void updateSistemAcSelectedValue(int? value) {
+    state = state.copyWith(sistemAcSelectedValue: value);
   }
 
   void updateSistemAcIsEnabled(bool? enabled) {
@@ -210,216 +210,216 @@ class FormNotifier extends StateNotifier<FormData> {
   }
 
   // New update methods for Page Five Two
-  void updateGetaranMesinSelectedIndex(int? index) {
-    state = state.copyWith(getaranMesinSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateGetaranMesinSelectedValue(int? value) {
+    state = state.copyWith(getaranMesinSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateGetaranMesinIsEnabled(bool? enabled) {
     state = state.copyWith(getaranMesinIsEnabled: enabled);
   }
 
-  void updateSuaraMesinSelectedIndex(int? index) {
-    state = state.copyWith(suaraMesinSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateSuaraMesinSelectedValue(int? value) {
+    state = state.copyWith(suaraMesinSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateSuaraMesinIsEnabled(bool? enabled) {
     state = state.copyWith(suaraMesinIsEnabled: enabled);
   }
 
-  void updateTransmisiSelectedIndex(int? index) {
-    state = state.copyWith(transmisiSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateTransmisiSelectedValue(int? value) {
+    state = state.copyWith(transmisiSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateTransmisiIsEnabled(bool? enabled) {
     state = state.copyWith(transmisiIsEnabled: enabled);
   }
 
-  void updatePompaPowerSteeringSelectedIndex(int? index) {
-    state = state.copyWith(pompaPowerSteeringSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updatePompaPowerSteeringSelectedValue(int? value) {
+    state = state.copyWith(pompaPowerSteeringSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updatePompaPowerSteeringIsEnabled(bool? enabled) {
     state = state.copyWith(pompaPowerSteeringIsEnabled: enabled);
   }
 
-  void updateCoverTimingChainSelectedIndex(int? index) {
-    state = state.copyWith(coverTimingChainSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateCoverTimingChainSelectedValue(int? value) {
+    state = state.copyWith(coverTimingChainSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateCoverTimingChainIsEnabled(bool? enabled) {
     state = state.copyWith(coverTimingChainIsEnabled: enabled);
   }
 
-  void updateOliPowerSteeringSelectedIndex(int? index) {
-    state = state.copyWith(oliPowerSteeringSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateOliPowerSteeringSelectedValue(int? value) {
+    state = state.copyWith(oliPowerSteeringSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateOliPowerSteeringIsEnabled(bool? enabled) {
     state = state.copyWith(oliPowerSteeringIsEnabled: enabled);
   }
 
-  void updateAccuSelectedIndex(int? index) {
-    state = state.copyWith(accuSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateAccuSelectedValue(int? value) {
+    state = state.copyWith(accuSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateAccuIsEnabled(bool? enabled) {
     state = state.copyWith(accuIsEnabled: enabled);
   }
 
-  void updateKompressorAcSelectedIndex(int? index) {
-    state = state.copyWith(kompressorAcSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateKompressorAcSelectedValue(int? value) {
+    state = state.copyWith(kompressorAcSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateKompressorAcIsEnabled(bool? enabled) {
     state = state.copyWith(kompressorAcIsEnabled: enabled);
   }
 
-  void updateFanSelectedIndex(int? index) {
-    state = state.copyWith(fanSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateFanSelectedValue(int? value) {
+    state = state.copyWith(fanSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateFanIsEnabled(bool? enabled) {
     state = state.copyWith(fanIsEnabled: enabled);
   }
 
-  void updateSelangSelectedIndex(int? index) {
-    state = state.copyWith(selangSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateSelangSelectedValue(int? value) {
+    state = state.copyWith(selangSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateSelangIsEnabled(bool? enabled) {
     state = state.copyWith(selangIsEnabled: enabled);
   }
 
-  void updateKarterOliSelectedIndex(int? index) {
-    state = state.copyWith(karterOliSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateKarterOliSelectedValue(int? value) {
+    state = state.copyWith(karterOliSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateKarterOliIsEnabled(bool? enabled) {
     state = state.copyWith(karterOliIsEnabled: enabled);
   }
 
-  void updateOilRemSelectedIndex(int? index) {
-    state = state.copyWith(oilRemSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateOilRemSelectedValue(int? value) {
+    state = state.copyWith(oilRemSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateOilRemIsEnabled(bool? enabled) {
     state = state.copyWith(oilRemIsEnabled: enabled);
   }
 
-  void updateKabelSelectedIndex(int? index) {
-    state = state.copyWith(kabelSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateKabelSelectedValue(int? value) {
+    state = state.copyWith(kabelSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateKabelIsEnabled(bool? enabled) {
     state = state.copyWith(kabelIsEnabled: enabled);
   }
 
-  void updateKondensorSelectedIndex(int? index) {
-    state = state.copyWith(kondensorSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateKondensorSelectedValue(int? value) {
+    state = state.copyWith(kondensorSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateKondensorIsEnabled(bool? enabled) {
     state = state.copyWith(kondensorIsEnabled: enabled);
   }
 
-  void updateRadiatorSelectedIndex(int? index) {
-    state = state.copyWith(radiatorSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateRadiatorSelectedValue(int? value) {
+    state = state.copyWith(radiatorSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateRadiatorIsEnabled(bool? enabled) {
     state = state.copyWith(radiatorIsEnabled: enabled);
   }
 
-  void updateCylinderHeadSelectedIndex(int? index) {
-    state = state.copyWith(cylinderHeadSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateCylinderHeadSelectedValue(int? value) {
+    state = state.copyWith(cylinderHeadSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateCylinderHeadIsEnabled(bool? enabled) {
     state = state.copyWith(cylinderHeadIsEnabled: enabled);
   }
 
-  void updateOliMesinSelectedIndex(int? index) {
-    state = state.copyWith(oliMesinSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateOliMesinSelectedValue(int? value) {
+    state = state.copyWith(oliMesinSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateOliMesinIsEnabled(bool? enabled) {
     state = state.copyWith(oliMesinIsEnabled: enabled);
   }
 
-  void updateAirRadiatorSelectedIndex(int? index) {
-    state = state.copyWith(airRadiatorSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateAirRadiatorSelectedValue(int? value) {
+    state = state.copyWith(airRadiatorSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateAirRadiatorIsEnabled(bool? enabled) {
     state = state.copyWith(airRadiatorIsEnabled: enabled);
   }
 
-  void updateCoverKlepSelectedIndex(int? index) {
-    state = state.copyWith(coverKlepSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateCoverKlepSelectedValue(int? value) {
+    state = state.copyWith(coverKlepSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateCoverKlepIsEnabled(bool? enabled) {
     state = state.copyWith(coverKlepIsEnabled: enabled);
   }
 
-  void updateAlternatorSelectedIndex(int? index) {
-    state = state.copyWith(alternatorSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateAlternatorSelectedValue(int? value) {
+    state = state.copyWith(alternatorSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateAlternatorIsEnabled(bool? enabled) {
     state = state.copyWith(alternatorIsEnabled: enabled);
   }
 
-  void updateWaterPumpSelectedIndex(int? index) {
-    state = state.copyWith(waterPumpSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateWaterPumpSelectedValue(int? value) {
+    state = state.copyWith(waterPumpSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateWaterPumpIsEnabled(bool? enabled) {
     state = state.copyWith(waterPumpIsEnabled: enabled);
   }
 
-  void updateBeltSelectedIndex(int? index) {
-    state = state.copyWith(beltSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateBeltSelectedValue(int? value) {
+    state = state.copyWith(beltSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateBeltIsEnabled(bool? enabled) {
     state = state.copyWith(beltIsEnabled: enabled);
   }
 
-  void updateOliTransmisiSelectedIndex(int? index) {
-    state = state.copyWith(oliTransmisiSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateOliTransmisiSelectedValue(int? value) {
+    state = state.copyWith(oliTransmisiSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateOliTransmisiIsEnabled(bool? enabled) {
     state = state.copyWith(oliTransmisiIsEnabled: enabled);
   }
 
-  void updateCylinderBlockSelectedIndex(int? index) {
-    state = state.copyWith(cylinderBlockSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateCylinderBlockSelectedValue(int? value) {
+    state = state.copyWith(cylinderBlockSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateCylinderBlockIsEnabled(bool? enabled) {
     state = state.copyWith(cylinderBlockIsEnabled: enabled);
   }
 
-  void updateBushingBesarSelectedIndex(int? index) {
-    state = state.copyWith(bushingBesarSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateBushingBesarSelectedValue(int? value) {
+    state = state.copyWith(bushingBesarSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateBushingBesarIsEnabled(bool? enabled) {
     state = state.copyWith(bushingBesarIsEnabled: enabled);
   }
 
-  void updateBushingKecilSelectedIndex(int? index) {
-    state = state.copyWith(bushingKecilSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateBushingKecilSelectedValue(int? value) {
+    state = state.copyWith(bushingKecilSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateBushingKecilIsEnabled(bool? enabled) {
     state = state.copyWith(bushingKecilIsEnabled: enabled);
   }
 
-  void updateTutupRadiatorSelectedIndex(int? index) {
-    state = state.copyWith(tutupRadiatorSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateTutupRadiatorSelectedValue(int? value) {
+    state = state.copyWith(tutupRadiatorSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateTutupRadiatorIsEnabled(bool? enabled) {
@@ -431,192 +431,192 @@ class FormNotifier extends StateNotifier<FormData> {
   }
 
   // New update methods for Page Five Three
-  void updateStirSelectedIndex(int? index) {
-    state = state.copyWith(stirSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateStirSelectedValue(int? value) {
+    state = state.copyWith(stirSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateStirIsEnabled(bool? enabled) {
     state = state.copyWith(stirIsEnabled: enabled);
   }
 
-  void updateRemTonganSelectedIndex(int? index) {
-    state = state.copyWith(remTonganSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateRemTonganSelectedValue(int? value) {
+    state = state.copyWith(remTonganSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateRemTonganIsEnabled(bool? enabled) {
     state = state.copyWith(remTonganIsEnabled: enabled);
   }
 
-  void updatePedalSelectedIndex(int? index) {
-    state = state.copyWith(pedalSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updatePedalSelectedValue(int? value) {
+    state = state.copyWith(pedalSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updatePedalIsEnabled(bool? enabled) {
     state = state.copyWith(pedalIsEnabled: enabled);
   }
 
-  void updateSwitchWiperSelectedIndex(int? index) {
-    state = state.copyWith(switchWiperSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateSwitchWiperSelectedValue(int? value) {
+    state = state.copyWith(switchWiperSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateSwitchWiperIsEnabled(bool? enabled) {
     state = state.copyWith(switchWiperIsEnabled: enabled);
   }
 
-  void updateLampuHazardSelectedIndex(int? index) {
-    state = state.copyWith(lampuHazardSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateLampuHazardSelectedValue(int? value) {
+    state = state.copyWith(lampuHazardSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateLampuHazardIsEnabled(bool? enabled) {
     state = state.copyWith(lampuHazardIsEnabled: enabled);
   }
 
-  void updatePanelDashboardSelectedIndex(int? index) {
-    state = state.copyWith(panelDashboardSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updatePanelDashboardSelectedValue(int? value) {
+    state = state.copyWith(panelDashboardSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updatePanelDashboardIsEnabled(bool? enabled) {
     state = state.copyWith(panelDashboardIsEnabled: enabled);
   }
 
-  void updatePembukaKapMesinSelectedIndex(int? index) {
-    state = state.copyWith(pembukaKapMesinSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updatePembukaKapMesinSelectedValue(int? value) {
+    state = state.copyWith(pembukaKapMesinSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updatePembukaKapMesinIsEnabled(bool? enabled) {
     state = state.copyWith(pembukaKapMesinIsEnabled: enabled);
   }
 
-  void updatePembukaBagasiSelectedIndex(int? index) {
-    state = state.copyWith(pembukaBagasiSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updatePembukaBagasiSelectedValue(int? value) {
+    state = state.copyWith(pembukaBagasiSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updatePembukaBagasiIsEnabled(bool? enabled) {
     state = state.copyWith(pembukaBagasiIsEnabled: enabled);
   }
 
-  void updateJokDepanSelectedIndex(int? index) {
-    state = state.copyWith(jokDepanSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateJokDepanSelectedValue(int? value) {
+    state = state.copyWith(jokDepanSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateJokDepanIsEnabled(bool? enabled) {
     state = state.copyWith(jokDepanIsEnabled: enabled);
   }
 
-  void updateAromaInteriorSelectedIndex(int? index) {
-    state = state.copyWith(aromaInteriorSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateAromaInteriorSelectedValue(int? value) {
+    state = state.copyWith(aromaInteriorSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateAromaInteriorIsEnabled(bool? enabled) {
     state = state.copyWith(aromaInteriorIsEnabled: enabled);
   }
 
-  void updateHandlePintuSelectedIndex(int? index) {
-    state = state.copyWith(handlePintuSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateHandlePintuSelectedValue(int? value) {
+    state = state.copyWith(handlePintuSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateHandlePintuIsEnabled(bool? enabled) {
     state = state.copyWith(handlePintuIsEnabled: enabled);
   }
 
-  void updateConsoleBoxSelectedIndex(int? index) {
-    state = state.copyWith(consoleBoxSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateConsoleBoxSelectedValue(int? value) {
+    state = state.copyWith(consoleBoxSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateConsoleBoxIsEnabled(bool? enabled) {
     state = state.copyWith(consoleBoxIsEnabled: enabled);
   }
 
-  void updateSpionTengahSelectedIndex(int? index) {
-    state = state.copyWith(spionTengahSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateSpionTengahSelectedValue(int? value) {
+    state = state.copyWith(spionTengahSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateSpionTengahIsEnabled(bool? enabled) {
     state = state.copyWith(spionTengahIsEnabled: enabled);
   }
 
-  void updateTuasPersnelingSelectedIndex(int? index) {
-    state = state.copyWith(tuasPersnelingSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateTuasPersnelingSelectedValue(int? value) {
+    state = state.copyWith(tuasPersnelingSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateTuasPersnelingIsEnabled(bool? enabled) {
     state = state.copyWith(tuasPersnelingIsEnabled: enabled);
   }
 
-  void updateJokBelakangSelectedIndex(int? index) {
-    state = state.copyWith(jokBelakangSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateJokBelakangSelectedValue(int? value) {
+    state = state.copyWith(jokBelakangSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateJokBelakangIsEnabled(bool? enabled) {
     state = state.copyWith(jokBelakangIsEnabled: enabled);
   }
 
-  void updatePanelIndikatorSelectedIndex(int? index) {
-    state = state.copyWith(panelIndikatorSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updatePanelIndikatorSelectedValue(int? value) {
+    state = state.copyWith(panelIndikatorSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updatePanelIndikatorIsEnabled(bool? enabled) {
     state = state.copyWith(panelIndikatorIsEnabled: enabled);
   }
 
-  void updateSwitchLampuSelectedIndex(int? index) {
-    state = state.copyWith(switchLampuSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateSwitchLampuSelectedValue(int? value) {
+    state = state.copyWith(switchLampuSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateSwitchLampuIsEnabled(bool? enabled) {
     state = state.copyWith(switchLampuIsEnabled: enabled);
   }
 
-  void updateKarpetDasarSelectedIndex(int? index) {
-    state = state.copyWith(karpetDasarSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateKarpetDasarSelectedValue(int? value) {
+    state = state.copyWith(karpetDasarSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateKarpetDasarIsEnabled(bool? enabled) {
     state = state.copyWith(karpetDasarIsEnabled: enabled);
   }
 
-  void updateKlaksonSelectedIndex(int? index) {
-    state = state.copyWith(klaksonSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateKlaksonSelectedValue(int? value) {
+    state = state.copyWith(klaksonSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateKlaksonIsEnabled(bool? enabled) {
     state = state.copyWith(klaksonIsEnabled: enabled);
   }
 
-  void updateSunVisorSelectedIndex(int? index) {
-    state = state.copyWith(sunVisorSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateSunVisorSelectedValue(int? value) {
+    state = state.copyWith(sunVisorSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateSunVisorIsEnabled(bool? enabled) {
     state = state.copyWith(sunVisorIsEnabled: enabled);
   }
 
-  void updateTuasTangkiBensinSelectedIndex(int? index) {
-    state = state.copyWith(tuasTangkiBensinSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateTuasTangkiBensinSelectedValue(int? value) {
+    state = state.copyWith(tuasTangkiBensinSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateTuasTangkiBensinIsEnabled(bool? enabled) {
     state = state.copyWith(tuasTangkiBensinIsEnabled: enabled);
   }
 
-  void updateSabukPengamanSelectedIndex(int? index) {
-    state = state.copyWith(sabukPengamanSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateSabukPengamanSelectedValue(int? value) {
+    state = state.copyWith(sabukPengamanSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateSabukPengamanIsEnabled(bool? enabled) {
     state = state.copyWith(sabukPengamanIsEnabled: enabled);
   }
 
-  void updateTrimInteriorSelectedIndex(int? index) {
-    state = state.copyWith(trimInteriorSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateTrimInteriorSelectedValue(int? value) {
+    state = state.copyWith(trimInteriorSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateTrimInteriorIsEnabled(bool? enabled) {
     state = state.copyWith(trimInteriorIsEnabled: enabled);
   }
 
-  void updatePlafonSelectedIndex(int? index) {
-    state = state.copyWith(plafonSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updatePlafonSelectedValue(int? value) {
+    state = state.copyWith(plafonSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updatePlafonIsEnabled(bool? enabled) {
@@ -628,240 +628,240 @@ class FormNotifier extends StateNotifier<FormData> {
   }
 
   // New update methods for Page Five Four
-  void updateBumperDepanSelectedIndex(int? index) {
-    state = state.copyWith(bumperDepanSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateBumperDepanSelectedValue(int? value) {
+    state = state.copyWith(bumperDepanSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateBumperDepanIsEnabled(bool? enabled) {
     state = state.copyWith(bumperDepanIsEnabled: enabled);
   }
 
-  void updateKapMesinSelectedIndex(int? index) {
-    state = state.copyWith(kapMesinSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateKapMesinSelectedValue(int? value) {
+    state = state.copyWith(kapMesinSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateKapMesinIsEnabled(bool? enabled) {
     state = state.copyWith(kapMesinIsEnabled: enabled);
   }
 
-  void updateLampuUtamaSelectedIndex(int? index) {
-    state = state.copyWith(lampuUtamaSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateLampuUtamaSelectedValue(int? value) {
+    state = state.copyWith(lampuUtamaSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateLampuUtamaIsEnabled(bool? enabled) {
     state = state.copyWith(lampuUtamaIsEnabled: enabled);
   }
 
-  void updatePanelAtapSelectedIndex(int? index) {
-    state = state.copyWith(panelAtapSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updatePanelAtapSelectedValue(int? value) {
+    state = state.copyWith(panelAtapSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updatePanelAtapIsEnabled(bool? enabled) {
     state = state.copyWith(panelAtapIsEnabled: enabled);
   }
 
-  void updateGrillSelectedIndex(int? index) {
-    state = state.copyWith(grillSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateGrillSelectedValue(int? value) {
+    state = state.copyWith(grillSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateGrillIsEnabled(bool? enabled) {
     state = state.copyWith(grillIsEnabled: enabled);
   }
 
-  void updateLampuFoglampSelectedIndex(int? index) {
-    state = state.copyWith(lampuFoglampSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateLampuFoglampSelectedValue(int? value) {
+    state = state.copyWith(lampuFoglampSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateLampuFoglampIsEnabled(bool? enabled) {
     state = state.copyWith(lampuFoglampIsEnabled: enabled);
   }
 
-  void updateKacaBeningSelectedIndex(int? index) {
-    state = state.copyWith(kacaBeningSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateKacaBeningSelectedValue(int? value) {
+    state = state.copyWith(kacaBeningSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateKacaBeningIsEnabled(bool? enabled) {
     state = state.copyWith(kacaBeningIsEnabled: enabled);
   }
 
-  void updateWiperBelakangSelectedIndex(int? index) {
-    state = state.copyWith(wiperBelakangSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateWiperBelakangSelectedValue(int? value) {
+    state = state.copyWith(wiperBelakangSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateWiperBelakangIsEnabled(bool? enabled) {
     state = state.copyWith(wiperBelakangIsEnabled: enabled);
   }
 
-  void updateBumperBelakangSelectedIndex(int? index) {
-    state = state.copyWith(bumperBelakangSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateBumperBelakangSelectedValue(int? value) {
+    state = state.copyWith(bumperBelakangSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateBumperBelakangIsEnabled(bool? enabled) {
     state = state.copyWith(bumperBelakangIsEnabled: enabled);
   }
 
-  void updateLampuBelakangSelectedIndex(int? index) {
-    state = state.copyWith(lampuBelakangSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateLampuBelakangSelectedValue(int? value) {
+    state = state.copyWith(lampuBelakangSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateLampuBelakangIsEnabled(bool? enabled) {
     state = state.copyWith(lampuBelakangIsEnabled: enabled);
   }
 
-  void updateTrunklidSelectedIndex(int? index) {
-    state = state.copyWith(trunklidSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateTrunklidSelectedValue(int? value) {
+    state = state.copyWith(trunklidSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateTrunklidIsEnabled(bool? enabled) {
     state = state.copyWith(trunklidIsEnabled: enabled);
   }
 
-  void updateKacaDepanSelectedIndex(int? index) {
-    state = state.copyWith(kacaDepanSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateKacaDepanSelectedValue(int? value) {
+    state = state.copyWith(kacaDepanSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateKacaDepanIsEnabled(bool? enabled) {
     state = state.copyWith(kacaDepanIsEnabled: enabled);
   }
 
-  void updateFenderKananSelectedIndex(int? index) {
-    state = state.copyWith(fenderKananSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateFenderKananSelectedValue(int? value) {
+    state = state.copyWith(fenderKananSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateFenderKananIsEnabled(bool? enabled) {
     state = state.copyWith(fenderKananIsEnabled: enabled);
   }
 
-  void updateQuarterPanelKananSelectedIndex(int? index) {
-    state = state.copyWith(quarterPanelKananSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateQuarterPanelKananSelectedValue(int? value) {
+    state = state.copyWith(quarterPanelKananSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateQuarterPanelKananIsEnabled(bool? enabled) {
     state = state.copyWith(quarterPanelKananIsEnabled: enabled);
   }
 
-  void updatePintuBelakangKananSelectedIndex(int? index) {
-    state = state.copyWith(pintuBelakangKananSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updatePintuBelakangKananSelectedValue(int? value) {
+    state = state.copyWith(pintuBelakangKananSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updatePintuBelakangKananIsEnabled(bool? enabled) {
     state = state.copyWith(pintuBelakangKananIsEnabled: enabled);
   }
 
-  void updateSpionKananSelectedIndex(int? index) {
-    state = state.copyWith(spionKananSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateSpionKananSelectedValue(int? value) {
+    state = state.copyWith(spionKananSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateSpionKananIsEnabled(bool? enabled) {
     state = state.copyWith(spionKananIsEnabled: enabled);
   }
 
-  void updateLisplangKananSelectedIndex(int? index) {
-    state = state.copyWith(lisplangKananSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateLisplangKananSelectedValue(int? value) {
+    state = state.copyWith(lisplangKananSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateLisplangKananIsEnabled(bool? enabled) {
     state = state.copyWith(lisplangKananIsEnabled: enabled);
   }
 
-  void updateSideSkirtKananSelectedIndex(int? index) {
-    state = state.copyWith(sideSkirtKananSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateSideSkirtKananSelectedValue(int? value) {
+    state = state.copyWith(sideSkirtKananSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateSideSkirtKananIsEnabled(bool? enabled) {
     state = state.copyWith(sideSkirtKananIsEnabled: enabled);
   }
 
-  void updateDaunWiperSelectedIndex(int? index) {
-    state = state.copyWith(daunWiperSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateDaunWiperSelectedValue(int? value) {
+    state = state.copyWith(daunWiperSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateDaunWiperIsEnabled(bool? enabled) {
     state = state.copyWith(daunWiperIsEnabled: enabled);
   }
 
-  void updatePintuBelakangSelectedIndex(int? index) {
-    state = state.copyWith(pintuBelakangSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updatePintuBelakangSelectedValue(int? value) {
+    state = state.copyWith(pintuBelakangSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updatePintuBelakangIsEnabled(bool? enabled) {
     state = state.copyWith(pintuBelakangIsEnabled: enabled);
   }
 
-  void updateFenderKiriSelectedIndex(int? index) {
-    state = state.copyWith(fenderKiriSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateFenderKiriSelectedValue(int? value) {
+    state = state.copyWith(fenderKiriSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateFenderKiriIsEnabled(bool? enabled) {
     state = state.copyWith(fenderKiriIsEnabled: enabled);
   }
 
-  void updateQuarterPanelKiriSelectedIndex(int? index) {
-    state = state.copyWith(quarterPanelKiriSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateQuarterPanelKiriSelectedValue(int? value) {
+    state = state.copyWith(quarterPanelKiriSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateQuarterPanelKiriIsEnabled(bool? enabled) {
     state = state.copyWith(quarterPanelKiriIsEnabled: enabled);
   }
 
-  void updatePintuDepanSelectedIndex(int? index) {
-    state = state.copyWith(pintuDepanSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updatePintuDepanSelectedValue(int? value) {
+    state = state.copyWith(pintuDepanSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updatePintuDepanIsEnabled(bool? enabled) {
     state = state.copyWith(pintuDepanIsEnabled: enabled);
   }
 
-  void updateKacaJendelaKananSelectedIndex(int? index) {
-    state = state.copyWith(kacaJendelaKananSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateKacaJendelaKananSelectedValue(int? value) {
+    state = state.copyWith(kacaJendelaKananSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateKacaJendelaKananIsEnabled(bool? enabled) {
     state = state.copyWith(kacaJendelaKananIsEnabled: enabled);
   }
 
-  void updatePintuBelakangKiriSelectedIndex(int? index) {
-    state = state.copyWith(pintuBelakangKiriSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updatePintuBelakangKiriSelectedValue(int? value) {
+    state = state.copyWith(pintuBelakangKiriSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updatePintuBelakangKiriIsEnabled(bool? enabled) {
     state = state.copyWith(pintuBelakangKiriIsEnabled: enabled);
   }
 
-  void updateSpionKiriSelectedIndex(int? index) {
-    state = state.copyWith(spionKiriSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateSpionKiriSelectedValue(int? value) {
+    state = state.copyWith(spionKiriSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateSpionKiriIsEnabled(bool? enabled) {
     state = state.copyWith(spionKiriIsEnabled: enabled);
   }
 
-  void updatePintuDepanKiriSelectedIndex(int? index) {
-    state = state.copyWith(pintuDepanKiriSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updatePintuDepanKiriSelectedValue(int? value) {
+    state = state.copyWith(pintuDepanKiriSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updatePintuDepanKiriIsEnabled(bool? enabled) {
     state = state.copyWith(pintuDepanKiriIsEnabled: enabled);
   }
 
-  void updateKacaJendelaKiriSelectedIndex(int? index) {
-    state = state.copyWith(kacaJendelaKiriSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateKacaJendelaKiriSelectedValue(int? value) {
+    state = state.copyWith(kacaJendelaKiriSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateKacaJendelaKiriIsEnabled(bool? enabled) {
     state = state.copyWith(kacaJendelaKiriIsEnabled: enabled);
   }
 
-  void updateLisplangKiriSelectedIndex(int? index) {
-    state = state.copyWith(lisplangKiriSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateLisplangKiriSelectedValue(int? value) {
+    state = state.copyWith(lisplangKiriSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateLisplangKiriIsEnabled(bool? enabled) {
     state = state.copyWith(lisplangKiriIsEnabled: enabled);
   }
 
-  void updateSideSkirtKiriSelectedIndex(int? index) {
-    state = state.copyWith(sideSkirtKiriSelectedIndex: (index == null || index <= 0) ? 0 : index);
+  void updateSideSkirtKiriSelectedValue(int? value) {
+    state = state.copyWith(sideSkirtKiriSelectedValue: (value == null || value <= 0) ? 0 : value);
   }
 
   void updateSideSkirtKiriIsEnabled(bool? enabled) {
@@ -914,189 +914,189 @@ extension on FormData {
     String? merk,
     String? tipeVelg,
     String? ketebalan,
-    int? interiorSelectedIndex,
-    int? eksteriorSelectedIndex,
-    int? kakiKakiSelectedIndex,
-    int? mesinSelectedIndex,
-    int? penilaianKeseluruhanSelectedIndex,
+    int? interiorSelectedValue,
+    int? eksteriorSelectedValue,
+    int? kakiKakiSelectedValue,
+    int? mesinSelectedValue,
+    int? penilaianKeseluruhanSelectedValue,
     List<String>? keteranganInterior,
     List<String>? keteranganEksterior,
     List<String>? keteranganKakiKaki,
     List<String>? keteranganMesin,
     List<String>? deskripsiKeseluruhan,
     List<Map<String, String>>? repairEstimations,
-    int? airbagSelectedIndex,
+    int? airbagSelectedValue,
     bool? airbagIsEnabled,
-    int? sistemAudioSelectedIndex,
+    int? sistemAudioSelectedValue,
     bool? sistemAudioIsEnabled,
-    int? powerWindowSelectedIndex,
+    int? powerWindowSelectedValue,
     bool? powerWindowIsEnabled,
-    int? sistemAcSelectedIndex,
+    int? sistemAcSelectedValue,
     bool? sistemAcIsEnabled,
     List<String>? fiturCatatanList,
-    int? getaranMesinSelectedIndex,
+    int? getaranMesinSelectedValue,
     bool? getaranMesinIsEnabled,
-    int? suaraMesinSelectedIndex,
+    int? suaraMesinSelectedValue,
     bool? suaraMesinIsEnabled,
-    int? transmisiSelectedIndex,
+    int? transmisiSelectedValue,
     bool? transmisiIsEnabled,
-    int? pompaPowerSteeringSelectedIndex,
+    int? pompaPowerSteeringSelectedValue,
     bool? pompaPowerSteeringIsEnabled,
-    int? coverTimingChainSelectedIndex,
+    int? coverTimingChainSelectedValue,
     bool? coverTimingChainIsEnabled,
-    int? oliPowerSteeringSelectedIndex,
+    int? oliPowerSteeringSelectedValue,
     bool? oliPowerSteeringIsEnabled,
-    int? accuSelectedIndex,
+    int? accuSelectedValue,
     bool? accuIsEnabled,
-    int? kompressorAcSelectedIndex,
+    int? kompressorAcSelectedValue,
     bool? kompressorAcIsEnabled,
-    int? fanSelectedIndex,
+    int? fanSelectedValue,
     bool? fanIsEnabled,
-    int? selangSelectedIndex,
+    int? selangSelectedValue,
     bool? selangIsEnabled,
-    int? karterOliSelectedIndex,
+    int? karterOliSelectedValue,
     bool? karterOliIsEnabled,
-    int? oilRemSelectedIndex,
+    int? oilRemSelectedValue,
     bool? oilRemIsEnabled,
-    int? kabelSelectedIndex,
+    int? kabelSelectedValue,
     bool? kabelIsEnabled,
-    int? kondensorSelectedIndex,
+    int? kondensorSelectedValue,
     bool? kondensorIsEnabled,
-    int? radiatorSelectedIndex,
+    int? radiatorSelectedValue,
     bool? radiatorIsEnabled,
-    int? cylinderHeadSelectedIndex,
+    int? cylinderHeadSelectedValue,
     bool? cylinderHeadIsEnabled,
-    int? oliMesinSelectedIndex,
+    int? oliMesinSelectedValue,
     bool? oliMesinIsEnabled,
-    int? airRadiatorSelectedIndex,
+    int? airRadiatorSelectedValue,
     bool? airRadiatorIsEnabled,
-    int? coverKlepSelectedIndex,
+    int? coverKlepSelectedValue,
     bool? coverKlepIsEnabled,
-    int? alternatorSelectedIndex,
+    int? alternatorSelectedValue,
     bool? alternatorIsEnabled,
-    int? waterPumpSelectedIndex,
+    int? waterPumpSelectedValue,
     bool? waterPumpIsEnabled,
-    int? beltSelectedIndex,
+    int? beltSelectedValue,
     bool? beltIsEnabled,
-    int? oliTransmisiSelectedIndex,
+    int? oliTransmisiSelectedValue,
     bool? oliTransmisiIsEnabled,
-    int? cylinderBlockSelectedIndex,
+    int? cylinderBlockSelectedValue,
     bool? cylinderBlockIsEnabled,
-    int? bushingBesarSelectedIndex,
+    int? bushingBesarSelectedValue,
     bool? bushingBesarIsEnabled,
-    int? bushingKecilSelectedIndex,
+    int? bushingKecilSelectedValue,
     bool? bushingKecilIsEnabled,
-    int? tutupRadiatorSelectedIndex,
+    int? tutupRadiatorSelectedValue,
     bool? tutupRadiatorIsEnabled,
     List<String>? mesinCatatanList,
-    int? stirSelectedIndex,
+    int? stirSelectedValue,
     bool? stirIsEnabled,
-    int? remTonganSelectedIndex,
+    int? remTonganSelectedValue,
     bool? remTonganIsEnabled,
-    int? pedalSelectedIndex,
+    int? pedalSelectedValue,
     bool? pedalIsEnabled,
-    int? switchWiperSelectedIndex,
+    int? switchWiperSelectedValue,
     bool? switchWiperIsEnabled,
-    int? lampuHazardSelectedIndex,
+    int? lampuHazardSelectedValue,
     bool? lampuHazardIsEnabled,
-    int? panelDashboardSelectedIndex,
+    int? panelDashboardSelectedValue,
     bool? panelDashboardIsEnabled,
-    int? pembukaKapMesinSelectedIndex,
+    int? pembukaKapMesinSelectedValue,
     bool? pembukaKapMesinIsEnabled,
-    int? pembukaBagasiSelectedIndex,
+    int? pembukaBagasiSelectedValue,
     bool? pembukaBagasiIsEnabled,
-    int? jokDepanSelectedIndex,
+    int? jokDepanSelectedValue,
     bool? jokDepanIsEnabled,
-    int? aromaInteriorSelectedIndex,
+    int? aromaInteriorSelectedValue,
     bool? aromaInteriorIsEnabled,
-    int? handlePintuSelectedIndex,
+    int? handlePintuSelectedValue,
     bool? handlePintuIsEnabled,
-    int? consoleBoxSelectedIndex,
+    int? consoleBoxSelectedValue,
     bool? consoleBoxIsEnabled,
-    int? spionTengahSelectedIndex,
+    int? spionTengahSelectedValue,
     bool? spionTengahIsEnabled,
-    int? tuasPersnelingSelectedIndex,
+    int? tuasPersnelingSelectedValue,
     bool? tuasPersnelingIsEnabled,
-    int? jokBelakangSelectedIndex,
+    int? jokBelakangSelectedValue,
     bool? jokBelakangIsEnabled,
-    int? panelIndikatorSelectedIndex,
+    int? panelIndikatorSelectedValue,
     bool? panelIndikatorIsEnabled,
-    int? switchLampuSelectedIndex,
+    int? switchLampuSelectedValue,
     bool? switchLampuIsEnabled,
-    int? karpetDasarSelectedIndex,
+    int? karpetDasarSelectedValue,
     bool? karpetDasarIsEnabled,
-    int? klaksonSelectedIndex,
+    int? klaksonSelectedValue,
     bool? klaksonIsEnabled,
-    int? sunVisorSelectedIndex,
+    int? sunVisorSelectedValue,
     bool? sunVisorIsEnabled,
-    int? tuasTangkiBensinSelectedIndex,
+    int? tuasTangkiBensinSelectedValue,
     bool? tuasTangkiBensinIsEnabled,
-    int? sabukPengamanSelectedIndex,
+    int? sabukPengamanSelectedValue,
     bool? sabukPengamanIsEnabled,
-    int? trimInteriorSelectedIndex,
+    int? trimInteriorSelectedValue,
     bool? trimInteriorIsEnabled,
-    int? plafonSelectedIndex,
+    int? plafonSelectedValue,
     bool? plafonIsEnabled,
     List<String>? interiorCatatanList,
-    int? bumperDepanSelectedIndex,
+    int? bumperDepanSelectedValue,
     bool? bumperDepanIsEnabled,
-    int? kapMesinSelectedIndex,
+    int? kapMesinSelectedValue,
     bool? kapMesinIsEnabled,
-    int? lampuUtamaSelectedIndex,
+    int? lampuUtamaSelectedValue,
     bool? lampuUtamaIsEnabled,
-    int? panelAtapSelectedIndex,
+    int? panelAtapSelectedValue,
     bool? panelAtapIsEnabled,
-    int? grillSelectedIndex,
+    int? grillSelectedValue,
     bool? grillIsEnabled,
-    int? lampuFoglampSelectedIndex,
+    int? lampuFoglampSelectedValue,
     bool? lampuFoglampIsEnabled,
-    int? kacaBeningSelectedIndex,
+    int? kacaBeningSelectedValue,
     bool? kacaBeningIsEnabled,
-    int? wiperBelakangSelectedIndex,
+    int? wiperBelakangSelectedValue,
     bool? wiperBelakangIsEnabled,
-    int? bumperBelakangSelectedIndex,
+    int? bumperBelakangSelectedValue,
     bool? bumperBelakangIsEnabled,
-    int? lampuBelakangSelectedIndex,
+    int? lampuBelakangSelectedValue,
     bool? lampuBelakangIsEnabled,
-    int? trunklidSelectedIndex,
+    int? trunklidSelectedValue,
     bool? trunklidIsEnabled,
-    int? kacaDepanSelectedIndex,
+    int? kacaDepanSelectedValue,
     bool? kacaDepanIsEnabled,
-    int? fenderKananSelectedIndex,
+    int? fenderKananSelectedValue,
     bool? fenderKananIsEnabled,
-    int? quarterPanelKananSelectedIndex,
+    int? quarterPanelKananSelectedValue,
     bool? quarterPanelKananIsEnabled,
-    int? pintuBelakangKananSelectedIndex,
+    int? pintuBelakangKananSelectedValue,
     bool? pintuBelakangKananIsEnabled,
-    int? spionKananSelectedIndex,
+    int? spionKananSelectedValue,
     bool? spionKananIsEnabled,
-    int? lisplangKananSelectedIndex,
+    int? lisplangKananSelectedValue,
     bool? lisplangKananIsEnabled,
-    int? sideSkirtKananSelectedIndex,
+    int? sideSkirtKananSelectedValue,
     bool? sideSkirtKananIsEnabled,
-    int? daunWiperSelectedIndex,
+    int? daunWiperSelectedValue,
     bool? daunWiperIsEnabled,
-    int? pintuBelakangSelectedIndex,
+    int? pintuBelakangSelectedValue,
     bool? pintuBelakangIsEnabled,
-    int? fenderKiriSelectedIndex,
+    int? fenderKiriSelectedValue,
     bool? fenderKiriIsEnabled,
-    int? quarterPanelKiriSelectedIndex,
+    int? quarterPanelKiriSelectedValue,
     bool? quarterPanelKiriIsEnabled,
-    int? pintuDepanSelectedIndex,
+    int? pintuDepanSelectedValue,
     bool? pintuDepanIsEnabled,
-    int? kacaJendelaKananSelectedIndex,
+    int? kacaJendelaKananSelectedValue,
     bool? kacaJendelaKananIsEnabled,
-    int? pintuBelakangKiriSelectedIndex,
+    int? pintuBelakangKiriSelectedValue,
     bool? pintuBelakangKiriIsEnabled,
-    int? spionKiriSelectedIndex,
+    int? spionKiriSelectedValue,
     bool? spionKiriIsEnabled,
-    int? pintuDepanKiriSelectedIndex,
+    int? pintuDepanKiriSelectedValue,
     bool? pintuDepanKiriIsEnabled,
-    int? kacaJendelaKiriSelectedIndex,
+    int? kacaJendelaKiriSelectedValue,
     bool? kacaJendelaKiriIsEnabled,
-    int? lisplangKiriSelectedIndex,
+    int? lisplangKiriSelectedValue,
     bool? lisplangKiriIsEnabled,
-    int? sideSkirtKiriSelectedIndex,
+    int? sideSkirtKiriSelectedValue,
     bool? sideSkirtKiriIsEnabled,
     List<String>? eksteriorCatatanList,
   }) {
@@ -1132,189 +1132,189 @@ extension on FormData {
       merk: merk ?? this.merk,
       tipeVelg: tipeVelg ?? this.tipeVelg,
       ketebalan: ketebalan ?? this.ketebalan,
-      interiorSelectedIndex: interiorSelectedIndex ?? this.interiorSelectedIndex,
-      eksteriorSelectedIndex: eksteriorSelectedIndex ?? this.eksteriorSelectedIndex,
-      kakiKakiSelectedIndex: kakiKakiSelectedIndex ?? this.kakiKakiSelectedIndex,
-      mesinSelectedIndex: mesinSelectedIndex ?? this.mesinSelectedIndex,
-      penilaianKeseluruhanSelectedIndex: penilaianKeseluruhanSelectedIndex ?? this.penilaianKeseluruhanSelectedIndex,
+      interiorSelectedValue: interiorSelectedValue ?? this.interiorSelectedValue,
+      eksteriorSelectedValue: eksteriorSelectedValue ?? this.eksteriorSelectedValue,
+      kakiKakiSelectedValue: kakiKakiSelectedValue ?? this.kakiKakiSelectedValue,
+      mesinSelectedValue: mesinSelectedValue ?? this.mesinSelectedValue,
+      penilaianKeseluruhanSelectedValue: penilaianKeseluruhanSelectedValue ?? this.penilaianKeseluruhanSelectedValue,
       keteranganInterior: keteranganInterior ?? this.keteranganInterior,
       keteranganEksterior: keteranganEksterior ?? this.keteranganEksterior,
       keteranganKakiKaki: keteranganKakiKaki ?? this.keteranganKakiKaki,
       keteranganMesin: keteranganMesin ?? this.keteranganMesin,
       deskripsiKeseluruhan: deskripsiKeseluruhan ?? this.deskripsiKeseluruhan,
       repairEstimations: repairEstimations ?? this.repairEstimations,
-      airbagSelectedIndex: airbagSelectedIndex ?? this.airbagSelectedIndex,
+      airbagSelectedValue: airbagSelectedValue ?? this.airbagSelectedValue,
       airbagIsEnabled: airbagIsEnabled ?? this.airbagIsEnabled,
-      sistemAudioSelectedIndex: sistemAudioSelectedIndex ?? this.sistemAudioSelectedIndex,
+      sistemAudioSelectedValue: sistemAudioSelectedValue ?? this.sistemAudioSelectedValue,
       sistemAudioIsEnabled: sistemAudioIsEnabled ?? this.sistemAudioIsEnabled,
-      powerWindowSelectedIndex: powerWindowSelectedIndex ?? this.powerWindowSelectedIndex,
+      powerWindowSelectedValue: powerWindowSelectedValue ?? this.powerWindowSelectedValue,
       powerWindowIsEnabled: powerWindowIsEnabled ?? this.powerWindowIsEnabled,
-      sistemAcSelectedIndex: sistemAcSelectedIndex ?? this.sistemAcSelectedIndex,
+      sistemAcSelectedValue: sistemAcSelectedValue ?? this.sistemAcSelectedValue,
       sistemAcIsEnabled: sistemAcIsEnabled ?? this.sistemAcIsEnabled,
       fiturCatatanList: fiturCatatanList ?? this.fiturCatatanList,
-      getaranMesinSelectedIndex: getaranMesinSelectedIndex ?? this.getaranMesinSelectedIndex,
+      getaranMesinSelectedValue: getaranMesinSelectedValue ?? this.getaranMesinSelectedValue,
       getaranMesinIsEnabled: getaranMesinIsEnabled ?? this.getaranMesinIsEnabled,
-      suaraMesinSelectedIndex: suaraMesinSelectedIndex ?? this.suaraMesinSelectedIndex,
+      suaraMesinSelectedValue: suaraMesinSelectedValue ?? this.suaraMesinSelectedValue,
       suaraMesinIsEnabled: suaraMesinIsEnabled ?? this.suaraMesinIsEnabled,
-      transmisiSelectedIndex: transmisiSelectedIndex ?? this.transmisiSelectedIndex,
+      transmisiSelectedValue: transmisiSelectedValue ?? this.transmisiSelectedValue,
       transmisiIsEnabled: transmisiIsEnabled ?? this.transmisiIsEnabled,
-      pompaPowerSteeringSelectedIndex: pompaPowerSteeringSelectedIndex ?? this.pompaPowerSteeringSelectedIndex,
+      pompaPowerSteeringSelectedValue: pompaPowerSteeringSelectedValue ?? this.pompaPowerSteeringSelectedValue,
       pompaPowerSteeringIsEnabled: pompaPowerSteeringIsEnabled ?? this.pompaPowerSteeringIsEnabled,
-      coverTimingChainSelectedIndex: coverTimingChainSelectedIndex ?? this.coverTimingChainSelectedIndex,
+      coverTimingChainSelectedValue: coverTimingChainSelectedValue ?? this.coverTimingChainSelectedValue,
       coverTimingChainIsEnabled: coverTimingChainIsEnabled ?? this.coverTimingChainIsEnabled,
-      oliPowerSteeringSelectedIndex: oliPowerSteeringSelectedIndex ?? this.oliPowerSteeringSelectedIndex,
+      oliPowerSteeringSelectedValue: oliPowerSteeringSelectedValue ?? this.oliPowerSteeringSelectedValue,
       oliPowerSteeringIsEnabled: oliPowerSteeringIsEnabled ?? this.oliPowerSteeringIsEnabled,
-      accuSelectedIndex: accuSelectedIndex ?? this.accuSelectedIndex,
+      accuSelectedValue: accuSelectedValue ?? this.accuSelectedValue,
       accuIsEnabled: accuIsEnabled ?? this.accuIsEnabled,
-      kompressorAcSelectedIndex: kompressorAcSelectedIndex ?? this.kompressorAcSelectedIndex,
+      kompressorAcSelectedValue: kompressorAcSelectedValue ?? this.kompressorAcSelectedValue,
       kompressorAcIsEnabled: kompressorAcIsEnabled ?? this.kompressorAcIsEnabled,
-      fanSelectedIndex: fanSelectedIndex ?? this.fanSelectedIndex,
+      fanSelectedValue: fanSelectedValue ?? this.fanSelectedValue,
       fanIsEnabled: fanIsEnabled ?? this.fanIsEnabled,
-      selangSelectedIndex: selangSelectedIndex ?? this.selangSelectedIndex,
+      selangSelectedValue: selangSelectedValue ?? this.selangSelectedValue,
       selangIsEnabled: selangIsEnabled ?? this.selangIsEnabled,
-      karterOliSelectedIndex: karterOliSelectedIndex ?? this.karterOliSelectedIndex,
+      karterOliSelectedValue: karterOliSelectedValue ?? this.karterOliSelectedValue,
       karterOliIsEnabled: karterOliIsEnabled ?? this.karterOliIsEnabled,
-      oilRemSelectedIndex: oilRemSelectedIndex ?? this.oilRemSelectedIndex,
+      oilRemSelectedValue: oilRemSelectedValue ?? this.oilRemSelectedValue,
       oilRemIsEnabled: oilRemIsEnabled ?? this.oilRemIsEnabled,
-      kabelSelectedIndex: kabelSelectedIndex ?? this.kabelSelectedIndex,
+      kabelSelectedValue: kabelSelectedValue ?? this.kabelSelectedValue,
       kabelIsEnabled: kabelIsEnabled ?? this.kabelIsEnabled,
-      kondensorSelectedIndex: kondensorSelectedIndex ?? this.kondensorSelectedIndex,
+      kondensorSelectedValue: kondensorSelectedValue ?? this.kondensorSelectedValue,
       kondensorIsEnabled: kondensorIsEnabled ?? this.kondensorIsEnabled,
-      radiatorSelectedIndex: radiatorSelectedIndex ?? this.radiatorSelectedIndex,
+      radiatorSelectedValue: radiatorSelectedValue ?? this.radiatorSelectedValue,
       radiatorIsEnabled: radiatorIsEnabled ?? this.radiatorIsEnabled,
-      cylinderHeadSelectedIndex: cylinderHeadSelectedIndex ?? this.cylinderHeadSelectedIndex,
+      cylinderHeadSelectedValue: cylinderHeadSelectedValue ?? this.cylinderHeadSelectedValue,
       cylinderHeadIsEnabled: cylinderHeadIsEnabled ?? this.cylinderHeadIsEnabled,
-      oliMesinSelectedIndex: oliMesinSelectedIndex ?? this.oliMesinSelectedIndex,
+      oliMesinSelectedValue: oliMesinSelectedValue ?? this.oliMesinSelectedValue,
       oliMesinIsEnabled: oliMesinIsEnabled ?? this.oliMesinIsEnabled,
-      airRadiatorSelectedIndex: airRadiatorSelectedIndex ?? this.airRadiatorSelectedIndex,
+      airRadiatorSelectedValue: airRadiatorSelectedValue ?? this.airRadiatorSelectedValue,
       airRadiatorIsEnabled: airRadiatorIsEnabled ?? this.airRadiatorIsEnabled,
-      coverKlepSelectedIndex: coverKlepSelectedIndex ?? this.coverKlepSelectedIndex,
+      coverKlepSelectedValue: coverKlepSelectedValue ?? this.coverKlepSelectedValue,
       coverKlepIsEnabled: coverKlepIsEnabled ?? this.coverKlepIsEnabled,
-      alternatorSelectedIndex: alternatorSelectedIndex ?? this.alternatorSelectedIndex,
+      alternatorSelectedValue: alternatorSelectedValue ?? this.alternatorSelectedValue,
       alternatorIsEnabled: alternatorIsEnabled ?? this.alternatorIsEnabled,
-      waterPumpSelectedIndex: waterPumpSelectedIndex ?? this.waterPumpSelectedIndex,
+      waterPumpSelectedValue: waterPumpSelectedValue ?? this.waterPumpSelectedValue,
       waterPumpIsEnabled: waterPumpIsEnabled ?? this.waterPumpIsEnabled,
-      beltSelectedIndex: beltSelectedIndex ?? this.beltSelectedIndex,
+      beltSelectedValue: beltSelectedValue ?? this.beltSelectedValue,
       beltIsEnabled: beltIsEnabled ?? this.beltIsEnabled,
-      oliTransmisiSelectedIndex: oliTransmisiSelectedIndex ?? this.oliTransmisiSelectedIndex,
+      oliTransmisiSelectedValue: oliTransmisiSelectedValue ?? this.oliTransmisiSelectedValue,
       oliTransmisiIsEnabled: oliTransmisiIsEnabled ?? this.oliTransmisiIsEnabled,
-      cylinderBlockSelectedIndex: cylinderBlockSelectedIndex ?? this.cylinderBlockSelectedIndex,
+      cylinderBlockSelectedValue: cylinderBlockSelectedValue ?? this.cylinderBlockSelectedValue,
       cylinderBlockIsEnabled: cylinderBlockIsEnabled ?? this.cylinderBlockIsEnabled,
-      bushingBesarSelectedIndex: bushingBesarSelectedIndex ?? this.bushingBesarSelectedIndex,
+      bushingBesarSelectedValue: bushingBesarSelectedValue ?? this.bushingBesarSelectedValue,
       bushingBesarIsEnabled: bushingBesarIsEnabled ?? this.bushingBesarIsEnabled,
-      bushingKecilSelectedIndex: bushingKecilSelectedIndex ?? this.bushingKecilSelectedIndex,
+      bushingKecilSelectedValue: bushingKecilSelectedValue ?? this.bushingKecilSelectedValue,
       bushingKecilIsEnabled: bushingKecilIsEnabled ?? this.bushingKecilIsEnabled,
-      tutupRadiatorSelectedIndex: tutupRadiatorSelectedIndex ?? this.tutupRadiatorSelectedIndex,
+      tutupRadiatorSelectedValue: tutupRadiatorSelectedValue ?? this.tutupRadiatorSelectedValue,
       tutupRadiatorIsEnabled: tutupRadiatorIsEnabled ?? this.tutupRadiatorIsEnabled,
       mesinCatatanList: mesinCatatanList ?? this.mesinCatatanList,
-      stirSelectedIndex: stirSelectedIndex ?? this.stirSelectedIndex,
+      stirSelectedValue: stirSelectedValue ?? this.stirSelectedValue,
       stirIsEnabled: stirIsEnabled ?? this.stirIsEnabled,
-      remTonganSelectedIndex: remTonganSelectedIndex ?? this.remTonganSelectedIndex,
+      remTonganSelectedValue: remTonganSelectedValue ?? this.remTonganSelectedValue,
       remTonganIsEnabled: remTonganIsEnabled ?? this.remTonganIsEnabled,
-      pedalSelectedIndex: pedalSelectedIndex ?? this.pedalSelectedIndex,
+      pedalSelectedValue: pedalSelectedValue ?? this.pedalSelectedValue,
       pedalIsEnabled: pedalIsEnabled ?? this.pedalIsEnabled,
-      switchWiperSelectedIndex: switchWiperSelectedIndex ?? this.switchWiperSelectedIndex,
+      switchWiperSelectedValue: switchWiperSelectedValue ?? this.switchWiperSelectedValue,
       switchWiperIsEnabled: switchWiperIsEnabled ?? this.switchWiperIsEnabled,
-      lampuHazardSelectedIndex: lampuHazardSelectedIndex ?? this.lampuHazardSelectedIndex,
+      lampuHazardSelectedValue: lampuHazardSelectedValue ?? this.lampuHazardSelectedValue,
       lampuHazardIsEnabled: lampuHazardIsEnabled ?? this.lampuHazardIsEnabled,
-      panelDashboardSelectedIndex: panelDashboardSelectedIndex ?? this.panelDashboardSelectedIndex,
+      panelDashboardSelectedValue: panelDashboardSelectedValue ?? this.panelDashboardSelectedValue,
       panelDashboardIsEnabled: panelDashboardIsEnabled ?? this.panelDashboardIsEnabled,
-      pembukaKapMesinSelectedIndex: pembukaKapMesinSelectedIndex ?? this.pembukaKapMesinSelectedIndex,
+      pembukaKapMesinSelectedValue: pembukaKapMesinSelectedValue ?? this.pembukaKapMesinSelectedValue,
       pembukaKapMesinIsEnabled: pembukaKapMesinIsEnabled ?? this.pembukaKapMesinIsEnabled,
-      pembukaBagasiSelectedIndex: pembukaBagasiSelectedIndex ?? this.pembukaBagasiSelectedIndex,
+      pembukaBagasiSelectedValue: pembukaBagasiSelectedValue ?? this.pembukaBagasiSelectedValue,
       pembukaBagasiIsEnabled: pembukaBagasiIsEnabled ?? this.pembukaBagasiIsEnabled,
-      jokDepanSelectedIndex: jokDepanSelectedIndex ?? this.jokDepanSelectedIndex,
+      jokDepanSelectedValue: jokDepanSelectedValue ?? this.jokDepanSelectedValue,
       jokDepanIsEnabled: jokDepanIsEnabled ?? this.jokDepanIsEnabled,
-      aromaInteriorSelectedIndex: aromaInteriorSelectedIndex ?? this.aromaInteriorSelectedIndex,
+      aromaInteriorSelectedValue: aromaInteriorSelectedValue ?? this.aromaInteriorSelectedValue,
       aromaInteriorIsEnabled: aromaInteriorIsEnabled ?? this.aromaInteriorIsEnabled,
-      handlePintuSelectedIndex: handlePintuSelectedIndex ?? this.handlePintuSelectedIndex,
+      handlePintuSelectedValue: handlePintuSelectedValue ?? this.handlePintuSelectedValue,
       handlePintuIsEnabled: handlePintuIsEnabled ?? this.handlePintuIsEnabled,
-      consoleBoxSelectedIndex: consoleBoxSelectedIndex ?? this.consoleBoxSelectedIndex,
+      consoleBoxSelectedValue: consoleBoxSelectedValue ?? this.consoleBoxSelectedValue,
       consoleBoxIsEnabled: consoleBoxIsEnabled ?? this.consoleBoxIsEnabled,
-      spionTengahSelectedIndex: spionTengahSelectedIndex ?? this.spionTengahSelectedIndex,
+      spionTengahSelectedValue: spionTengahSelectedValue ?? this.spionTengahSelectedValue,
       spionTengahIsEnabled: spionTengahIsEnabled ?? this.spionTengahIsEnabled,
-      tuasPersnelingSelectedIndex: tuasPersnelingSelectedIndex ?? this.tuasPersnelingSelectedIndex,
+      tuasPersnelingSelectedValue: tuasPersnelingSelectedValue ?? this.tuasPersnelingSelectedValue,
       tuasPersnelingIsEnabled: tuasPersnelingIsEnabled ?? this.tuasPersnelingIsEnabled,
-      jokBelakangSelectedIndex: jokBelakangSelectedIndex ?? this.jokBelakangSelectedIndex,
+      jokBelakangSelectedValue: jokBelakangSelectedValue ?? this.jokBelakangSelectedValue,
       jokBelakangIsEnabled: jokBelakangIsEnabled ?? this.jokBelakangIsEnabled,
-      panelIndikatorSelectedIndex: panelIndikatorSelectedIndex ?? this.panelIndikatorSelectedIndex,
+      panelIndikatorSelectedValue: panelIndikatorSelectedValue ?? this.panelIndikatorSelectedValue,
       panelIndikatorIsEnabled: panelIndikatorIsEnabled ?? this.panelIndikatorIsEnabled,
-      switchLampuSelectedIndex: switchLampuSelectedIndex ?? this.switchLampuSelectedIndex,
+      switchLampuSelectedValue: switchLampuSelectedValue ?? this.switchLampuSelectedValue,
       switchLampuIsEnabled: switchLampuIsEnabled ?? this.switchLampuIsEnabled,
-      karpetDasarSelectedIndex: karpetDasarSelectedIndex ?? this.karpetDasarSelectedIndex,
+      karpetDasarSelectedValue: karpetDasarSelectedValue ?? this.karpetDasarSelectedValue,
       karpetDasarIsEnabled: karpetDasarIsEnabled ?? this.karpetDasarIsEnabled,
-      klaksonSelectedIndex: klaksonSelectedIndex ?? this.klaksonSelectedIndex,
+      klaksonSelectedValue: klaksonSelectedValue ?? this.klaksonSelectedValue,
       klaksonIsEnabled: klaksonIsEnabled ?? this.klaksonIsEnabled,
-      sunVisorSelectedIndex: sunVisorSelectedIndex ?? this.sunVisorSelectedIndex,
+      sunVisorSelectedValue: sunVisorSelectedValue ?? this.sunVisorSelectedValue,
       sunVisorIsEnabled: sunVisorIsEnabled ?? this.sunVisorIsEnabled,
-      tuasTangkiBensinSelectedIndex: tuasTangkiBensinSelectedIndex ?? this.tuasTangkiBensinSelectedIndex,
+      tuasTangkiBensinSelectedValue: tuasTangkiBensinSelectedValue ?? this.tuasTangkiBensinSelectedValue,
       tuasTangkiBensinIsEnabled: tuasTangkiBensinIsEnabled ?? this.tuasTangkiBensinIsEnabled,
-      sabukPengamanSelectedIndex: sabukPengamanSelectedIndex ?? this.sabukPengamanSelectedIndex,
+      sabukPengamanSelectedValue: sabukPengamanSelectedValue ?? this.sabukPengamanSelectedValue,
       sabukPengamanIsEnabled: sabukPengamanIsEnabled ?? this.sabukPengamanIsEnabled,
-      trimInteriorSelectedIndex: trimInteriorSelectedIndex ?? this.trimInteriorSelectedIndex,
+      trimInteriorSelectedValue: trimInteriorSelectedValue ?? this.trimInteriorSelectedValue,
       trimInteriorIsEnabled: trimInteriorIsEnabled ?? this.trimInteriorIsEnabled,
-      plafonSelectedIndex: plafonSelectedIndex ?? this.plafonSelectedIndex,
+      plafonSelectedValue: plafonSelectedValue ?? this.plafonSelectedValue,
       plafonIsEnabled: plafonIsEnabled ?? this.plafonIsEnabled,
       interiorCatatanList: interiorCatatanList ?? this.interiorCatatanList,
-      bumperDepanSelectedIndex: bumperDepanSelectedIndex ?? this.bumperDepanSelectedIndex,
+      bumperDepanSelectedValue: bumperDepanSelectedValue ?? this.bumperDepanSelectedValue,
       bumperDepanIsEnabled: bumperDepanIsEnabled ?? this.bumperDepanIsEnabled,
-      kapMesinSelectedIndex: kapMesinSelectedIndex ?? this.kapMesinSelectedIndex,
+      kapMesinSelectedValue: kapMesinSelectedValue ?? this.kapMesinSelectedValue,
       kapMesinIsEnabled: kapMesinIsEnabled ?? this.kapMesinIsEnabled,
-      lampuUtamaSelectedIndex: lampuUtamaSelectedIndex ?? this.lampuUtamaSelectedIndex,
+      lampuUtamaSelectedValue: lampuUtamaSelectedValue ?? this.lampuUtamaSelectedValue,
       lampuUtamaIsEnabled: lampuUtamaIsEnabled ?? this.lampuUtamaIsEnabled,
-      panelAtapSelectedIndex: panelAtapSelectedIndex ?? this.panelAtapSelectedIndex,
+      panelAtapSelectedValue: panelAtapSelectedValue ?? this.panelAtapSelectedValue,
       panelAtapIsEnabled: panelAtapIsEnabled ?? this.panelAtapIsEnabled,
-      grillSelectedIndex: grillSelectedIndex ?? this.grillSelectedIndex,
+      grillSelectedValue: grillSelectedValue ?? this.grillSelectedValue,
       grillIsEnabled: grillIsEnabled ?? this.grillIsEnabled,
-      lampuFoglampSelectedIndex: lampuFoglampSelectedIndex ?? this.lampuFoglampSelectedIndex,
+      lampuFoglampSelectedValue: lampuFoglampSelectedValue ?? this.lampuFoglampSelectedValue,
       lampuFoglampIsEnabled: lampuFoglampIsEnabled ?? this.lampuFoglampIsEnabled,
-      kacaBeningSelectedIndex: kacaBeningSelectedIndex ?? this.kacaBeningSelectedIndex,
+      kacaBeningSelectedValue: kacaBeningSelectedValue ?? this.kacaBeningSelectedValue,
       kacaBeningIsEnabled: kacaBeningIsEnabled ?? this.kacaBeningIsEnabled,
-      wiperBelakangSelectedIndex: wiperBelakangSelectedIndex ?? this.wiperBelakangSelectedIndex,
+      wiperBelakangSelectedValue: wiperBelakangSelectedValue ?? this.wiperBelakangSelectedValue,
       wiperBelakangIsEnabled: wiperBelakangIsEnabled ?? this.wiperBelakangIsEnabled,
-      bumperBelakangSelectedIndex: bumperBelakangSelectedIndex ?? this.bumperBelakangSelectedIndex,
+      bumperBelakangSelectedValue: bumperBelakangSelectedValue ?? this.bumperBelakangSelectedValue,
       bumperBelakangIsEnabled: bumperBelakangIsEnabled ?? this.bumperBelakangIsEnabled,
-      lampuBelakangSelectedIndex: lampuBelakangSelectedIndex ?? this.lampuBelakangSelectedIndex,
+      lampuBelakangSelectedValue: lampuBelakangSelectedValue ?? this.lampuBelakangSelectedValue,
       lampuBelakangIsEnabled: lampuBelakangIsEnabled ?? this.lampuBelakangIsEnabled,
-      trunklidSelectedIndex: trunklidSelectedIndex ?? this.trunklidSelectedIndex,
+      trunklidSelectedValue: trunklidSelectedValue ?? this.trunklidSelectedValue,
       trunklidIsEnabled: trunklidIsEnabled ?? this.trunklidIsEnabled,
-      kacaDepanSelectedIndex: kacaDepanSelectedIndex ?? this.kacaDepanSelectedIndex,
+      kacaDepanSelectedValue: kacaDepanSelectedValue ?? this.kacaDepanSelectedValue,
       kacaDepanIsEnabled: kacaDepanIsEnabled ?? this.kacaDepanIsEnabled,
-      fenderKananSelectedIndex: fenderKananSelectedIndex ?? this.fenderKananSelectedIndex,
+      fenderKananSelectedValue: fenderKananSelectedValue ?? this.fenderKananSelectedValue,
       fenderKananIsEnabled: fenderKananIsEnabled ?? this.fenderKananIsEnabled,
-      quarterPanelKananSelectedIndex: quarterPanelKananSelectedIndex ?? this.quarterPanelKananSelectedIndex,
+      quarterPanelKananSelectedValue: quarterPanelKananSelectedValue ?? this.quarterPanelKananSelectedValue,
       quarterPanelKananIsEnabled: quarterPanelKananIsEnabled ?? this.quarterPanelKananIsEnabled,
-      pintuBelakangKananSelectedIndex: pintuBelakangKananSelectedIndex ?? this.pintuBelakangKananSelectedIndex,
+      pintuBelakangKananSelectedValue: pintuBelakangKananSelectedValue ?? this.pintuBelakangKananSelectedValue,
       pintuBelakangKananIsEnabled: pintuBelakangKananIsEnabled ?? this.pintuBelakangKananIsEnabled,
-      spionKananSelectedIndex: spionKananSelectedIndex ?? this.spionKananSelectedIndex,
+      spionKananSelectedValue: spionKananSelectedValue ?? this.spionKananSelectedValue,
       spionKananIsEnabled: spionKananIsEnabled ?? this.spionKananIsEnabled,
-      lisplangKananSelectedIndex: lisplangKananSelectedIndex ?? this.lisplangKananSelectedIndex,
+      lisplangKananSelectedValue: lisplangKananSelectedValue ?? this.lisplangKananSelectedValue,
       lisplangKananIsEnabled: lisplangKananIsEnabled ?? this.lisplangKananIsEnabled,
-      sideSkirtKananSelectedIndex: sideSkirtKananSelectedIndex ?? this.sideSkirtKananSelectedIndex,
+      sideSkirtKananSelectedValue: sideSkirtKananSelectedValue ?? this.sideSkirtKananSelectedValue,
       sideSkirtKananIsEnabled: sideSkirtKananIsEnabled ?? this.sideSkirtKananIsEnabled,
-      daunWiperSelectedIndex: daunWiperSelectedIndex ?? this.daunWiperSelectedIndex,
+      daunWiperSelectedValue: daunWiperSelectedValue ?? this.daunWiperSelectedValue,
       daunWiperIsEnabled: daunWiperIsEnabled ?? this.daunWiperIsEnabled,
-      pintuBelakangSelectedIndex: pintuBelakangSelectedIndex ?? this.pintuBelakangSelectedIndex,
+      pintuBelakangSelectedValue: pintuBelakangSelectedValue ?? this.pintuBelakangSelectedValue,
       pintuBelakangIsEnabled: pintuBelakangIsEnabled ?? this.pintuBelakangIsEnabled,
-      fenderKiriSelectedIndex: fenderKiriSelectedIndex ?? this.fenderKiriSelectedIndex,
+      fenderKiriSelectedValue: fenderKiriSelectedValue ?? this.fenderKiriSelectedValue,
       fenderKiriIsEnabled: fenderKiriIsEnabled ?? this.fenderKiriIsEnabled,
-      quarterPanelKiriSelectedIndex: quarterPanelKiriSelectedIndex ?? this.quarterPanelKiriSelectedIndex,
+      quarterPanelKiriSelectedValue: quarterPanelKiriSelectedValue ?? this.quarterPanelKiriSelectedValue,
       quarterPanelKiriIsEnabled: quarterPanelKiriIsEnabled ?? this.quarterPanelKiriIsEnabled,
-      pintuDepanSelectedIndex: pintuDepanSelectedIndex ?? this.pintuDepanSelectedIndex,
+      pintuDepanSelectedValue: pintuDepanSelectedValue ?? this.pintuDepanSelectedValue,
       pintuDepanIsEnabled: pintuDepanIsEnabled ?? this.pintuDepanIsEnabled,
-      kacaJendelaKananSelectedIndex: kacaJendelaKananSelectedIndex ?? this.kacaJendelaKananSelectedIndex,
+      kacaJendelaKananSelectedValue: kacaJendelaKananSelectedValue ?? this.kacaJendelaKananSelectedValue,
       kacaJendelaKananIsEnabled: kacaJendelaKananIsEnabled ?? this.kacaJendelaKananIsEnabled,
-      pintuBelakangKiriSelectedIndex: pintuBelakangKiriSelectedIndex ?? this.pintuBelakangKiriSelectedIndex,
+      pintuBelakangKiriSelectedValue: pintuBelakangKiriSelectedValue ?? this.pintuBelakangKiriSelectedValue,
       pintuBelakangKiriIsEnabled: pintuBelakangKiriIsEnabled ?? this.pintuBelakangKiriIsEnabled,
-      spionKiriSelectedIndex: spionKiriSelectedIndex ?? this.spionKiriSelectedIndex,
+      spionKiriSelectedValue: spionKiriSelectedValue ?? this.spionKiriSelectedValue,
       spionKiriIsEnabled: spionKiriIsEnabled ?? this.spionKiriIsEnabled,
-      pintuDepanKiriSelectedIndex: pintuDepanKiriSelectedIndex ?? this.pintuDepanKiriSelectedIndex,
+      pintuDepanKiriSelectedValue: pintuDepanKiriSelectedValue ?? this.pintuDepanKiriSelectedValue,
       pintuDepanKiriIsEnabled: pintuDepanKiriIsEnabled ?? this.pintuDepanKiriIsEnabled,
-      kacaJendelaKiriSelectedIndex: kacaJendelaKiriSelectedIndex ?? this.kacaJendelaKiriSelectedIndex,
+      kacaJendelaKiriSelectedValue: kacaJendelaKiriSelectedValue ?? this.kacaJendelaKiriSelectedValue,
       kacaJendelaKiriIsEnabled: kacaJendelaKiriIsEnabled ?? this.kacaJendelaKiriIsEnabled,
-      lisplangKiriSelectedIndex: lisplangKiriSelectedIndex ?? this.lisplangKiriSelectedIndex,
+      lisplangKiriSelectedValue: lisplangKiriSelectedValue ?? this.lisplangKiriSelectedValue,
       lisplangKiriIsEnabled: lisplangKiriIsEnabled ?? this.lisplangKiriIsEnabled,
-      sideSkirtKiriSelectedIndex: sideSkirtKiriSelectedIndex ?? this.sideSkirtKiriSelectedIndex,
+      sideSkirtKiriSelectedValue: sideSkirtKiriSelectedValue ?? this.sideSkirtKiriSelectedValue,
       sideSkirtKiriIsEnabled: sideSkirtKiriIsEnabled ?? this.sideSkirtKiriIsEnabled,
       eksteriorCatatanList: eksteriorCatatanList ?? this.eksteriorCatatanList,
     );

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -227,14 +227,14 @@ class ApiService {
       );
 
       if (response.statusCode == 200 || response.statusCode == 201) {
-        print('Form data submitted successfully!');
+        //print('Form data submitted successfully!');
         // TODO: Handle success (e.g., show a success message)
       } else {
-        print('Failed to submit form data: ${response.statusCode}');
+        //print('Failed to submit form data: ${response.statusCode}');
         // TODO: Handle errors (e.g., show an error message)
       }
     } catch (e) {
-      print('Error submitting form data: $e');
+      //print('Error submitting form data: $e');
       // TODO: Handle network errors or exceptions (e.g., show an error message)
     }
   }

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -227,14 +227,14 @@ class ApiService {
       );
 
       if (response.statusCode == 200 || response.statusCode == 201) {
-        //print('Form data submitted successfully!');
+        print('Form data submitted successfully!');
         // TODO: Handle success (e.g., show a success message)
       } else {
-        //print('Failed to submit form data: ${response.statusCode}');
+        print('Failed to submit form data: ${response.statusCode}');
         // TODO: Handle errors (e.g., show an error message)
       }
     } catch (e) {
-      //print('Error submitting form data: $e');
+      print('Error submitting form data: $e');
       // TODO: Handle network errors or exceptions (e.g., show an error message)
     }
   }

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -3,73 +3,226 @@ import 'package:form_app/models/form_data.dart';
 
 class ApiService {
   final dio.Dio _dio = dio.Dio(); // Use prefix
-  final String _baseUrl = 'http://31.220.81.182/api/v1/inspections'; // Your API endpoint
+  final String _baseUrl =
+      'http://31.220.81.182/api/v1/inspections'; // Your API endpoint
 
   Future<void> submitFormData(FormData formData) async {
     try {
       final response = await _dio.post(
         _baseUrl,
         data: {
-          "id": "YOUR_GENERATED_OR_FETCHED_ID", // TODO: Generate or get ID
-          "submittedByUserId": null, // TODO: Get user ID
           "vehiclePlateNumber": formData.platNomor,
           "inspectionDate": formData.tanggalInspeksi?.toIso8601String(),
-          "overallRating": null, // TODO: Get overall rating from form data
+          "overallRating": formData.penilaianKeseluruhanSelectedValue,
           "identityDetails": {
-              "namaCustomer": formData.namaCustomer,
-              "namaInspektor": formData.namaInspektor,
-              "cabangInspeksi": formData.cabangInspeksi
+            "namaInspektor": formData.namaInspektor,
+            "namaCustomer": formData.namaCustomer,
+            "cabangInspeksi": formData.cabangInspeksi,
           },
           "vehicleData": {
-              "tahun": int.tryParse(formData.tahun),
-              "odometer": int.tryParse(formData.odometer),
-              "platNomor": formData.platNomor,
-              "transmisi": formData.transmisi,
-              "biayaPajak": int.tryParse(formData.biayaPajak),
-              "kepemilikan": formData.kepemilikan,
-              "pajak1Tahun": formData.pajak1TahunDate?.toIso8601String().split('T')[0],
-              "pajak5Tahun": formData.pajak5TahunDate?.toIso8601String().split('T')[0],
-              "tipeKendaraan": formData.tipeKendaraan,
-              "merekKendaraan": formData.merekKendaraan,
-              "warnaKendaraan": formData.warnaKendaraan
+            "merekKendaraan": formData.merekKendaraan,
+            "tipeKendaraan": formData.tipeKendaraan,
+            "tahun": formData.tahun,
+            "transmisi": formData.transmisi,
+            "warnaKendaraan": formData.warnaKendaraan,
+            "odometer": formData.odometer,
+            "kepemilikan": formData.kepemilikan,
+            "platNomor": formData.platNomor,
+            "pajak1Tahun": formData.pajak1TahunDate?.toIso8601String(),
+            "pajak5Tahun": formData.pajak5TahunDate?.toIso8601String(),
+            "biayaPajak": formData.biayaPajak,
           },
           "equipmentChecklist": {
-              "bpkb": formData.bpkp == 'Ada',
-              "noMesin": formData.noMesin == 'Ada',
-              "toolkit": formData.toolkit == 'Ada',
-              "banSerep": formData.banSerep == 'Ada',
-              "dongkrak": formData.dongkrak == 'Ada',
-              "noRangka": formData.noRangka == 'Ada',
-              "bukuManual": formData.bukuManual == 'Ada',
-              "kunciSerep": formData.kunciSerep == 'Ada',
-              "bukuService": formData.bukuService == 'Ada'
+            "bukuService": formData.bukuService != null ? (formData.bukuService == 'Ada') : null,
+            "kunciSerep": formData.kunciSerep != null ? (formData.kunciSerep == 'Ada') : null,
+            "bukuManual": formData.bukuManual != null ? (formData.bukuManual == 'Ada') : null,
+            "banSerep": formData.banSerep != null ? (formData.banSerep == 'Ada') : null,
+            "bpkb": formData.bpkp != null ? (formData.bpkp == 'Ada') : null,
+            "dongkrak": formData.dongkrak != null ? (formData.dongkrak == 'Ada') : null,
+            "toolkit": formData.toolkit != null ? (formData.toolkit == 'Ada') : null,
+            "noRangka": formData.noRangka != null ? (formData.noRangka == 'Ada') : null,
+            "noMesin": formData.noMesin != null ? (formData.noMesin == 'Ada') : null,
           },
           "inspectionSummary": {
-              "mesinNotes": null, // TODO: Get from form data
-              "mesinScore": null, // TODO: Get from form data
-              "interiorNotes": null, // TODO: Get from form data
-              "interiorScore": null, // TODO: Get from form data
-              "kakiKakiNotes": null, // TODO: Get from form data
-              "kakiKakiScore": null, // TODO: Get from form data
-              "eksteriorNotes": null, // TODO: Get from form data
-              "eksteriorScore": null, // TODO: Get from form data
-              "indikasiBanjir": formData.indikasiBanjir == 'Terindikasi',
-              "indikasiTabrakan": formData.indikasiTabrakan == 'Terindikasi',
-              "estimasiPerbaikan": [], // TODO: Get from form data if available
-              "deskripsiKeseluruhan": [], // TODO: Get from form data if available
-              "indikasiOdometerReset": formData.indikasiOdometerReset == 'Terindikasi',
-              "penilaianKeseluruhanScore": null // TODO: Get from form data
+            "interiorScore": formData.interiorSelectedValue,
+            "interiorNotes": formData.keteranganInterior.isNotEmpty ? formData.keteranganInterior.join(', ') : null,
+            "eksteriorScore": formData.eksteriorSelectedValue,
+            "eksteriorNotes": formData.keteranganEksterior.isNotEmpty ? formData.keteranganEksterior.join(', ') : null,
+            "kakiKakiScore": formData.kakiKakiSelectedValue,
+            "kakiKakiNotes": formData.keteranganKakiKaki.isNotEmpty ? formData.keteranganKakiKaki.join(', ') : null,
+            "mesinScore": formData.mesinSelectedValue,
+            "mesinNotes": formData.keteranganMesin.isNotEmpty ? formData.keteranganMesin.join(', ') : null,
+            "penilaianKeseluruhanScore": formData.penilaianKeseluruhanSelectedValue,
+            "deskripsiKeseluruhan": formData.deskripsiKeseluruhan.isNotEmpty ? formData.deskripsiKeseluruhan : null,
+            "indikasiTabrakan": formData.indikasiTabrakan != null ? (formData.indikasiTabrakan == 'Ya') : null,
+            "indikasiBanjir": formData.indikasiBanjir != null ? (formData.indikasiBanjir == 'Ya') : null,
+            "indikasiOdometerReset": formData.indikasiOdometerReset != null ? (formData.indikasiOdometerReset == 'Ya') : null,
+            "posisiBan": formData.posisiBan,
+            "merkban": formData.merk,
+            "tipeVelg": formData.tipeVelg,
+            "ketebalanBan": formData.ketebalan,
+            "estimasiPerbaikan": formData.repairEstimations.isNotEmpty ? formData.repairEstimations : null,
           },
           "detailedAssessment": {
-              // TODO: Map detailed assessment data from form
+            "testDrive": {
+              "bunyiGetaran": null, // TODO: Map to FormData field if available
+              "performaStir": null, // TODO: Map to FormData field if available
+              "perpindahanTransmisi": null, // TODO: Map to FormData field if available
+              "stirBalance": null, // TODO: Map to FormData field if available
+              "performaSuspensi": null, // TODO: Map to FormData field if available
+              "performaKopling": null, // TODO: Map to FormData field if available
+              "rpm": null, // TODO: Map to FormData field if available
+              "catatan": formData.fiturCatatanList.isNotEmpty ? formData.fiturCatatanList.join(', ') : null,
+            },
+            "banDanKakiKaki": {
+              "banDepan": null, // TODO: Map to FormData field if available
+              "velgDepan": null, // TODO: Map to FormData field if available
+              "discBrake": null, // TODO: Map to FormData field if available
+              "masterRem": null, // TODO: Map to FormData field if available
+              "tieRod": null, // TODO: Map to FormData field if available
+              "gardan": null, // TODO: Map to FormData field if available
+              "banBelakang": null, // TODO: Map to FormData field if available
+              "velgBelakang": null, // TODO: Map to FormData field if available
+              "brakePad": null, // TODO: Map to FormData field if available
+              "crossmember": null, // TODO: Map to FormData field if available
+              "knalpot": null, // TODO: Map to FormData field if available
+              "balljoint": null, // TODO: Map to FormData field if available
+              "rocksteer": null, // TODO: Map to FormData field if available
+              "karetBoot": null, // TODO: Map to FormData field if available
+              "upperLowerArm": null, // TODO: Map to FormData field if available
+              "shockBreaker": null, // TODO: Map to FormData field if available
+              "linkStabilizer": null, // TODO: Map to FormData field if available
+              "catatan": formData.mesinCatatanList.isNotEmpty ? formData.mesinCatatanList.join(', ') : null,
+            },
+            "hasilInspeksiEksterior": {
+              "bumperDepan": formData.bumperDepanSelectedValue,
+              "kapMesin": formData.kapMesinSelectedValue,
+              "lampuUtama": formData.lampuUtamaSelectedValue,
+              "panelAtap": formData.panelAtapSelectedValue,
+              "grill": formData.grillSelectedValue,
+              "lampuFoglamp": formData.lampuFoglampSelectedValue,
+              "kacaBening": formData.kacaBeningSelectedValue,
+              "wiperBelakang": formData.wiperBelakangSelectedValue,
+              "bumperBelakang": formData.bumperBelakangSelectedValue,
+              "lampuBelakang": formData.lampuBelakangSelectedValue,
+              "trunklid": formData.trunklidSelectedValue,
+              "kacaDepan": formData.kacaDepanSelectedValue,
+              "fenderKanan": formData.fenderKananSelectedValue,
+              "quarterPanelKanan": formData.quarterPanelKananSelectedValue,
+              "pintuBelakangKanan": formData.pintuBelakangKananSelectedValue,
+              "spionKanan": formData.spionKananSelectedValue,
+              "lisplangKanan": formData.lisplangKananSelectedValue,
+              "sideSkirtKanan": formData.sideSkirtKananSelectedValue,
+              "daunWiper": formData.daunWiperSelectedValue,
+              "pintuBelakang": formData.pintuBelakangSelectedValue,
+              "fenderKiri": formData.fenderKiriSelectedValue,
+              "quarterPanelKiri": formData.quarterPanelKiriSelectedValue,
+              "pintuDepan": formData.pintuDepanSelectedValue,
+              "kacaJendelaKanan": formData.kacaJendelaKananSelectedValue,
+              "pintuBelakangKiri": formData.pintuBelakangKiriSelectedValue,
+              "spionKiri": formData.spionKiriSelectedValue,
+              "pintuDepanKiri": formData.pintuDepanKiriSelectedValue,
+              "kacaJendelaKiri": formData.kacaJendelaKiriSelectedValue,
+              "lisplangKiri": formData.lisplangKiriSelectedValue,
+              "sideSkirtKiri": formData.sideSkirtKiriSelectedValue,
+              "catatan": formData.eksteriorCatatanList.isNotEmpty ? formData.eksteriorCatatanList.join(', ') : null,
+            },
+            "toolsTest": {
+              "tebalCatBodyDepan": null, // TODO: Map to FormData field if available
+              "tebalCatBodyKiri": null, // TODO: Map to FormData field if available
+              "temperatureAC": null, // TODO: Map to FormData field if available
+              "tebalCatBodyKanan": null, // TODO: Map to FormData field if available
+              "tebalCatBodyBelakang": null, // TODO: Map to FormData field if available
+              "obdScanner": null, // TODO: Map to FormData field if available
+              "tebalCatBodyAtap": null, // TODO: Map to FormData field if available
+              "testAccu": null, // TODO: Map to FormData field if available
+              "catatan": null, // TODO: Map to FormData field if available
+            },
+            "fitur": {
+              "airbag": formData.airbagSelectedValue,
+              "sistemAudio": formData.sistemAudioSelectedValue,
+              "powerWindow": formData.powerWindowSelectedValue,
+              "sistemAC": formData.sistemAcSelectedValue,
+              "interior1": null, // TODO: Map to FormData field if available
+              "interior2": null, // TODO: Map to FormData field if available
+              "interior3": null, // TODO: Map to FormData field if available
+              "catatan": formData.fiturCatatanList.isNotEmpty ? formData.fiturCatatanList.join(', ') : null,
+            },
+            "hasilInspeksiMesin": {
+              "getaranMesin": formData.getaranMesinSelectedValue,
+              "suaraMesin": formData.suaraMesinSelectedValue,
+              "transmisi": formData.transmisiSelectedValue,
+              "pompaPowerSteering": formData.pompaPowerSteeringSelectedValue,
+              "coverTimingChain": formData.coverTimingChainSelectedValue,
+              "oliPowerSteering": formData.oliPowerSteeringSelectedValue,
+              "accu": formData.accuSelectedValue,
+              "kompressorAC": formData.kompressorAcSelectedValue,
+              "fan": formData.fanSelectedValue,
+              "selang": formData.selangSelectedValue,
+              "karterOli": formData.karterOliSelectedValue,
+              "oliRem": formData.oilRemSelectedValue,
+              "kabel": formData.kabelSelectedValue,
+              "kondensor": formData.kondensorSelectedValue,
+              "radiator": formData.radiatorSelectedValue,
+              "cylinderHead": formData.cylinderHeadSelectedValue,
+              "oliMesin": formData.oliMesinSelectedValue,
+              "airRadiator": formData.airRadiatorSelectedValue,
+              "coverKlep": formData.coverKlepSelectedValue,
+              "alternator": formData.alternatorSelectedValue,
+              "waterPump": formData.waterPumpSelectedValue,
+              "belt": formData.beltSelectedValue,
+              "oliTransmisi": formData.oliTransmisiSelectedValue,
+              "cylinderBlock": formData.cylinderBlockSelectedValue,
+              "bushingBesar": formData.bushingBesarSelectedValue,
+              "bushingKecil": formData.bushingKecilSelectedValue,
+              "tutupRadiator": formData.tutupRadiatorSelectedValue,
+              "catatan": formData.mesinCatatanList.isNotEmpty ? formData.mesinCatatanList.join(', ') : null,
+            },
+            "hasilInspeksiInterior": {
+              "stir": formData.stirSelectedValue,
+              "remTangan": formData.remTonganSelectedValue,
+              "pedal": formData.pedalSelectedValue,
+              "switchWiper": formData.switchWiperSelectedValue,
+              "lampuHazard": formData.lampuHazardSelectedValue,
+              "switchLampu": formData.switchLampuSelectedValue,
+              "panelDashboard": formData.panelDashboardSelectedValue,
+              "pembukaKapMesin": formData.pembukaKapMesinSelectedValue,
+              "pembukaBagasi": formData.pembukaBagasiSelectedValue,
+              "jokDepan": formData.jokDepanSelectedValue,
+              "aromaInterior": formData.aromaInteriorSelectedValue,
+              "handlePintu": formData.handlePintuSelectedValue,
+              "consoleBox": formData.consoleBoxSelectedValue,
+              "spionTengah": formData.spionTengahSelectedValue,
+              "tuasPersneling": formData.tuasPersnelingSelectedValue,
+              "jokBelakang": formData.jokBelakangSelectedValue,
+              "panelIndikator": formData.panelIndikatorSelectedValue,
+              "switchLampuInterior": formData.switchLampuSelectedValue,
+              "karpetDasar": formData.karpetDasarSelectedValue,
+              "klakson": formData.klaksonSelectedValue,
+              "sunVisor": formData.sunVisorSelectedValue,
+              "tuasTangkiBensin": formData.tuasTangkiBensinSelectedValue,
+              "sabukPengaman": formData.sabukPengamanSelectedValue,
+              "trimInterior": formData.trimInteriorSelectedValue,
+              "plafon": formData.plafonSelectedValue,
+              "catatan": formData.interiorCatatanList.isNotEmpty ? formData.interiorCatatanList.join(', ') : null,
+            },
           },
-          "photoPaths": [], // TODO: Get from form data if available
-          "nftAssetId": null, // TODO: Get from form data if available
-          "transactionHash": null, // TODO: Get from form data if available
-          "reportPdfUrl": null, // TODO: Get from form data if available
-          "reportHash": null, // TODO: Get from form data if available
-          "createdAt": DateTime.now().toIso8601String(),
-          "updatedAt": DateTime.now().toIso8601String()
+          "bodyPaintThickness": {
+            "front": null, // TODO: Map to FormData field if available
+            "rear": {"trunk": null, "bumper": null}, // TODO: Map to FormData field if available
+            "right": {
+              "frontFender": null, // TODO: Map to FormData field if available
+              "frontDoor": null, // TODO: Map to FormData field if available
+              "rearDoor": null, // TODO: Map to FormData field if available
+              "rearFender": null, // TODO: Map to FormData field if available
+            },
+            "left": {
+              "frontFender": null, // TODO: Map to FormData field if available
+              "frontDoor": null, // TODO: Map to FormData field if available
+              "rearDoor": null, // TODO: Map to FormData field if available
+              "rearFender": null, // TODO: Map to FormData field if available
+            },
+          },
         },
       );
 

--- a/lib/statics/app_styles.dart
+++ b/lib/statics/app_styles.dart
@@ -5,7 +5,7 @@ import 'package:google_fonts/google_fonts.dart';
 
 // Colors
 const Color borderColor = Color(0xFFC28CFF);
-const Color labelTextColor = Colors.black87;
+const Color labelTextColor = Colors.black;
 const Color hintTextColor = Color(0xFFCBCBCB);
 const Color selectedDateColor = Color(
   0xFF4C1C82,

--- a/lib/widgets/custom_checkbox_tile.dart
+++ b/lib/widgets/custom_checkbox_tile.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:form_app/statics/app_styles.dart';
+
+class CustomCheckboxTile extends StatefulWidget {
+  final String label;
+  final bool initialValue;
+  final ValueChanged<bool> onChanged;
+
+  const CustomCheckboxTile({
+    super.key,
+    required this.label,
+    this.initialValue = false,
+    required this.onChanged,
+  });
+
+  @override
+  State<CustomCheckboxTile> createState() => _CustomCheckboxTileState();
+}
+
+class _CustomCheckboxTileState extends State<CustomCheckboxTile> {
+  late bool _isChecked;
+
+  @override
+  void initState() {
+    super.initState();
+    _isChecked = widget.initialValue;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Container(
+          width: 24,
+          height: 24,
+          alignment: Alignment.center,
+          child: SizedBox(
+            width: 18,
+            height: 18,
+            child: Checkbox(
+              value: _isChecked,
+              onChanged: (bool? newValue) {
+                setState(() {
+                  _isChecked = newValue ?? false;
+                });
+                widget.onChanged(_isChecked);
+              },
+              activeColor: toggleOptionSelectedLengkapColor,
+              materialTapTargetSize: MaterialTapTargetSize.padded, // Changed to padded
+              visualDensity: VisualDensity.compact,
+              side: BorderSide(
+                color: toggleOptionSelectedLengkapColor,
+                width: 2,
+              ),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(4),
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(width: 4),
+        Text(
+          widget.label,
+          style: labelStyle.copyWith(fontWeight: FontWeight.w500),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/navigation_button_row.dart
+++ b/lib/widgets/navigation_button_row.dart
@@ -83,8 +83,9 @@ class NavigationButtonRow extends StatelessWidget {
             onPressed: onNextPressed, // Always use the provided callback
             // Apply base style and override background/foreground explicitly for clarity
             style: _baseButtonStyle.copyWith(
-               backgroundColor: WidgetStateProperty.all(buttonColor), // Always orange when enabled
+               backgroundColor: WidgetStateProperty.all(isLastPage ? toggleOptionSelectedLengkapColor : buttonColor), // Blue if last page, else orange
                foregroundColor: WidgetStateProperty.all(buttonTextColor), // Always white when enabled
+               shadowColor: WidgetStateProperty.all(isLastPage ? toggleOptionSelectedLengkapColor.withAlpha(102) : buttonColor.withAlpha(102)), // Adjust shadow color
             ),
             // TODO: Handle isLoading state here later if needed
             // child: isLoading
@@ -97,7 +98,7 @@ class NavigationButtonRow extends StatelessWidget {
             //         ),
             //       )
             //     : Text(nextButtonText, style: buttonTextStyle),
-              child: Text(isLastPage ? 'Submit' : nextButtonText, style: buttonTextStyle),
+              child: Text(isLastPage ? 'Kirim' : nextButtonText, style: buttonTextStyle),
           ),
         ),
       ],

--- a/lib/widgets/numbered_button_list.dart
+++ b/lib/widgets/numbered_button_list.dart
@@ -4,14 +4,14 @@ import 'package:form_app/statics/app_styles.dart';
 class NumberedButtonList extends StatefulWidget {
   final String label;
   final int count;
-  final int selectedIndex;
+  final int selectedValue;
   final ValueChanged<int> onItemSelected;
 
   const NumberedButtonList({
     super.key,
     required this.label,
     required this.count,
-    required this.selectedIndex,
+    required this.selectedValue,
     required this.onItemSelected,
   });
 
@@ -32,12 +32,12 @@ class _NumberedButtonListState extends State<NumberedButtonList> {
         const SizedBox(height: 8.0),
         Row(
           mainAxisAlignment: MainAxisAlignment.spaceAround, // Distribute space around the buttons
-          children: List.generate(widget.count, (index) {
-            final itemNumber = index + 1;
-            final isSelected = itemNumber == widget.selectedIndex;
+          children: List.generate(widget.count, (value) {
+            final itemNumber = value + 1;
+            final isSelected = itemNumber == widget.selectedValue;
             return Expanded( // Use Expanded to make buttons take equal space
               child: GestureDetector(
-                onTap: () => widget.onItemSelected(index + 1),
+                onTap: () => widget.onItemSelected(value + 1),
                 child: Container(
                   height: 35, // Maintain height
                   width: 35, // Set a fixed width for the button
@@ -46,9 +46,9 @@ class _NumberedButtonListState extends State<NumberedButtonList> {
                     color: isSelected ? numberedButtonColors[itemNumber] : Colors.white,
                     borderRadius: BorderRadius.circular(12),
                     border: Border.all(
-                      color: widget.selectedIndex != -1 && widget.selectedIndex <= numberedButtonColors.length
-                          ? numberedButtonColors[widget.selectedIndex]!
-                          : toggleOptionSelectedLengkapColor, // Default color if no button is selected or index is out of bounds
+                      color: widget.selectedValue != -1 && widget.selectedValue <= numberedButtonColors.length
+                          ? numberedButtonColors[widget.selectedValue]!
+                          : toggleOptionSelectedLengkapColor, // Default color if no button is selected or value is out of bounds
                       width: 2,
                     ),
                   ),

--- a/lib/widgets/repair_estimation.dart
+++ b/lib/widgets/repair_estimation.dart
@@ -123,9 +123,10 @@ class _RepairEstimationState extends State<RepairEstimation> {
                         ),
                         child: TextField(
                           controller: _repairControllers[index],
+                          textCapitalization: TextCapitalization.sentences, // Auto capitalize the first letter of each sentence
                           style: repairHasText ? toggleOptionTextStyle.copyWith(color: Colors.white) : hintTextStyle, // Use toggleOptionTextStyle when text is present, hintTextStyle otherwise
                           decoration: InputDecoration(
-                            hintText: 'Masukkan perbaikan',
+                            hintText: 'Barang',
                             hintStyle: hintTextStyle, // Use hintTextStyle
                             filled: repairHasText, // Fill only if text is present
                             fillColor: borderColor, // Use borderColor for background when filled
@@ -158,7 +159,7 @@ class _RepairEstimationState extends State<RepairEstimation> {
                                   ThousandsSeparatorInputFormatter()
                                 ], // Apply thousands separator formatter
                                 decoration: InputDecoration(
-                                  hintText: 'Masukkan harga',
+                                  hintText: 'Biaya',
                                   hintStyle: hintTextStyle, // Use hintTextStyle
                                   filled: false, // Do not fill based on text
                                   fillColor: Colors.transparent, // Keep background transparent

--- a/lib/widgets/toggleable_numbered_button_list.dart
+++ b/lib/widgets/toggleable_numbered_button_list.dart
@@ -5,7 +5,7 @@ import 'package:form_app/statics/app_styles.dart';
 class ToggleableNumberedButtonList extends StatefulWidget {
   final String label;
   final int count;
-  final int selectedIndex; // Represents 1-based number (1-10) or <= 0 if none/disabled
+  final int selectedValue; // Represents 1-based number (1-10) or <= 0 if none/disabled
   final ValueChanged<int> onItemSelected; // Passes 1-based number or <= 0
   final bool initialEnabled;
   final ValueChanged<bool> onEnabledChanged;
@@ -15,7 +15,7 @@ class ToggleableNumberedButtonList extends StatefulWidget {
     super.key,
     required this.label,
     required this.count,
-    required this.selectedIndex,
+    required this.selectedValue,
     required this.onItemSelected,
     this.initialEnabled = true,
     required this.onEnabledChanged,
@@ -54,8 +54,8 @@ class _ToggleableNumberedButtonListState extends State<ToggleableNumberedButtonL
     final Color effectiveBorderColor;
     if (!_isEnabled) {
       effectiveBorderColor = Colors.grey.shade300;
-    } else if (widget.selectedIndex > 0 && numberedButtonColors.containsKey(widget.selectedIndex)) {
-      effectiveBorderColor = numberedButtonColors[widget.selectedIndex]!;
+    } else if (widget.selectedValue > 0 && numberedButtonColors.containsKey(widget.selectedValue)) {
+      effectiveBorderColor = numberedButtonColors[widget.selectedValue]!;
     } else {
       effectiveBorderColor = toggleOptionSelectedLengkapColor;
     }
@@ -121,7 +121,7 @@ class _ToggleableNumberedButtonListState extends State<ToggleableNumberedButtonL
            mainAxisAlignment: MainAxisAlignment.spaceAround,
           children: List.generate(widget.count, (index) {
             final itemNumber = index + 1;
-            final isSelected = _isEnabled && (itemNumber == widget.selectedIndex);
+            final isSelected = _isEnabled && (itemNumber == widget.selectedValue);
 
             final Color buttonBackgroundColor;
              if (isSelected) {
@@ -135,7 +135,7 @@ class _ToggleableNumberedButtonListState extends State<ToggleableNumberedButtonL
             return Expanded(
               child: GestureDetector(
                 onTap: _isEnabled
-                  ? () => widget.onItemSelected(itemNumber == widget.selectedIndex ? -1 : itemNumber)
+                  ? () => widget.onItemSelected(itemNumber == widget.selectedValue ? -1 : itemNumber)
                   : null,
                 // --- Container INSIDE Expanded with fixed size ---
                 child: Container(

--- a/lib/widgets/toggleable_numbered_button_list.dart
+++ b/lib/widgets/toggleable_numbered_button_list.dart
@@ -81,7 +81,7 @@ class _ToggleableNumberedButtonListState extends State<ToggleableNumberedButtonL
                   value: _isEnabled,
                   onChanged: _handleCheckboxChange,
                   activeColor: toggleOptionSelectedLengkapColor,
-                  materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  materialTapTargetSize: MaterialTapTargetSize.padded, // Changed to padded
                   visualDensity: VisualDensity.compact,
                   side: BorderSide(
                     color: toggleOptionSelectedLengkapColor,


### PR DESCRIPTION
## Description

This pull request introduces the assessment page for "Ban dan Kaki-kaki" and integrates its data submission with the API.

### Key Changes:

- **`lib/pages/page_five_five.dart`**: Added a new page for "Ban dan Kaki-kaki" assessment. This page includes a series of `ToggleableNumberedButtonList` widgets for items like Ban Depan, Velg Depan, Disc Brake, etc., and an `ExpandableTextField` for additional notes, all connected to the `formProvider` for state management.
- **`lib/pages/page_nine.dart`**: Added the finalization page, which includes a checkbox for user agreement and a "Kirim" (Submit) button. The submit button triggers the form data submission via the `ApiService`.
- **`lib/services/api_service.dart`**: Updated the `submitFormData` method to include placeholders for the new "Ban dan Kaki-kaki" assessment data in the API request body. Note that the mapping of the specific assessment values from `FormData` to the API request still needs to be completed (indicated by `TODO` comments in the code).
- **Form Data and Provider**: Modified `lib/models/form_data.dart` and `lib/providers/form_provider.dart` to include the necessary fields and state management logic for the new "Ban dan Kaki-kaki" assessment data.