### PR TITLE
feat(ui): display update file size and enhance download progress indicator

### DIFF
--- a/lib/services/update_service.dart
+++ b/lib/services/update_service.dart
@@ -27,6 +27,8 @@ class UpdateState {
   final String downloadedApkPath;
   final String apkFileName; // New field for the exact APK filename from GitHub
   final String errorMessage;
+  final String? fileSize; // New field for formatted file size
+  final int? rawFileSize; // New field for raw file size in bytes
 
   UpdateState({
     this.isLoading = false,
@@ -39,6 +41,8 @@ class UpdateState {
     this.downloadedApkPath = '',
     this.apkFileName = '', // Initialize new field
     this.errorMessage = '',
+    this.fileSize, // Initialize new field
+    this.rawFileSize, // Initialize new field
   });
 
   UpdateState copyWith({
@@ -52,6 +56,8 @@ class UpdateState {
     String? downloadedApkPath,
     String? apkFileName, // New field for copyWith
     String? errorMessage,
+    String? fileSize, // New field for copyWith
+    int? rawFileSize, // New field for copyWith
   }) {
     return UpdateState(
       isLoading: isLoading ?? this.isLoading,
@@ -64,6 +70,8 @@ class UpdateState {
       downloadedApkPath: downloadedApkPath ?? this.downloadedApkPath,
       apkFileName: apkFileName ?? this.apkFileName, // Copy new field
       errorMessage: errorMessage ?? this.errorMessage,
+      fileSize: fileSize ?? this.fileSize, // Copy new field
+      rawFileSize: rawFileSize ?? this.rawFileSize, // Copy new field
     );
   }
 }
@@ -190,7 +198,9 @@ class UpdateNotifier extends StateNotifier<UpdateState> {
       }
 
       final apkDownloadUrl = apkAsset['browser_download_url'] as String;
-      debugPrint('UpdateService: Found APK: ${apkAsset['name']}. Download URL: $apkDownloadUrl');
+      final rawFileSize = apkAsset['size'] as int; // Get raw file size in bytes
+      final formattedFileSize = _formatBytes(rawFileSize); // Format for display
+      debugPrint('UpdateService: Found APK: ${apkAsset['name']}. Download URL: $apkDownloadUrl, Size: $formattedFileSize');
 
       // 3. Compare versions
       if (_isNewerVersion(latestVersion, fullCurrentVersion)) {
@@ -202,6 +212,8 @@ class UpdateNotifier extends StateNotifier<UpdateState> {
           releaseNotes: releaseNotes,
           apkDownloadUrl: apkDownloadUrl,
           apkFileName: Uri.decodeComponent(apkAsset['name'] as String), // Store the decoded filename
+          fileSize: formattedFileSize, // Store formatted file size
+          rawFileSize: rawFileSize, // Store raw file size
         );
       } else {
         debugPrint('UpdateService: No newer version available.');
@@ -229,7 +241,7 @@ class UpdateNotifier extends StateNotifier<UpdateState> {
         onReceiveProgress: (received, total) {
           if (total != -1) {
             final progress = received / total;
-            state = state.copyWith(downloadProgress: progress);
+            state = state.copyWith(downloadProgress: progress, rawFileSize: total); // Update rawFileSize during download
           }
         },
       );
@@ -288,5 +300,12 @@ class UpdateNotifier extends StateNotifier<UpdateState> {
     }
 
     return false; // Versions are the same or current is newer
+  }
+
+  String _formatBytes(int bytes) {
+    if (bytes <= 0) return "0 B";
+    const suffixes = ["B", "KB", "MB", "GB", "TB"];
+    int i = (bytes > 0 ? (bytes.toString().length - 1) : 0) ~/ 3;
+    return '${(bytes / (1 << (i * 10))).toStringAsFixed(1)} ${suffixes[i]}';
   }
 }

--- a/lib/services/update_service.dart
+++ b/lib/services/update_service.dart
@@ -137,9 +137,10 @@ class UpdateNotifier extends StateNotifier<UpdateState> {
     }
     state = state.copyWith(isLoading: true, errorMessage: '');
 
-    // Re-check if the downloaded APK still exists on app start
+    // Always re-check if the downloaded APK still exists before checking for updates
     if (state.downloadedApkPath.isNotEmpty) {
-      if (!await File(state.downloadedApkPath).exists()) {
+      final fileExists = await File(state.downloadedApkPath).exists();
+      if (!fileExists) {
         state = state.copyWith(downloadedApkPath: '');
         await _clearDownloadedApkPath();
         debugPrint('UpdateService: Previously downloaded APK not found, cleared state.');

--- a/lib/widgets/tambahan_image_selection.dart
+++ b/lib/widgets/tambahan_image_selection.dart
@@ -123,11 +123,11 @@ class _TambahanImageSelectionState extends ConsumerState<TambahanImageSelection>
 
     // --- EXISTING LOGIC FOR GALLERY ---
     if (source == ImageSource.gallery) {
-      ref.read(imageProcessingServiceProvider.notifier).taskStarted(widget.identifier);
       try {
         final List<XFile> pickedFiles = await ImageCaptureAndProcessingUtil.pickMultiImagesFromGallery();
 
         if (pickedFiles.isNotEmpty) {
+          ref.read(imageProcessingServiceProvider.notifier).taskStarted(widget.identifier); // Move taskStarted here
           for (final XFile pickedFile in pickedFiles) {
             final String originalPath = pickedFile.path; // This is the true original path
 

--- a/lib/widgets/update_dialog.dart
+++ b/lib/widgets/update_dialog.dart
@@ -73,6 +73,17 @@ class UpdateDialog extends ConsumerWidget {
                 ),
               ),
             ),
+            if (updateState.fileSize != null) ...[
+              const SizedBox(height: 16),
+              Text(
+                'Ukuran File: ${updateState.fileSize}',
+                textAlign: TextAlign.center,
+                style: labelStyle.copyWith(
+                  fontSize: 16,
+                  color: darkTextColor,
+                ),
+              ),
+            ],
             if (updateState.isDownloading) ...[
               const SizedBox(height: 20),
               ClipRRect(
@@ -87,8 +98,11 @@ class UpdateDialog extends ConsumerWidget {
               const SizedBox(height: 8),
               Center(
                 child: Text(
-                  'Mengunduh: ${(updateState.downloadProgress * 100).toStringAsFixed(0)}%',
-                  style: labelStyle.copyWith(color: darkTextColor),
+                  'Mengunduh: ${(updateState.downloadProgress * 100).toStringAsFixed(0)}% ${updateState.fileSize != null ? '(${(updateState.downloadProgress * (updateState.rawFileSize ?? 0) / (1024 * 1024)).toStringAsFixed(1)} MB / ${updateState.fileSize})' : ''}',
+                  style: labelStyle.copyWith(
+                  fontSize: 16,
+                  color: darkTextColor,
+                ),
                 ),
               )
             ],

--- a/lib/widgets/update_dialog.dart
+++ b/lib/widgets/update_dialog.dart
@@ -73,7 +73,7 @@ class UpdateDialog extends ConsumerWidget {
                 ),
               ),
             ),
-            if (updateState.fileSize != null) ...[
+            if (updateState.fileSize != null && updateState.downloadedApkPath.isEmpty) ...[ // Only show if not downloaded
               const SizedBox(height: 16),
               Text(
                 'Ukuran File: ${updateState.fileSize}',


### PR DESCRIPTION
### ✨ Feature: Enhanced Update Experience

This update significantly improves the in-app update process by providing users with more information and better feedback. Users can now see the size of an available update before starting the download, helping them make an informed decision based on their data plan or available storage.

**Key Enhancements:**

*   **📊 Display Update Size:** The update dialog now clearly shows the file size of the new version (e.g., "15.2 MB").
*   **📈 Improved Download Progress:** While downloading, the progress indicator now displays the downloaded amount versus the total file size (e.g., "Mengunduh: 50% (7.6 MB / 15.2 MB)"), giving more precise feedback than just a percentage.
*   **⚙️ Robust State Management:** The underlying `UpdateService` and `UpdateState` have been updated to efficiently fetch, store, and format the file size information from the GitHub release assets.

This enhancement makes the update process more transparent and user-friendly.

Fixes #97