### PR TITLE
Refactor: Enhance Page Six Image Uploads and Update Page Seven for Document Photos

### DIFF
--- a/lib/pages/page_eight.dart
+++ b/lib/pages/page_eight.dart
@@ -23,9 +23,9 @@ class PageEight extends StatelessWidget {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   PageNumber(data: '8/9'),
-                  const SizedBox(height: 8.0),
+                  const SizedBox(height: 4),
                   PageTitle(data: 'Page Eight Title'), // Placeholder Title
-                  const SizedBox(height: 24.0),
+                  const SizedBox(height: 6.0),
                   const Center(child: Text('Masih On Progress')),
                   const SizedBox(height: 32.0),
                   NavigationButtonRow(

--- a/lib/pages/page_five_five.dart
+++ b/lib/pages/page_five_five.dart
@@ -59,9 +59,9 @@ class _PageFiveFiveState extends ConsumerState<PageFiveFive> {
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         PageNumber(data: '5/9'),
-                        const SizedBox(height: 8.0),
+                        const SizedBox(height: 4),
                         PageTitle(data: 'Penilaian (5)'),
-                        const SizedBox(height: 24.0),
+                        const SizedBox(height: 6.0),
                         const HeadingOne(text: 'Ban dan Kaki-kaki'),
                         const SizedBox(height: 16.0),
                         ToggleableNumberedButtonList(

--- a/lib/pages/page_five_four.dart
+++ b/lib/pages/page_five_four.dart
@@ -60,9 +60,9 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> {
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         PageNumber(data: '5/9'),
-                        const SizedBox(height: 8.0),
+                        const SizedBox(height: 4),
                         PageTitle(data: 'Penilaian (4)'),
-                        const SizedBox(height: 24.0),
+                        const SizedBox(height: 6.0),
                         const HeadingOne(text: 'Hasil Inspeksi Eksterior'),
                         const SizedBox(height: 16.0),
 

--- a/lib/pages/page_five_one.dart
+++ b/lib/pages/page_five_one.dart
@@ -62,9 +62,9 @@ class _PageFiveOneState extends ConsumerState<PageFiveOne> {
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         PageNumber(data: '5/9'),
-                        const SizedBox(height: 8.0),
+                        const SizedBox(height: 4),
                         PageTitle(data: 'Penilaian (1)'),
-                        const SizedBox(height: 24.0),
+                        const SizedBox(height: 6.0),
                         HeadingOne(text: 'Fitur'),
                         const SizedBox(height: 16.0),
                         ToggleableNumberedButtonList(

--- a/lib/pages/page_five_seven.dart
+++ b/lib/pages/page_five_seven.dart
@@ -59,9 +59,9 @@ class _PageFiveSevenState extends ConsumerState<PageFiveSeven> {
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         PageNumber(data: '5/9'),
-                        const SizedBox(height: 8.0),
+                        const SizedBox(height: 4),
                         PageTitle(data: 'Penilaian'),
-                        const SizedBox(height: 24.0),
+                        const SizedBox(height: 6.0),
                         const HeadingOne(text: 'Tools Test (7)'),
                         const SizedBox(height: 16.0),
                         ToggleableNumberedButtonList(

--- a/lib/pages/page_five_seven.dart
+++ b/lib/pages/page_five_seven.dart
@@ -6,7 +6,7 @@ import 'package:form_app/widgets/navigation_button_row.dart';
 import 'package:form_app/widgets/page_number.dart';
 import 'package:form_app/widgets/page_title.dart';
 import 'package:form_app/widgets/footer.dart';
-import 'package:form_app/pages/page_six.dart'; // Import PageSix
+import 'package:form_app/pages/page_six_general_wajib.dart';
 import 'package:form_app/providers/form_provider.dart';
 import 'package:form_app/widgets/toggleable_numbered_button_list.dart';
 import 'package:form_app/widgets/expandable_text_field.dart';
@@ -206,7 +206,7 @@ class _PageFiveSevenState extends ConsumerState<PageFiveSeven> {
                           onNextPressed: () {
                             Navigator.push(
                               context,
-                              MaterialPageRoute(builder: (context) => const PageSix()),
+                              MaterialPageRoute(builder: (context) => const PageSixGeneralWajib()),
                             );
                           },
                         ),

--- a/lib/pages/page_five_six.dart
+++ b/lib/pages/page_five_six.dart
@@ -58,10 +58,10 @@ class _PageFiveSixState extends ConsumerState<PageFiveSix> {
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        PageNumber(data: '6/9'), // Updated page number
-                        const SizedBox(height: 8.0),
+                        PageNumber(data: '6/9'),
+                        const SizedBox(height: 4),
                         PageTitle(data: 'Penilaian (6)'),
-                        const SizedBox(height: 24.0),
+                        const SizedBox(height: 6.0),
                         const HeadingOne(text: 'Test Drive'),
                         const SizedBox(height: 16.0),
                         ToggleableNumberedButtonList(

--- a/lib/pages/page_five_three.dart
+++ b/lib/pages/page_five_three.dart
@@ -60,9 +60,9 @@ class _PageFiveThreeState extends ConsumerState<PageFiveThree> {
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         PageNumber(data: '5/9'),
-                        const SizedBox(height: 8.0),
+                        const SizedBox(height: 4),
                         PageTitle(data: 'Penilaian (3)'),
-                        const SizedBox(height: 24.0),
+                        const SizedBox(height: 6.0),
                         const HeadingOne(text: 'Hasil Inspeksi Interior'),
                         const SizedBox(height: 16.0),
 

--- a/lib/pages/page_five_two.dart
+++ b/lib/pages/page_five_two.dart
@@ -61,10 +61,10 @@ class _PageFiveTwoState extends ConsumerState<PageFiveTwo> {
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        PageNumber(data: '5/9'), // Assuming this page is still 5/9 or needs adjustment
-                        const SizedBox(height: 8.0),
+                        PageNumber(data: '5/9'),
+                        const SizedBox(height: 4),
                         PageTitle(data: 'Penilaian (2)'),
-                        const SizedBox(height: 24.0),
+                        const SizedBox(height: 6.0),
                         const HeadingOne(text: 'Hasil Inspeksi Mesin'),
                         const SizedBox(height: 16.0),
 

--- a/lib/pages/page_four.dart
+++ b/lib/pages/page_four.dart
@@ -67,9 +67,9 @@ class _PageFourState extends ConsumerState<PageFour> {
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         PageNumber(data: '4/9'),
-                        const SizedBox(height: 8.0),
+                        const SizedBox(height: 4),
                         PageTitle(data: 'Hasil Inspeksi'), // Placeholder Title
-                        const SizedBox(height: 24.0),
+                        const SizedBox(height: 6.0),
                         NumberedButtonList(
                           label: 'Interior',
                           count: 10, // Assuming 10 options based on the image

--- a/lib/pages/page_four.dart
+++ b/lib/pages/page_four.dart
@@ -79,7 +79,7 @@ class _PageFourState extends ConsumerState<PageFour> {
                             formNotifier.updateInteriorSelectedValue(value == formData.interiorSelectedValue ? -1 : value);
                           },
                         ),
-                        const SizedBox(height: 24.0),
+                        const SizedBox(height: 12.0),
                         ExpandableTextField(
                           label: 'Keterangan Interior', // Placeholder label
                           hintText:
@@ -89,7 +89,7 @@ class _PageFourState extends ConsumerState<PageFour> {
                             formNotifier.updateKeteranganInterior(lines);
                           },
                         ),
-                        const SizedBox(height: 32.0),
+                        const SizedBox(height: 24.0),
                         NumberedButtonList(
                           label: 'Eksterior',
                           count: 10, // Assuming 10 options based on the image
@@ -99,7 +99,7 @@ class _PageFourState extends ConsumerState<PageFour> {
                             formNotifier.updateEksteriorSelectedValue(value == formData.eksteriorSelectedValue ? -1 : value);
                           },
                         ),
-                        const SizedBox(height: 24.0),
+                        const SizedBox(height: 12.0),
                         ExpandableTextField(
                           label: 'Keterangan Eksterior', // Placeholder label
                           hintText:
@@ -109,7 +109,7 @@ class _PageFourState extends ConsumerState<PageFour> {
                             formNotifier.updateKeteranganEksterior(lines);
                           },
                         ),
-                        const SizedBox(height: 32.0),
+                        const SizedBox(height: 24.0),
                         NumberedButtonList(
                           label: 'Kaki-kaki',
                           count: 10, // Assuming 10 options based on the image
@@ -119,7 +119,7 @@ class _PageFourState extends ConsumerState<PageFour> {
                             formNotifier.updateKakiKakiSelectedValue(value == formData.kakiKakiSelectedValue ? -1 : value);
                           },
                         ),
-                        const SizedBox(height: 24.0),
+                        const SizedBox(height: 12.0),
                         ExpandableTextField(
                           label: 'Keterangan Kaki-kaki', // Placeholder label
                           hintText:
@@ -129,7 +129,7 @@ class _PageFourState extends ConsumerState<PageFour> {
                             formNotifier.updateKeteranganKakiKaki(lines);
                           },
                         ),
-                        const SizedBox(height: 32.0),
+                        const SizedBox(height: 24.0),
                         NumberedButtonList(
                           label: 'Mesin',
                           count: 10, // Assuming 10 options based on the image
@@ -139,7 +139,7 @@ class _PageFourState extends ConsumerState<PageFour> {
                             formNotifier.updateMesinSelectedValue(value == formData.mesinSelectedValue ? -1 : value);
                           },
                         ),
-                        const SizedBox(height: 24.0),
+                        const SizedBox(height: 12.0),
                         ExpandableTextField(
                           label: 'Keterangan Mesin', // Placeholder label
                           hintText:
@@ -149,7 +149,7 @@ class _PageFourState extends ConsumerState<PageFour> {
                             formNotifier.updateKeteranganMesin(lines);
                           },
                         ),
-                        const SizedBox(height: 32.0),
+                        const SizedBox(height: 24.0),
                         NumberedButtonList(
                           label: 'Penilaian Keseluruhan',
                           count: 10, // Assuming 10 options based on the image
@@ -159,7 +159,7 @@ class _PageFourState extends ConsumerState<PageFour> {
                             formNotifier.updatePenilaianKeseluruhanSelectedValue(value == formData.penilaianKeseluruhanSelectedValue ? -1 : value);
                           },
                         ),
-                        const SizedBox(height: 24.0),
+                        const SizedBox(height: 12.0),
                         ExpandableTextField(
                           label: 'Deskripsi Keseluruhan', // Placeholder label
                           hintText:
@@ -169,7 +169,7 @@ class _PageFourState extends ConsumerState<PageFour> {
                             formNotifier.updateDeskripsiKeseluruhan(lines);
                           },
                         ),
-                        const SizedBox(height: 32.0), // Spacing before new toggle options
+                        const SizedBox(height: 24.0), // Spacing before new toggle options
                         ToggleOption(
                           label: 'Indikasi Tabrakan',
                           toggleValues: ['Tidak ada', 'Terindikasi'],
@@ -190,7 +190,7 @@ class _PageFourState extends ConsumerState<PageFour> {
                           initialValue: formData.indikasiOdometerReset,
                           onChanged: (value) => formNotifier.updateIndikasiOdometerReset(value),
                         ),
-                        const SizedBox(height: 32.0), // Spacing before new text fields
+                        const SizedBox(height: 24.0), // Spacing before new text fields
                         LabeledTextField(
                           label: 'Posisi Ban',
                           hintText: 'Misal : Ban agak miring ke kanan',
@@ -232,7 +232,7 @@ class _PageFourState extends ConsumerState<PageFour> {
                           initialEstimations: formData.repairEstimations,
                           onChanged: (estimations) => formNotifier.updateRepairEstimations(estimations),
                         ),
-                        const SizedBox(height: 32.0), // Spacing before navigation buttons
+                        const SizedBox(height: 24.0), // Spacing before navigation buttons
                         NavigationButtonRow(
                           onBackPressed: () => Navigator.pop(context),
                           onNextPressed: () {
@@ -243,7 +243,7 @@ class _PageFourState extends ConsumerState<PageFour> {
                           },                          
                         ),
                         SizedBox(
-                          height: 32.0,
+                          height: 24.0,
                         ), // Optional spacing below the content
                         // Footer
                         Footer(),

--- a/lib/pages/page_nine.dart
+++ b/lib/pages/page_nine.dart
@@ -68,9 +68,9 @@ class _PageNineState extends ConsumerState<PageNine> {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   PageNumber(data: '9/9'),
-                  const SizedBox(height: 8.0),
+                  const SizedBox(height: 4),
                   PageTitle(data: 'Finalisasi'), // Placeholder Title
-                  const SizedBox(height: 16.0),
+                  const SizedBox(height: 6.0),
                   Text(
                     'Pastikan data yang telah diisi telah sesuai dengan yang sebenarnya dan memenuhi SOP PT Inspeksi Mobil Jogja',
                     style: labelStyle.copyWith(fontWeight: FontWeight.w300), // Corrected font weight

--- a/lib/pages/page_one.dart
+++ b/lib/pages/page_one.dart
@@ -94,9 +94,9 @@ class _PageOneState extends ConsumerState<PageOne> {
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         PageNumber(data: '1/9'),
-                        const SizedBox(height: 8.0),
+                        const SizedBox(height: 4),
                         PageTitle(data: 'Identitas'),
-                        const SizedBox(height: 24.0), // Keep internal spacing
+                        const SizedBox(height: 6.0),
                         LabeledTextField(
                           label: 'Nama Inspektor',
                           hintText: 'Masukkan nama inspektor',

--- a/lib/pages/page_seven.dart
+++ b/lib/pages/page_seven.dart
@@ -44,10 +44,10 @@ class PageSeven extends ConsumerWidget { // Change to ConsumerWidget
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  PageNumber(data: '7/9'), // Update page number
-                  const SizedBox(height: 8.0),
+                  PageNumber(data: '7/9'),
+                  const SizedBox(height: 4),
                   PageTitle(data: 'Foto Dokumen'), // Update Title
-                  const SizedBox(height: 24.0),
+                  const SizedBox(height: 6.0),
 
                   // Image inputs will go here later
                    ...imageInputLabels.map((label) => Padding(

--- a/lib/pages/page_six_alat_alat_tambahan.dart
+++ b/lib/pages/page_six_alat_alat_tambahan.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:form_app/widgets/common_layout.dart';
+import 'package:form_app/widgets/heading_one.dart';
+import 'package:form_app/widgets/navigation_button_row.dart';
+import 'package:form_app/widgets/page_number.dart';
+import 'package:form_app/widgets/page_title.dart';
+import 'package:form_app/widgets/footer.dart';
+import 'package:form_app/widgets/image_input_widget.dart'; // Keep import in case needed later
+import 'dart:io'; // Keep import in case needed later
+import 'package:form_app/models/image_data.dart'; // Keep import in case needed later
+import 'package:form_app/providers/image_data_provider.dart'; // Keep import in case needed later
+import 'package:form_app/pages/page_seven.dart'; // Import the next page
+
+class PageSixAlatAlatTambahan extends ConsumerWidget {
+  const PageSixAlatAlatTambahan({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return CommonLayout(
+      child: Column(
+        children: [
+          Expanded(
+            child: SingleChildScrollView(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  PageNumber(data: '6.12/x'), // Placeholder page number
+                  const SizedBox(height: 8.0),
+                  PageTitle(data: 'Foto Alat-alat'),
+                  const SizedBox(height: 24.0),
+                  HeadingOne(text: 'Tambahan'),
+                  const SizedBox(height: 16.0),
+
+                  // Tambahan image inputs will go here later
+
+                  const SizedBox(height: 32.0),
+                  NavigationButtonRow(
+                    onBackPressed: () => Navigator.pop(context),
+                    onNextPressed: () {
+                       Navigator.push(
+                        context,
+                        MaterialPageRoute(builder: (context) => const PageSeven()),
+                      );
+                    },
+                  ),
+                  const SizedBox(height: 32.0),
+                  Footer(),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/pages/page_six_alat_alat_tambahan.dart
+++ b/lib/pages/page_six_alat_alat_tambahan.dart
@@ -25,10 +25,10 @@ class PageSixAlatAlatTambahan extends ConsumerWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  PageNumber(data: '6.12/x'), // Placeholder page number
-                  const SizedBox(height: 8.0),
+                  PageNumber(data: '6.12/x'),
+                  const SizedBox(height: 4),
                   PageTitle(data: 'Foto Alat-alat'),
-                  const SizedBox(height: 24.0),
+                  const SizedBox(height: 6.0),
                   HeadingOne(text: 'Tambahan'),
                   const SizedBox(height: 16.0),
 

--- a/lib/pages/page_six_alat_alat_tambahan.dart
+++ b/lib/pages/page_six_alat_alat_tambahan.dart
@@ -25,7 +25,7 @@ class PageSixAlatAlatTambahan extends ConsumerWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  PageNumber(data: '6.12/x'),
+                  PageNumber(data: '6/9'),
                   const SizedBox(height: 4),
                   PageTitle(data: 'Foto Alat-alat'),
                   const SizedBox(height: 6.0),

--- a/lib/pages/page_six_alat_alat_wajib.dart
+++ b/lib/pages/page_six_alat_alat_wajib.dart
@@ -50,10 +50,10 @@ class PageSixAlatAlatWajib extends ConsumerWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  PageNumber(data: '6.11/x'), // Placeholder page number
-                  const SizedBox(height: 8.0),
+                  PageNumber(data: '6.11/x'),
+                  const SizedBox(height: 4),
                   PageTitle(data: 'Foto Alat-alat'),
-                  const SizedBox(height: 24.0),
+                  const SizedBox(height: 6.0),
                   HeadingOne(text: 'Wajib'),
                   const SizedBox(height: 16.0),
 

--- a/lib/pages/page_six_alat_alat_wajib.dart
+++ b/lib/pages/page_six_alat_alat_wajib.dart
@@ -50,7 +50,7 @@ class PageSixAlatAlatWajib extends ConsumerWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  PageNumber(data: '6.11/x'),
+                  PageNumber(data: '6/9'),
                   const SizedBox(height: 4),
                   PageTitle(data: 'Foto Alat-alat'),
                   const SizedBox(height: 6.0),

--- a/lib/pages/page_six_alat_alat_wajib.dart
+++ b/lib/pages/page_six_alat_alat_wajib.dart
@@ -1,22 +1,28 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart'; // Import flutter_riverpod
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:form_app/widgets/common_layout.dart';
+import 'package:form_app/widgets/heading_one.dart';
 import 'package:form_app/widgets/navigation_button_row.dart';
 import 'package:form_app/widgets/page_number.dart';
 import 'package:form_app/widgets/page_title.dart';
 import 'package:form_app/widgets/footer.dart';
-import 'package:form_app/widgets/image_input_widget.dart'; // Import ImageInputWidget
-import 'dart:io'; // Import File
-import 'package:form_app/models/image_data.dart'; // Import ImageData
-import 'package:form_app/providers/image_data_provider.dart'; // Import ImageDataProvider
-import 'package:form_app/pages/page_eight.dart'; // Import PageEight
+import 'package:form_app/widgets/image_input_widget.dart'; // Keep import in case needed later
+import 'dart:io'; // Keep import in case needed later
+import 'package:form_app/models/image_data.dart'; // Keep import in case needed later
+import 'package:form_app/providers/image_data_provider.dart'; // Keep import in case needed later
+import 'package:form_app/pages/page_six_alat_alat_tambahan.dart'; // Import the next page
 
-// Foto Dokumen Page (formerly Page Seven)
-class PageSeven extends ConsumerWidget { // Change to ConsumerWidget
-  const PageSeven({super.key});
+class PageSixAlatAlatWajib extends ConsumerWidget {
+  const PageSixAlatAlatWajib({super.key});
 
-  // Image input labels will go here later
-  final List<String> imageInputLabels = const [];
+  final List<String> imageInputLabels = const [
+    'OBD Scanner',
+    'Sinar UV',
+    'Paint Thickness',
+    'Cek Aki',
+    'Tire Thickness',
+    'Endoscope (Jika Perlu)',
+  ];
 
   void _handleImagePicked(String label, File? imageFile, WidgetRef ref) {
     final imageDataListNotifier = ref.read(imageDataListProvider.notifier);
@@ -35,7 +41,7 @@ class PageSeven extends ConsumerWidget { // Change to ConsumerWidget
   }
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) { // Add WidgetRef ref
+  Widget build(BuildContext context, WidgetRef ref) {
     return CommonLayout(
       child: Column(
         children: [
@@ -44,12 +50,14 @@ class PageSeven extends ConsumerWidget { // Change to ConsumerWidget
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  PageNumber(data: '7/9'), // Update page number
+                  PageNumber(data: '6.11/x'), // Placeholder page number
                   const SizedBox(height: 8.0),
-                  PageTitle(data: 'Foto Dokumen'), // Update Title
+                  PageTitle(data: 'Foto Alat-alat'),
                   const SizedBox(height: 24.0),
+                  HeadingOne(text: 'Wajib'),
+                  const SizedBox(height: 16.0),
 
-                  // Image inputs will go here later
+                  // Wajib image inputs will go here later
                    ...imageInputLabels.map((label) => Padding(
                     padding: const EdgeInsets.only(bottom: 16.0),
                     child: ImageInputWidget(
@@ -66,7 +74,7 @@ class PageSeven extends ConsumerWidget { // Change to ConsumerWidget
                     onNextPressed: () {
                        Navigator.push(
                         context,
-                        MaterialPageRoute(builder: (context) => const PageEight()),
+                        MaterialPageRoute(builder: (context) => const PageSixAlatAlatTambahan()),
                       );
                     },
                   ),

--- a/lib/pages/page_six_eksterior_tambahan.dart
+++ b/lib/pages/page_six_eksterior_tambahan.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:form_app/widgets/common_layout.dart';
+import 'package:form_app/widgets/heading_one.dart';
+import 'package:form_app/widgets/navigation_button_row.dart';
+import 'package:form_app/widgets/page_number.dart';
+import 'package:form_app/widgets/page_title.dart';
+import 'package:form_app/widgets/footer.dart';
+import 'package:form_app/widgets/image_input_widget.dart'; // Keep import in case needed later
+import 'dart:io'; // Keep import in case needed later
+import 'package:form_app/models/image_data.dart'; // Keep import in case needed later
+import 'package:form_app/providers/image_data_provider.dart'; // Keep import in case needed later
+import 'package:form_app/pages/page_six_interior_wajib.dart'; // Import the next page
+
+class PageSixEksteriorTambahan extends ConsumerWidget {
+  const PageSixEksteriorTambahan({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return CommonLayout(
+      child: Column(
+        children: [
+          Expanded(
+            child: SingleChildScrollView(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  PageNumber(data: '6.4/x'), // Placeholder page number
+                  const SizedBox(height: 8.0),
+                  PageTitle(data: 'Foto Eksterior'),
+                  const SizedBox(height: 24.0),
+                  HeadingOne(text: 'Tambahan'),
+                  const SizedBox(height: 16.0),
+
+                  // Tambahan image inputs will go here later
+
+                  const SizedBox(height: 32.0),
+                  NavigationButtonRow(
+                    onBackPressed: () => Navigator.pop(context),
+                    onNextPressed: () {
+                       Navigator.push(
+                        context,
+                        MaterialPageRoute(builder: (context) => const PageSixInteriorWajib()),
+                      );
+                    },
+                  ),
+                  const SizedBox(height: 32.0),
+                  Footer(),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/pages/page_six_eksterior_tambahan.dart
+++ b/lib/pages/page_six_eksterior_tambahan.dart
@@ -25,10 +25,10 @@ class PageSixEksteriorTambahan extends ConsumerWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  PageNumber(data: '6.4/x'), // Placeholder page number
-                  const SizedBox(height: 8.0),
+                  PageNumber(data: '6.4/x'),
+                  const SizedBox(height: 4),
                   PageTitle(data: 'Foto Eksterior'),
-                  const SizedBox(height: 24.0),
+                  const SizedBox(height: 6.0),
                   HeadingOne(text: 'Tambahan'),
                   const SizedBox(height: 16.0),
 

--- a/lib/pages/page_six_eksterior_tambahan.dart
+++ b/lib/pages/page_six_eksterior_tambahan.dart
@@ -25,7 +25,7 @@ class PageSixEksteriorTambahan extends ConsumerWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  PageNumber(data: '6.4/x'),
+                  PageNumber(data: '6/9'),
                   const SizedBox(height: 4),
                   PageTitle(data: 'Foto Eksterior'),
                   const SizedBox(height: 6.0),

--- a/lib/pages/page_six_eksterior_wajib.dart
+++ b/lib/pages/page_six_eksterior_wajib.dart
@@ -62,10 +62,10 @@ class PageSixEksteriorWajib extends ConsumerWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  PageNumber(data: '6.3/x'), // Placeholder page number
-                  const SizedBox(height: 8.0),
+                  PageNumber(data: '6.3/x'), 
+                  const SizedBox(height: 4),
                   PageTitle(data: 'Foto Eksterior'),
-                  const SizedBox(height: 24.0),
+                  const SizedBox(height: 6.0),
                   HeadingOne(text: 'Wajib'),
                   const SizedBox(height: 16.0),
 

--- a/lib/pages/page_six_eksterior_wajib.dart
+++ b/lib/pages/page_six_eksterior_wajib.dart
@@ -62,7 +62,7 @@ class PageSixEksteriorWajib extends ConsumerWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  PageNumber(data: '6.3/x'), 
+                  PageNumber(data: '6/9'),
                   const SizedBox(height: 4),
                   PageTitle(data: 'Foto Eksterior'),
                   const SizedBox(height: 6.0),

--- a/lib/pages/page_six_eksterior_wajib.dart
+++ b/lib/pages/page_six_eksterior_wajib.dart
@@ -1,50 +1,55 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:form_app/widgets/common_layout.dart';
 import 'package:form_app/widgets/heading_one.dart';
 import 'package:form_app/widgets/navigation_button_row.dart';
 import 'package:form_app/widgets/page_number.dart';
 import 'package:form_app/widgets/page_title.dart';
 import 'package:form_app/widgets/footer.dart';
-import 'package:form_app/pages/page_seven.dart'; // Import PageSeven
-import 'package:form_app/widgets/image_input_widget.dart'; // Import ImageInputWidget
-import 'dart:io'; // Import File
-import 'package:flutter_riverpod/flutter_riverpod.dart'; // Import flutter_riverpod
-import 'package:form_app/models/image_data.dart'; // Import ImageData
-import 'package:form_app/providers/image_data_provider.dart'; // Import ImageDataProvider
+import 'package:form_app/widgets/image_input_widget.dart';
+import 'dart:io';
+import 'package:form_app/models/image_data.dart';
+import 'package:form_app/providers/image_data_provider.dart';
+import 'package:form_app/pages/page_six_eksterior_tambahan.dart'; // Import the next page
 
-class PageSix extends ConsumerWidget {
-  const PageSix({super.key});
+class PageSixEksteriorWajib extends ConsumerWidget {
+  const PageSixEksteriorWajib({super.key});
 
-  // List of labels for the ImageInputWidgets
   final List<String> imageInputLabels = const [
-    'OBD Scanner',
-    'Sinar UV',
-    'Paint Thickness',
-    'Cek Aki',
-    'Tire Thickness',
-    'Endoscope (Jika Perlu)',
+    'Cat Samping Kanan dan Kiri (Pintu Mobil)',
+    'Pilar Pintu Tengah Depan',
+    'Pilar Pintu Tengah Belakang',
+    'Karet Pada Pilar',
+    'Celah Bagasi',
+    'Sealer Bagasi',
+    'Pilar Bagasi',
+    'Karet Bagasi',
+    'Baut Bagasi',
+    'Kolong Bagasi',
+    'Asap Kendaraan Jika Ngobos',
+    'Bumper',
+    'Fender',
+    'Handle Pintu',
+    'Quarter',
+    'Lisplang',
+    'Lampu',
+    'Foglamp',
   ];
 
-  // Method to handle image picked callback
   void _handleImagePicked(String label, File? imageFile, WidgetRef ref) {
-    final imageDataListNotifier = ref.read(imageDataListProvider.notifier); // Access image data provider
+    final imageDataListNotifier = ref.read(imageDataListProvider.notifier);
 
     if (imageFile != null) {
-      // Find if an ImageData with the same label exists
       int existingIndex = ref.read(imageDataListProvider).indexWhere((img) => img.label == label);
 
       if (existingIndex != -1) {
-        // Update existing ImageData
         imageDataListNotifier.updateImageDataByLabel(label, imagePath: imageFile.path);
       } else {
-        // Add new ImageData
         imageDataListNotifier.addImageData(ImageData(label: label, imagePath: imageFile.path));
       }
     } else {
-       // If imageFile is null, remove the ImageData with the corresponding label
-      imageDataListNotifier.removeImageDataByLabel(label);
+       imageDataListNotifier.removeImageDataByLabel(label);
     }
-    //print('Image picked for $label: ${imageFile?.path}');
   }
 
   @override
@@ -57,34 +62,30 @@ class PageSix extends ConsumerWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  PageNumber(data: '6/9'),
+                  PageNumber(data: '6.3/x'), // Placeholder page number
                   const SizedBox(height: 8.0),
-                  PageTitle(data: 'Foto Alat-alat'),
+                  PageTitle(data: 'Foto Eksterior'),
                   const SizedBox(height: 24.0),
                   HeadingOne(text: 'Wajib'),
                   const SizedBox(height: 16.0),
-              
-                  // Add ImageInputWidgets dynamically
+
                   ...imageInputLabels.map((label) => Padding(
-                    padding: const EdgeInsets.only(bottom: 16.0), // Spacing between widgets
+                    padding: const EdgeInsets.only(bottom: 16.0),
                     child: ImageInputWidget(
                       label: label,
                       onImagePicked: (imageFile) {
-                        _handleImagePicked(label, imageFile, ref); // Pass ref
+                        _handleImagePicked(label, imageFile, ref);
                       },
                     ),
                   )),
-              
+
                   const SizedBox(height: 32.0),
                   NavigationButtonRow(
                     onBackPressed: () => Navigator.pop(context),
                     onNextPressed: () {
-                      // TODO: Pass the _pickedImages data to the next page or form data
-                      // Access image data list
-                      //print('Picked Images: $imageDataList');
-                      Navigator.push(
+                       Navigator.push(
                         context,
-                        MaterialPageRoute(builder: (context) => const PageSeven()),
+                        MaterialPageRoute(builder: (context) => const PageSixEksteriorTambahan()),
                       );
                     },
                   ),

--- a/lib/pages/page_six_general_tambahan.dart
+++ b/lib/pages/page_six_general_tambahan.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:form_app/widgets/common_layout.dart';
+import 'package:form_app/widgets/heading_one.dart';
+import 'package:form_app/widgets/navigation_button_row.dart';
+import 'package:form_app/widgets/page_number.dart';
+import 'package:form_app/widgets/page_title.dart';
+import 'package:form_app/widgets/footer.dart';
+import 'package:form_app/widgets/image_input_widget.dart'; // Keep import in case needed later
+import 'dart:io'; // Keep import in case needed later
+import 'package:form_app/models/image_data.dart'; // Keep import in case needed later
+import 'package:form_app/providers/image_data_provider.dart'; // Keep import in case needed later
+import 'package:form_app/pages/page_six_eksterior_wajib.dart'; // Import the next page
+
+class PageSixGeneralTambahan extends ConsumerWidget {
+  const PageSixGeneralTambahan({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return CommonLayout(
+      child: Column(
+        children: [
+          Expanded(
+            child: SingleChildScrollView(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  PageNumber(data: '6.2/x'), // Placeholder page number
+                  const SizedBox(height: 8.0),
+                  PageTitle(data: 'Foto General'),
+                  const SizedBox(height: 24.0),
+                  HeadingOne(text: 'Tambahan'),
+                  const SizedBox(height: 16.0),
+
+                  // Tambahan image inputs will go here later
+
+                  const SizedBox(height: 32.0),
+                  NavigationButtonRow(
+                    onBackPressed: () => Navigator.pop(context),
+                    onNextPressed: () {
+                       Navigator.push(
+                        context,
+                        MaterialPageRoute(builder: (context) => const PageSixEksteriorWajib()),
+                      );
+                    },
+                  ),
+                  const SizedBox(height: 32.0),
+                  Footer(),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/pages/page_six_general_tambahan.dart
+++ b/lib/pages/page_six_general_tambahan.dart
@@ -25,10 +25,10 @@ class PageSixGeneralTambahan extends ConsumerWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  PageNumber(data: '6.2/x'), // Placeholder page number
-                  const SizedBox(height: 8.0),
+                  PageNumber(data: '6.2/x'),
+                  const SizedBox(height: 4),
                   PageTitle(data: 'Foto General'),
-                  const SizedBox(height: 24.0),
+                  const SizedBox(height: 6.0),
                   HeadingOne(text: 'Tambahan'),
                   const SizedBox(height: 16.0),
 

--- a/lib/pages/page_six_general_tambahan.dart
+++ b/lib/pages/page_six_general_tambahan.dart
@@ -25,7 +25,7 @@ class PageSixGeneralTambahan extends ConsumerWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  PageNumber(data: '6.2/x'),
+                  PageNumber(data: '6/9'),
                   const SizedBox(height: 4),
                   PageTitle(data: 'Foto General'),
                   const SizedBox(height: 6.0),

--- a/lib/pages/page_six_general_wajib.dart
+++ b/lib/pages/page_six_general_wajib.dart
@@ -47,7 +47,7 @@ class PageSixGeneralWajib extends ConsumerWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  PageNumber(data: '6.1/x'),
+                  PageNumber(data: '6/9'),
                   const SizedBox(height: 4),
                   PageTitle(data: 'Foto General'),
                   const SizedBox(height: 6.0),

--- a/lib/pages/page_six_general_wajib.dart
+++ b/lib/pages/page_six_general_wajib.dart
@@ -1,22 +1,25 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart'; // Import flutter_riverpod
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:form_app/widgets/common_layout.dart';
+import 'package:form_app/widgets/heading_one.dart';
 import 'package:form_app/widgets/navigation_button_row.dart';
 import 'package:form_app/widgets/page_number.dart';
 import 'package:form_app/widgets/page_title.dart';
 import 'package:form_app/widgets/footer.dart';
-import 'package:form_app/widgets/image_input_widget.dart'; // Import ImageInputWidget
-import 'dart:io'; // Import File
-import 'package:form_app/models/image_data.dart'; // Import ImageData
-import 'package:form_app/providers/image_data_provider.dart'; // Import ImageDataProvider
-import 'package:form_app/pages/page_eight.dart'; // Import PageEight
+import 'package:form_app/widgets/image_input_widget.dart';
+import 'dart:io';
+import 'package:form_app/models/image_data.dart';
+import 'package:form_app/providers/image_data_provider.dart';
+import 'package:form_app/pages/page_six_general_tambahan.dart'; // Import the next page
 
-// Foto Dokumen Page (formerly Page Seven)
-class PageSeven extends ConsumerWidget { // Change to ConsumerWidget
-  const PageSeven({super.key});
+class PageSixGeneralWajib extends ConsumerWidget {
+  const PageSixGeneralWajib({super.key});
 
-  // Image input labels will go here later
-  final List<String> imageInputLabels = const [];
+  final List<String> imageInputLabels = const [
+    'Tampak Depan',
+    'Tampak Samping Kanan',
+    'Tampak Samping Kiri',
+  ];
 
   void _handleImagePicked(String label, File? imageFile, WidgetRef ref) {
     final imageDataListNotifier = ref.read(imageDataListProvider.notifier);
@@ -35,7 +38,7 @@ class PageSeven extends ConsumerWidget { // Change to ConsumerWidget
   }
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) { // Add WidgetRef ref
+  Widget build(BuildContext context, WidgetRef ref) {
     return CommonLayout(
       child: Column(
         children: [
@@ -44,13 +47,14 @@ class PageSeven extends ConsumerWidget { // Change to ConsumerWidget
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  PageNumber(data: '7/9'), // Update page number
+                  PageNumber(data: '6.1/x'), // Placeholder page number
                   const SizedBox(height: 8.0),
-                  PageTitle(data: 'Foto Dokumen'), // Update Title
+                  PageTitle(data: 'Foto General'),
                   const SizedBox(height: 24.0),
+                  HeadingOne(text: 'Wajib'),
+                  const SizedBox(height: 16.0),
 
-                  // Image inputs will go here later
-                   ...imageInputLabels.map((label) => Padding(
+                  ...imageInputLabels.map((label) => Padding(
                     padding: const EdgeInsets.only(bottom: 16.0),
                     child: ImageInputWidget(
                       label: label,
@@ -64,9 +68,9 @@ class PageSeven extends ConsumerWidget { // Change to ConsumerWidget
                   NavigationButtonRow(
                     onBackPressed: () => Navigator.pop(context),
                     onNextPressed: () {
-                       Navigator.push(
+                      Navigator.push(
                         context,
-                        MaterialPageRoute(builder: (context) => const PageEight()),
+                        MaterialPageRoute(builder: (context) => const PageSixGeneralTambahan()),
                       );
                     },
                   ),

--- a/lib/pages/page_six_general_wajib.dart
+++ b/lib/pages/page_six_general_wajib.dart
@@ -47,10 +47,10 @@ class PageSixGeneralWajib extends ConsumerWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  PageNumber(data: '6.1/x'), // Placeholder page number
-                  const SizedBox(height: 8.0),
+                  PageNumber(data: '6.1/x'),
+                  const SizedBox(height: 4),
                   PageTitle(data: 'Foto General'),
-                  const SizedBox(height: 24.0),
+                  const SizedBox(height: 6.0),
                   HeadingOne(text: 'Wajib'),
                   const SizedBox(height: 16.0),
 

--- a/lib/pages/page_six_interior_tambahan.dart
+++ b/lib/pages/page_six_interior_tambahan.dart
@@ -25,7 +25,7 @@ class PageSixInteriorTambahan extends ConsumerWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  PageNumber(data: '6.6/x'),
+                  PageNumber(data: '6/9'),
                   const SizedBox(height: 4),
                   PageTitle(data: 'Foto Interior'),
                   const SizedBox(height: 6.0),

--- a/lib/pages/page_six_interior_tambahan.dart
+++ b/lib/pages/page_six_interior_tambahan.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:form_app/widgets/common_layout.dart';
+import 'package:form_app/widgets/heading_one.dart';
+import 'package:form_app/widgets/navigation_button_row.dart';
+import 'package:form_app/widgets/page_number.dart';
+import 'package:form_app/widgets/page_title.dart';
+import 'package:form_app/widgets/footer.dart';
+import 'package:form_app/widgets/image_input_widget.dart'; // Keep import in case needed later
+import 'dart:io'; // Keep import in case needed later
+import 'package:form_app/models/image_data.dart'; // Keep import in case needed later
+import 'package:form_app/providers/image_data_provider.dart'; // Keep import in case needed later
+import 'package:form_app/pages/page_six_mesin_wajib.dart'; // Import the next page
+
+class PageSixInteriorTambahan extends ConsumerWidget {
+  const PageSixInteriorTambahan({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return CommonLayout(
+      child: Column(
+        children: [
+          Expanded(
+            child: SingleChildScrollView(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  PageNumber(data: '6.6/x'), // Placeholder page number
+                  const SizedBox(height: 8.0),
+                  PageTitle(data: 'Foto Interior'),
+                  const SizedBox(height: 24.0),
+                  HeadingOne(text: 'Tambahan'),
+                  const SizedBox(height: 16.0),
+
+                  // Tambahan image inputs will go here later
+
+                  const SizedBox(height: 32.0),
+                  NavigationButtonRow(
+                    onBackPressed: () => Navigator.pop(context),
+                    onNextPressed: () {
+                       Navigator.push(
+                        context,
+                        MaterialPageRoute(builder: (context) => const PageSixMesinWajib()),
+                      );
+                    },
+                  ),
+                  const SizedBox(height: 32.0),
+                  Footer(),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/pages/page_six_interior_tambahan.dart
+++ b/lib/pages/page_six_interior_tambahan.dart
@@ -25,10 +25,10 @@ class PageSixInteriorTambahan extends ConsumerWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  PageNumber(data: '6.6/x'), // Placeholder page number
-                  const SizedBox(height: 8.0),
+                  PageNumber(data: '6.6/x'),
+                  const SizedBox(height: 4),
                   PageTitle(data: 'Foto Interior'),
-                  const SizedBox(height: 24.0),
+                  const SizedBox(height: 6.0),
                   HeadingOne(text: 'Tambahan'),
                   const SizedBox(height: 16.0),
 

--- a/lib/pages/page_six_interior_wajib.dart
+++ b/lib/pages/page_six_interior_wajib.dart
@@ -56,10 +56,10 @@ class PageSixInteriorWajib extends ConsumerWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  PageNumber(data: '6.5/x'), // Placeholder page number
-                  const SizedBox(height: 8.0),
+                  PageNumber(data: '6.5/x'),
+                  const SizedBox(height: 4),
                   PageTitle(data: 'Foto Interior'),
-                  const SizedBox(height: 24.0),
+                  const SizedBox(height: 6.0),
                   HeadingOne(text: 'Wajib'),
                   const SizedBox(height: 16.0),
 

--- a/lib/pages/page_six_interior_wajib.dart
+++ b/lib/pages/page_six_interior_wajib.dart
@@ -1,22 +1,34 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart'; // Import flutter_riverpod
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:form_app/widgets/common_layout.dart';
+import 'package:form_app/widgets/heading_one.dart';
 import 'package:form_app/widgets/navigation_button_row.dart';
 import 'package:form_app/widgets/page_number.dart';
 import 'package:form_app/widgets/page_title.dart';
 import 'package:form_app/widgets/footer.dart';
-import 'package:form_app/widgets/image_input_widget.dart'; // Import ImageInputWidget
-import 'dart:io'; // Import File
-import 'package:form_app/models/image_data.dart'; // Import ImageData
-import 'package:form_app/providers/image_data_provider.dart'; // Import ImageDataProvider
-import 'package:form_app/pages/page_eight.dart'; // Import PageEight
+import 'package:form_app/widgets/image_input_widget.dart'; // Keep import in case needed later
+import 'dart:io'; // Keep import in case needed later
+import 'package:form_app/models/image_data.dart'; // Keep import in case needed later
+import 'package:form_app/providers/image_data_provider.dart'; // Keep import in case needed later
+import 'package:form_app/pages/page_six_interior_tambahan.dart'; // Import the next page
 
-// Foto Dokumen Page (formerly Page Seven)
-class PageSeven extends ConsumerWidget { // Change to ConsumerWidget
-  const PageSeven({super.key});
+class PageSixInteriorWajib extends ConsumerWidget {
+  const PageSixInteriorWajib({super.key});
 
-  // Image input labels will go here later
-  final List<String> imageInputLabels = const [];
+  final List<String> imageInputLabels = const [
+    'Transmisi',
+    'Pedal',
+    'Dashboard Mobil',
+    'Stir',
+    'Jok',
+    'Doortrim',
+    'Karpet',
+    'Plafon',
+    'Tuas Wiper',
+    'Tuas Lampu',
+    'Safety Belt',
+    'Lantai Mobil',
+  ];
 
   void _handleImagePicked(String label, File? imageFile, WidgetRef ref) {
     final imageDataListNotifier = ref.read(imageDataListProvider.notifier);
@@ -35,7 +47,7 @@ class PageSeven extends ConsumerWidget { // Change to ConsumerWidget
   }
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) { // Add WidgetRef ref
+  Widget build(BuildContext context, WidgetRef ref) {
     return CommonLayout(
       child: Column(
         children: [
@@ -44,12 +56,14 @@ class PageSeven extends ConsumerWidget { // Change to ConsumerWidget
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  PageNumber(data: '7/9'), // Update page number
+                  PageNumber(data: '6.5/x'), // Placeholder page number
                   const SizedBox(height: 8.0),
-                  PageTitle(data: 'Foto Dokumen'), // Update Title
+                  PageTitle(data: 'Foto Interior'),
                   const SizedBox(height: 24.0),
+                  HeadingOne(text: 'Wajib'),
+                  const SizedBox(height: 16.0),
 
-                  // Image inputs will go here later
+                  // Wajib image inputs will go here later
                    ...imageInputLabels.map((label) => Padding(
                     padding: const EdgeInsets.only(bottom: 16.0),
                     child: ImageInputWidget(
@@ -66,7 +80,7 @@ class PageSeven extends ConsumerWidget { // Change to ConsumerWidget
                     onNextPressed: () {
                        Navigator.push(
                         context,
-                        MaterialPageRoute(builder: (context) => const PageEight()),
+                        MaterialPageRoute(builder: (context) => const PageSixInteriorTambahan()),
                       );
                     },
                   ),

--- a/lib/pages/page_six_interior_wajib.dart
+++ b/lib/pages/page_six_interior_wajib.dart
@@ -56,7 +56,7 @@ class PageSixInteriorWajib extends ConsumerWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  PageNumber(data: '6.5/x'),
+                  PageNumber(data: '6/9'),
                   const SizedBox(height: 4),
                   PageTitle(data: 'Foto Interior'),
                   const SizedBox(height: 6.0),

--- a/lib/pages/page_six_kaki_kaki_tambahan.dart
+++ b/lib/pages/page_six_kaki_kaki_tambahan.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:form_app/widgets/common_layout.dart';
+import 'package:form_app/widgets/heading_one.dart';
+import 'package:form_app/widgets/navigation_button_row.dart';
+import 'package:form_app/widgets/page_number.dart';
+import 'package:form_app/widgets/page_title.dart';
+import 'package:form_app/widgets/footer.dart';
+import 'package:form_app/widgets/image_input_widget.dart'; // Keep import in case needed later
+import 'dart:io'; // Keep import in case needed later
+import 'package:form_app/models/image_data.dart'; // Keep import in case needed later
+import 'package:form_app/providers/image_data_provider.dart'; // Keep import in case needed later
+import 'package:form_app/pages/page_six_alat_alat_wajib.dart'; // Import the next page
+
+class PageSixKakiKakiTambahan extends ConsumerWidget {
+  const PageSixKakiKakiTambahan({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return CommonLayout(
+      child: Column(
+        children: [
+          Expanded(
+            child: SingleChildScrollView(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  PageNumber(data: '6.10/x'), // Placeholder page number
+                  const SizedBox(height: 8.0),
+                  PageTitle(data: 'Foto Kaki-kaki'),
+                  const SizedBox(height: 24.0),
+                  HeadingOne(text: 'Tambahan'),
+                  const SizedBox(height: 16.0),
+
+                  // Tambahan image inputs will go here later
+
+                  const SizedBox(height: 32.0),
+                  NavigationButtonRow(
+                    onBackPressed: () => Navigator.pop(context),
+                    onNextPressed: () {
+                       Navigator.push(
+                        context,
+                        MaterialPageRoute(builder: (context) => const PageSixAlatAlatWajib()),
+                      );
+                    },
+                  ),
+                  const SizedBox(height: 32.0),
+                  Footer(),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/pages/page_six_kaki_kaki_tambahan.dart
+++ b/lib/pages/page_six_kaki_kaki_tambahan.dart
@@ -25,10 +25,10 @@ class PageSixKakiKakiTambahan extends ConsumerWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  PageNumber(data: '6.10/x'), // Placeholder page number
-                  const SizedBox(height: 8.0),
+                  PageNumber(data: '6.10/x'),
+                  const SizedBox(height: 4),
                   PageTitle(data: 'Foto Kaki-kaki'),
-                  const SizedBox(height: 24.0),
+                  const SizedBox(height: 6.0),
                   HeadingOne(text: 'Tambahan'),
                   const SizedBox(height: 16.0),
 

--- a/lib/pages/page_six_kaki_kaki_tambahan.dart
+++ b/lib/pages/page_six_kaki_kaki_tambahan.dart
@@ -25,7 +25,7 @@ class PageSixKakiKakiTambahan extends ConsumerWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  PageNumber(data: '6.10/x'),
+                  PageNumber(data: '6/9'),
                   const SizedBox(height: 4),
                   PageTitle(data: 'Foto Kaki-kaki'),
                   const SizedBox(height: 6.0),

--- a/lib/pages/page_six_kaki_kaki_wajib.dart
+++ b/lib/pages/page_six_kaki_kaki_wajib.dart
@@ -58,7 +58,7 @@ class PageSixKakiKakiWajib extends ConsumerWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  PageNumber(data: '6.9/x'),
+                  PageNumber(data: '6/9'),
                   const SizedBox(height: 4),
                   PageTitle(data: 'Foto Kaki-kaki'),
                   const SizedBox(height: 6.0),

--- a/lib/pages/page_six_kaki_kaki_wajib.dart
+++ b/lib/pages/page_six_kaki_kaki_wajib.dart
@@ -58,10 +58,10 @@ class PageSixKakiKakiWajib extends ConsumerWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  PageNumber(data: '6.9/x'), // Placeholder page number
-                  const SizedBox(height: 8.0),
+                  PageNumber(data: '6.9/x'),
+                  const SizedBox(height: 4),
                   PageTitle(data: 'Foto Kaki-kaki'),
-                  const SizedBox(height: 24.0),
+                  const SizedBox(height: 6.0),
                   HeadingOne(text: 'Wajib'),
                   const SizedBox(height: 16.0),
 

--- a/lib/pages/page_six_kaki_kaki_wajib.dart
+++ b/lib/pages/page_six_kaki_kaki_wajib.dart
@@ -1,22 +1,36 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart'; // Import flutter_riverpod
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:form_app/widgets/common_layout.dart';
+import 'package:form_app/widgets/heading_one.dart';
 import 'package:form_app/widgets/navigation_button_row.dart';
 import 'package:form_app/widgets/page_number.dart';
 import 'package:form_app/widgets/page_title.dart';
 import 'package:form_app/widgets/footer.dart';
-import 'package:form_app/widgets/image_input_widget.dart'; // Import ImageInputWidget
-import 'dart:io'; // Import File
-import 'package:form_app/models/image_data.dart'; // Import ImageData
-import 'package:form_app/providers/image_data_provider.dart'; // Import ImageDataProvider
-import 'package:form_app/pages/page_eight.dart'; // Import PageEight
+import 'package:form_app/widgets/image_input_widget.dart'; // Keep import in case needed later
+import 'dart:io'; // Keep import in case needed later
+import 'package:form_app/models/image_data.dart'; // Keep import in case needed later
+import 'package:form_app/providers/image_data_provider.dart'; // Keep import in case needed later
+import 'package:form_app/pages/page_six_kaki_kaki_tambahan.dart'; // Import the next page
 
-// Foto Dokumen Page (formerly Page Seven)
-class PageSeven extends ConsumerWidget { // Change to ConsumerWidget
-  const PageSeven({super.key});
+class PageSixKakiKakiWajib extends ConsumerWidget {
+  const PageSixKakiKakiWajib({super.key});
 
-  // Image input labels will go here later
-  final List<String> imageInputLabels = const [];
+  final List<String> imageInputLabels = const [
+    'Cakram',
+    'Kampas rem',
+    'Celah Antara Roda dan Fender',
+    'Ulir Ban',
+    'Usia Ban',
+    'Tie Rod',
+    'Link Stabilizer',
+    'Balljoint',
+    'Shock Breaker',
+    'As Roda Depan',
+    'Kabel Ties',
+    'Lower Arm',
+    'Crossmember',
+    'Chassis',
+  ];
 
   void _handleImagePicked(String label, File? imageFile, WidgetRef ref) {
     final imageDataListNotifier = ref.read(imageDataListProvider.notifier);
@@ -35,7 +49,7 @@ class PageSeven extends ConsumerWidget { // Change to ConsumerWidget
   }
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) { // Add WidgetRef ref
+  Widget build(BuildContext context, WidgetRef ref) {
     return CommonLayout(
       child: Column(
         children: [
@@ -44,12 +58,14 @@ class PageSeven extends ConsumerWidget { // Change to ConsumerWidget
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  PageNumber(data: '7/9'), // Update page number
+                  PageNumber(data: '6.9/x'), // Placeholder page number
                   const SizedBox(height: 8.0),
-                  PageTitle(data: 'Foto Dokumen'), // Update Title
+                  PageTitle(data: 'Foto Kaki-kaki'),
                   const SizedBox(height: 24.0),
+                  HeadingOne(text: 'Wajib'),
+                  const SizedBox(height: 16.0),
 
-                  // Image inputs will go here later
+                  // Wajib image inputs will go here later
                    ...imageInputLabels.map((label) => Padding(
                     padding: const EdgeInsets.only(bottom: 16.0),
                     child: ImageInputWidget(
@@ -66,7 +82,7 @@ class PageSeven extends ConsumerWidget { // Change to ConsumerWidget
                     onNextPressed: () {
                        Navigator.push(
                         context,
-                        MaterialPageRoute(builder: (context) => const PageEight()),
+                        MaterialPageRoute(builder: (context) => const PageSixKakiKakiTambahan()),
                       );
                     },
                   ),

--- a/lib/pages/page_six_mesin_tambahan.dart
+++ b/lib/pages/page_six_mesin_tambahan.dart
@@ -25,10 +25,10 @@ class PageSixMesinTambahan extends ConsumerWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  PageNumber(data: '6.8/x'), // Placeholder page number
-                  const SizedBox(height: 8.0),
+                  PageNumber(data: '6.8/x'),
+                  const SizedBox(height: 4),
                   PageTitle(data: 'Foto Mesin'),
-                  const SizedBox(height: 24.0),
+                  const SizedBox(height: 6.0),
                   HeadingOne(text: 'Tambahan'),
                   const SizedBox(height: 16.0),
 

--- a/lib/pages/page_six_mesin_tambahan.dart
+++ b/lib/pages/page_six_mesin_tambahan.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:form_app/widgets/common_layout.dart';
+import 'package:form_app/widgets/heading_one.dart';
+import 'package:form_app/widgets/navigation_button_row.dart';
+import 'package:form_app/widgets/page_number.dart';
+import 'package:form_app/widgets/page_title.dart';
+import 'package:form_app/widgets/footer.dart';
+import 'package:form_app/widgets/image_input_widget.dart'; // Keep import in case needed later
+import 'dart:io'; // Keep import in case needed later
+import 'package:form_app/models/image_data.dart'; // Keep import in case needed later
+import 'package:form_app/providers/image_data_provider.dart'; // Keep import in case needed later
+import 'package:form_app/pages/page_six_kaki_kaki_wajib.dart'; // Import the next page
+
+class PageSixMesinTambahan extends ConsumerWidget {
+  const PageSixMesinTambahan({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return CommonLayout(
+      child: Column(
+        children: [
+          Expanded(
+            child: SingleChildScrollView(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  PageNumber(data: '6.8/x'), // Placeholder page number
+                  const SizedBox(height: 8.0),
+                  PageTitle(data: 'Foto Mesin'),
+                  const SizedBox(height: 24.0),
+                  HeadingOne(text: 'Tambahan'),
+                  const SizedBox(height: 16.0),
+
+                  // Tambahan image inputs will go here later
+
+                  const SizedBox(height: 32.0),
+                  NavigationButtonRow(
+                    onBackPressed: () => Navigator.pop(context),
+                    onNextPressed: () {
+                       Navigator.push(
+                        context,
+                        MaterialPageRoute(builder: (context) => const PageSixKakiKakiWajib()),
+                      );
+                    },
+                  ),
+                  const SizedBox(height: 32.0),
+                  Footer(),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/pages/page_six_mesin_tambahan.dart
+++ b/lib/pages/page_six_mesin_tambahan.dart
@@ -25,7 +25,7 @@ class PageSixMesinTambahan extends ConsumerWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  PageNumber(data: '6.8/x'),
+                  PageNumber(data: '6/9'),
                   const SizedBox(height: 4),
                   PageTitle(data: 'Foto Mesin'),
                   const SizedBox(height: 6.0),

--- a/lib/pages/page_six_mesin_wajib.dart
+++ b/lib/pages/page_six_mesin_wajib.dart
@@ -74,10 +74,10 @@ class PageSixMesinWajib extends ConsumerWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  PageNumber(data: '6.7/x'), // Placeholder page number
-                  const SizedBox(height: 8.0),
+                  PageNumber(data: '6.7/x'),
+                  const SizedBox(height: 4),
                   PageTitle(data: 'Foto Mesin'),
-                  const SizedBox(height: 24.0),
+                  const SizedBox(height: 6.0),
                   HeadingOne(text: 'Wajib'),
                   const SizedBox(height: 16.0),
 

--- a/lib/pages/page_six_mesin_wajib.dart
+++ b/lib/pages/page_six_mesin_wajib.dart
@@ -74,7 +74,7 @@ class PageSixMesinWajib extends ConsumerWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  PageNumber(data: '6.7/x'),
+                  PageNumber(data: '6/9'),
                   const SizedBox(height: 4),
                   PageTitle(data: 'Foto Mesin'),
                   const SizedBox(height: 6.0),

--- a/lib/pages/page_six_mesin_wajib.dart
+++ b/lib/pages/page_six_mesin_wajib.dart
@@ -1,22 +1,52 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart'; // Import flutter_riverpod
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:form_app/widgets/common_layout.dart';
+import 'package:form_app/widgets/heading_one.dart';
 import 'package:form_app/widgets/navigation_button_row.dart';
 import 'package:form_app/widgets/page_number.dart';
 import 'package:form_app/widgets/page_title.dart';
 import 'package:form_app/widgets/footer.dart';
-import 'package:form_app/widgets/image_input_widget.dart'; // Import ImageInputWidget
-import 'dart:io'; // Import File
-import 'package:form_app/models/image_data.dart'; // Import ImageData
-import 'package:form_app/providers/image_data_provider.dart'; // Import ImageDataProvider
-import 'package:form_app/pages/page_eight.dart'; // Import PageEight
+import 'package:form_app/widgets/image_input_widget.dart'; // Keep import in case needed later
+import 'dart:io'; // Keep import in case needed later
+import 'package:form_app/models/image_data.dart'; // Keep import in case needed later
+import 'package:form_app/providers/image_data_provider.dart'; // Keep import in case needed later
+import 'package:form_app/pages/page_six_mesin_tambahan.dart'; // Import the next page
 
-// Foto Dokumen Page (formerly Page Seven)
-class PageSeven extends ConsumerWidget { // Change to ConsumerWidget
-  const PageSeven({super.key});
+class PageSixMesinWajib extends ConsumerWidget {
+  const PageSixMesinWajib({super.key});
 
-  // Image input labels will go here later
-  final List<String> imageInputLabels = const [];
+  final List<String> imageInputLabels = const [
+    'Sealer Kap Mesin',
+    'Support bumper',
+    'Dashboard Mobil',
+    'Celah Kap Mesin',
+    'Baut Kap Mesin',
+    'Rangka Mesin Mobil',
+    'Las Listrik',
+    'Bulatan Pada Rangka',
+    'Radiator (Penyok/Tidak)',
+    'Dip Stick Oli Mesin',
+    'Kondisi Oli dari Tutup',
+    'Cover Valve',
+    'Cover Timing Chain',
+    'Seal Crankshaft Depan',
+    'Seal Crankshaft Belakang',
+    'Carter',
+    'V Belt',
+    'Turbo (jika ada)',
+    'Selang-selang',
+    'Kipas Radiator',
+    'Motor Fan',
+    'Minyak Rem',
+    'Support Shock',
+    'Engine Mounting',
+    'Aki',
+    'Alternator',
+    'Tutup Radiator Dibuka',
+    'Sambungan Radiator (assembly)',
+    'Reservoir Radiator',
+    'Compressor AC',
+  ];
 
   void _handleImagePicked(String label, File? imageFile, WidgetRef ref) {
     final imageDataListNotifier = ref.read(imageDataListProvider.notifier);
@@ -35,7 +65,7 @@ class PageSeven extends ConsumerWidget { // Change to ConsumerWidget
   }
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) { // Add WidgetRef ref
+  Widget build(BuildContext context, WidgetRef ref) {
     return CommonLayout(
       child: Column(
         children: [
@@ -44,12 +74,14 @@ class PageSeven extends ConsumerWidget { // Change to ConsumerWidget
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  PageNumber(data: '7/9'), // Update page number
+                  PageNumber(data: '6.7/x'), // Placeholder page number
                   const SizedBox(height: 8.0),
-                  PageTitle(data: 'Foto Dokumen'), // Update Title
+                  PageTitle(data: 'Foto Mesin'),
                   const SizedBox(height: 24.0),
+                  HeadingOne(text: 'Wajib'),
+                  const SizedBox(height: 16.0),
 
-                  // Image inputs will go here later
+                  // Wajib image inputs will go here later
                    ...imageInputLabels.map((label) => Padding(
                     padding: const EdgeInsets.only(bottom: 16.0),
                     child: ImageInputWidget(
@@ -66,7 +98,7 @@ class PageSeven extends ConsumerWidget { // Change to ConsumerWidget
                     onNextPressed: () {
                        Navigator.push(
                         context,
-                        MaterialPageRoute(builder: (context) => const PageEight()),
+                        MaterialPageRoute(builder: (context) => const PageSixMesinTambahan()),
                       );
                     },
                   ),

--- a/lib/pages/page_three.dart
+++ b/lib/pages/page_three.dart
@@ -27,9 +27,9 @@ class PageThree extends ConsumerWidget {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 PageNumber(data: '3/9'),
-                const SizedBox(height: 8.0),
+                const SizedBox(height: 4),
                 PageTitle(data: 'Kelengkapan'),
-                const SizedBox(height: 24.0),
+                const SizedBox(height: 6.0),
                 ToggleOption(
                   toggleValues: ['Lengkap', 'Tidak'],
                   label: 'Buku Service',

--- a/lib/pages/page_two.dart
+++ b/lib/pages/page_two.dart
@@ -94,9 +94,9 @@ class _PageTwoState extends ConsumerState<PageTwo> {
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         PageNumber(data: '2/9'), // Updated Page Number
-                        const SizedBox(height: 8.0),
+                        const SizedBox(height: 4),
                         PageTitle(data: 'Data Kendaraan'), // Updated Title
-                        const SizedBox(height: 24.0),
+                        const SizedBox(height: 6.0),
 
                         // Input Fields based on user request
                         LabeledTextField(

--- a/lib/widgets/expandable_text_field.dart
+++ b/lib/widgets/expandable_text_field.dart
@@ -192,7 +192,7 @@ class _ExpandableTextFieldState extends State<ExpandableTextField> {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(widget.label, style: labelStyle),
-        const SizedBox(height: 8.0),
+        const SizedBox(height: 4.0),
         Focus(
           focusNode: _focusNode,
           onKeyEvent: _handleKeyEvent,

--- a/lib/widgets/image_input_widget.dart
+++ b/lib/widgets/image_input_widget.dart
@@ -89,7 +89,7 @@ class _ImageInputWidgetState extends ConsumerState<ImageInputWidget> { // Change
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Padding(
-          padding: EdgeInsets.only(bottom: storedImage == null ? 8.0 : 4.0), // Conditional bottom padding
+          padding: EdgeInsets.only(bottom: storedImage == null ? 4.0 : 2.0), // Conditional bottom padding
           child: Text(
             widget.label,
             style: labelStyle, // Using the style from app_styles.dart

--- a/lib/widgets/labeled_date_field.dart
+++ b/lib/widgets/labeled_date_field.dart
@@ -121,7 +121,7 @@ class _LabeledDateFieldState extends State<LabeledDateField> {
       children: [
         // --- Label ---
         Text(widget.label, style: labelStyle), // Access labelStyle from AppStyles
-        const SizedBox(height: 8.0),
+        const SizedBox(height: 4.0),
 
         // --- Tappable Date Input Area ---
         // Use FormField to integrate with Form and provide validation

--- a/lib/widgets/labeled_text_field.dart
+++ b/lib/widgets/labeled_text_field.dart
@@ -66,7 +66,7 @@ class _LabeledTextFieldState extends State<LabeledTextField> {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(widget.label, style: labelStyle),
-        const SizedBox(height: 8.0), // Consistent spacing
+        const SizedBox(height: 4.0), // Consistent spacing
         TextFormField( // Use TextFormField for validation integration
           key: _formFieldKey, // Assign the key
           controller: _internalController, // Use the internal controller

--- a/lib/widgets/numbered_button_list.dart
+++ b/lib/widgets/numbered_button_list.dart
@@ -29,7 +29,7 @@ class _NumberedButtonListState extends State<NumberedButtonList> {
           widget.label,
           style: labelStyle,
         ),
-        const SizedBox(height: 8.0),
+        const SizedBox(height: 4.0),
         Row(
           mainAxisAlignment: MainAxisAlignment.spaceAround, // Distribute space around the buttons
           children: List.generate(widget.count, (value) {

--- a/lib/widgets/repair_estimation.dart
+++ b/lib/widgets/repair_estimation.dart
@@ -99,7 +99,7 @@ class _RepairEstimationState extends State<RepairEstimation> {
             final bool priceHasText = _priceControllers[index].text.isNotEmpty;
 
             return Padding(
-              padding: const EdgeInsets.only(bottom: 8.0),
+              padding: const EdgeInsets.only(bottom: 4.0),
               child: Container( // Wrap with Container for border
                 decoration: BoxDecoration(
                   border: Border.all(

--- a/lib/widgets/toggle_option_widget.dart
+++ b/lib/widgets/toggle_option_widget.dart
@@ -34,7 +34,7 @@ class _ToggleOptionState extends State<ToggleOption> {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Padding(
-          padding: const EdgeInsets.only(bottom: 8.0),
+          padding: const EdgeInsets.only(bottom: 4.0),
           child: Text(
             widget.label,
             style: labelStyle,

--- a/lib/widgets/toggleable_numbered_button_list.dart
+++ b/lib/widgets/toggleable_numbered_button_list.dart
@@ -122,7 +122,7 @@ class _ToggleableNumberedButtonListState extends State<ToggleableNumberedButtonL
                 ),
           ],
         ),
-        const SizedBox(height: 10.0),
+        const SizedBox(height: 4.0),
 
         // --- Row for Numbered Buttons ---
         Row(


### PR DESCRIPTION
This update changes how users upload inspection photos and reworks Page Seven.

**Key Changes:**

1.  **New "Page Six" for Photos:**
    *   The old `PageSix` for all photos is gone.
    *   It's replaced by a series of new pages (e.g., `page_six_general_wajib.dart`, `page_six_eksterior_wajib.dart`, etc.).
    *   Users now upload photos in categories: General, Eksterior, Interior, Mesin, Kaki-kaki, and Alat-alat.
    *   Each category has a "Wajib" (Mandatory) page and a "Tambahan" (Additional) page.
    *   After `PageFiveSeven`, users now go to `PageSixGeneralWajib` to start uploading photos.

2.  **Updated "Page Seven":**
    *   `PageSeven` is now titled "Foto Dokumen" (Document Photos).
    *   It's ready for users to upload document images (though no specific image fields are added yet).

3.  **UI Spacing:**
    *   Reduced some vertical spacing on various pages and input fields for a cleaner look. For example, the space after page numbers, titles, and field labels is smaller.

**Impact:**

*   Makes photo uploading more organized by breaking it into steps.
*   Prepares `PageSeven` for document uploads.
*   Slightly adjusts UI spacing for better consistency.

**How to Test:**
1.  Go through the form from the beginning.
2.  After `PageFiveSeven`, ensure you see the new photo upload pages, starting with "Foto General (Wajib)".
3.  Go through all the new "Page Six" photo upload screens.
4.  Check that `PageSeven` is now "Foto Dokumen".
5.  Look for slightly tighter spacing on various form pages.
