### PR TITLE
fix: Correct "Rocksteer" and "Pintu Depan" labels & improve release versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,9 +34,16 @@ jobs:
         id: pubspec
         run: |
           VERSION_LINE=$(grep '^version:' pubspec.yaml)
-          SEMANTIC_VERSION=$(echo "$VERSION_LINE" | sed 's/version: //g' | sed 's/+\.*//g' | tr -d '[:space:]')
-          FULL_VERSION="${SEMANTIC_VERSION}.${{ github.run_number }}"
+          # Extract semantic version (e.g., 2.0.0)
+          SEMANTIC_VERSION=$(echo "$VERSION_LINE" | sed -E 's/version: ([0-9]+\.[0-9]+\.[0-9]+)(\+.*)?/\1/' | tr -d '[:space:]')
+          
+          # Always use GitHub run number as the full build number
+          FULL_BUILD_NUMBER="${{ github.run_number }}"
+
+          FULL_VERSION="${SEMANTIC_VERSION}+${FULL_BUILD_NUMBER}"
+
           echo "semantic_version=$SEMANTIC_VERSION" >> $GITHUB_OUTPUT
+          echo "full_build_number=$FULL_BUILD_NUMBER" >> $GITHUB_OUTPUT
           echo "full_version=$FULL_VERSION" >> $GITHUB_OUTPUT
 
       # Creates an .env file with the API base URL for the release build.
@@ -45,13 +52,13 @@ jobs:
         env:
           API_BASE_URL: ${{ secrets.API_BASE_URL }}
 
-      # Builds ABI-specific release APKs for different architectures.
+      # Builds ABI-Specific Release APKs
       - name: Build ABI-Specific Release APKs
-        run: flutter build apk --split-per-abi --release --build-name=${{ steps.pubspec.outputs.full_version }} --build-number=${{ github.run_number }}
+        run: flutter build apk --split-per-abi --release --build-name=${{ steps.pubspec.outputs.semantic_version }} --build-number=${{ steps.pubspec.outputs.full_build_number }}
 
-      # Builds a universal (fat) release APK.
+      # Builds a universal (fat) Release APK.
       - name: Build Universal (Fat) Release APK
-        run: flutter build apk --release --build-name=${{ steps.pubspec.outputs.full_version }} --build-number=${{ github.run_number }}
+        run: flutter build apk --release --build-name=${{ steps.pubspec.outputs.semantic_version }} --build-number=${{ steps.pubspec.outputs.full_build_number }}
 
       # Creates an .env file with the API base URL for the debug build.
       - name: Create .env file for Debug Build
@@ -61,7 +68,7 @@ jobs:
 
       # Builds a debug APK.
       - name: Build Debug APK
-        run: flutter build apk --debug --build-name=${{ steps.pubspec.outputs.full_version }} --build-number=${{ github.run_number }}
+        run: flutter build apk --debug --build-name=${{ steps.pubspec.outputs.semantic_version }} --build-number=${{ steps.pubspec.outputs.full_build_number }}
 
       # Renames the universal release APK to include version and build number.
       - name: Rename Universal Release APK
@@ -161,7 +168,7 @@ jobs:
           HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
           FULL_VERSION: ${{ steps.pubspec.outputs.full_version }}
 
-      # Creates a new GitHub release.
+      # Creates a new GitHub Release.
       - name: Create GitHub Release
         id: create_release
         uses: actions/create-release@v1

--- a/lib/models/form_data.dart
+++ b/lib/models/form_data.dart
@@ -172,7 +172,7 @@ class FormData extends Equatable {
   final int? crossmemberSelectedValue;
   final int? knalpotSelectedValue;
   final int? balljointSelectedValue;
-  final int? rocksteerSelectedValue;
+  final int? racksteerSelectedValue;
   final int? karetBootSelectedValue;
   final int? upperLowerArmSelectedValue;
   final int? shockBreakerSelectedValue;
@@ -366,7 +366,7 @@ class FormData extends Equatable {
     this.crossmemberSelectedValue,
     this.knalpotSelectedValue,
     this.balljointSelectedValue,
-    this.rocksteerSelectedValue,
+    this.racksteerSelectedValue,
     this.karetBootSelectedValue,
     this.upperLowerArmSelectedValue,
     this.shockBreakerSelectedValue,
@@ -556,7 +556,7 @@ class FormData extends Equatable {
     crossmemberSelectedValue,
     knalpotSelectedValue,
     balljointSelectedValue,
-    rocksteerSelectedValue,
+    racksteerSelectedValue,
     karetBootSelectedValue,
     upperLowerArmSelectedValue,
     shockBreakerSelectedValue,
@@ -742,7 +742,7 @@ class FormData extends Equatable {
       'crossmemberSelectedValue': crossmemberSelectedValue,
       'knalpotSelectedValue': knalpotSelectedValue,
       'balljointSelectedValue': balljointSelectedValue,
-      'rocksteerSelectedValue': rocksteerSelectedValue,
+      'racksteerSelectedValue': racksteerSelectedValue,
       'karetBootSelectedValue': karetBootSelectedValue,
       'upperLowerArmSelectedValue': upperLowerArmSelectedValue,
       'shockBreakerSelectedValue': shockBreakerSelectedValue,
@@ -939,7 +939,7 @@ class FormData extends Equatable {
       crossmemberSelectedValue: json['crossmemberSelectedValue'] as int?,
       knalpotSelectedValue: json['knalpotSelectedValue'] as int?,
       balljointSelectedValue: json['balljointSelectedValue'] as int?,
-      rocksteerSelectedValue: json['rocksteerSelectedValue'] as int?,
+      racksteerSelectedValue: json['racksteerSelectedValue'] as int?,
       karetBootSelectedValue: json['karetBootSelectedValue'] as int?,
       upperLowerArmSelectedValue: json['upperLowerArmSelectedValue'] as int?,
       shockBreakerSelectedValue: json['shockBreakerSelectedValue'] as int?,
@@ -1126,7 +1126,7 @@ class FormData extends Equatable {
     int? crossmemberSelectedValue,
     int? knalpotSelectedValue,
     int? balljointSelectedValue,
-    int? rocksteerSelectedValue,
+    int? racksteerSelectedValue,
     int? karetBootSelectedValue,
     int? upperLowerArmSelectedValue,
     int? shockBreakerSelectedValue,
@@ -1311,7 +1311,7 @@ class FormData extends Equatable {
       crossmemberSelectedValue: crossmemberSelectedValue ?? this.crossmemberSelectedValue,
       knalpotSelectedValue: knalpotSelectedValue ?? this.knalpotSelectedValue,
       balljointSelectedValue: balljointSelectedValue ?? this.balljointSelectedValue,
-      rocksteerSelectedValue: rocksteerSelectedValue ?? this.rocksteerSelectedValue,
+      racksteerSelectedValue: racksteerSelectedValue ?? this.racksteerSelectedValue,
       karetBootSelectedValue: karetBootSelectedValue ?? this.karetBootSelectedValue,
       upperLowerArmSelectedValue: upperLowerArmSelectedValue ?? this.upperLowerArmSelectedValue,
       shockBreakerSelectedValue: shockBreakerSelectedValue ?? this.shockBreakerSelectedValue,

--- a/lib/pages/page_five_five.dart
+++ b/lib/pages/page_five_five.dart
@@ -156,9 +156,9 @@ class _PageFiveFiveState extends ConsumerState<PageFiveFive> with AutomaticKeepA
         'onItemSelected': (value) => formNotifier.updateBalljointSelectedValue(value),
       },
       {
-        'label': 'Rocksteer',
-        'selectedValue': formData.rocksteerSelectedValue,
-        'onItemSelected': (value) => formNotifier.updateRocksteerSelectedValue(value),
+        'label': 'Racksteer',
+        'selectedValue': formData.racksteerSelectedValue,
+        'onItemSelected': (value) => formNotifier.updateRacksteerSelectedValue(value),
       },
       {
         'label': 'Karet Boot',

--- a/lib/pages/page_five_four.dart
+++ b/lib/pages/page_five_four.dart
@@ -206,7 +206,7 @@ class _PageFiveFourState extends ConsumerState<PageFiveFour> with AutomaticKeepA
         'onItemSelected': (value) => formNotifier.updateQuarterPanelKiriSelectedValue(value),
       },
       {
-        'label': 'Pintu Depan',
+        'label': 'Pintu Depan Kanan',
         'selectedValue': formData.pintuDepanSelectedValue,
         'onItemSelected': (value) => formNotifier.updatePintuDepanSelectedValue(value),
       },

--- a/lib/providers/form_provider.dart
+++ b/lib/providers/form_provider.dart
@@ -753,8 +753,8 @@ class FormNotifier extends StateNotifier<FormData> {
   }
 
 
-  void updateRocksteerSelectedValue(int? value) {
-    state = state.copyWith(rocksteerSelectedValue: value);
+  void updateRacksteerSelectedValue(int? value) {
+    state = state.copyWith(racksteerSelectedValue: value);
   }
 
 

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -163,7 +163,7 @@ class ApiService {
               "crossmember": formData.crossmemberSelectedValue ?? 0,
               "knalpot": formData.knalpotSelectedValue ?? 0,
               "balljoint": formData.balljointSelectedValue ?? 0,
-              "rocksteer": formData.rocksteerSelectedValue ?? 0,
+              "racksteer": formData.racksteerSelectedValue ?? 0,
               "karetBoot": formData.karetBootSelectedValue ?? 0,
               "upperLowerArm": formData.upperLowerArmSelectedValue ?? 0,
               "shockBreaker": formData.shockBreakerSelectedValue ?? 0,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 2.0.0+1
+version: 2.0.1+1
 
 environment:
   sdk: ^3.7.2


### PR DESCRIPTION
# 🚀 Version 2.0.1: Label Fixes & CI/CD Enhancements

This update addresses some important label corrections within the inspection form and introduces significant improvements to our automated build and release process.

## 🐞 Bug Fixes

This release corrects a couple of mislabeled items in the detailed assessment pages to ensure data accuracy and clarity for our inspectors.

*   **Ban dan Kaki-kaki:** The item "Rocksteer" has been corrected to its proper term, **"Racksteer"**. This fix applies to the selection button, internal data model, and API submission payload.
*   **Hasil Inspeksi Eksterior:** The "Pintu Depan" item has been clarified to **"Pintu Depan Kanan"** to avoid ambiguity with the left side door.

## ⚙️ CI/CD Improvements

Our GitHub Actions release workflow (`release.yml`) has been overhauled for more reliable and consistent versioning:

*   **Robust Versioning:** The build process now correctly separates the semantic version (e.g., `2.0.1`) from the build number.
*   **Consistent Build Number:** The `versionCode` for Android is now always set to the unique GitHub Actions run number, ensuring each build is sequentially versioned.
*   **Standardized Naming:** The generated APK files and release tags now follow a consistent `v<semantic_version>+<build_number>` format (e.g., `v2.0.1+123`).

---

Fixes #59