### PR TITLE
fix: Resolve 'problem parsing the package' error on update installation

### DIFF
--- a/android/app/src/main/res/xml/provider_paths.xml
+++ b/android/app/src/main/res/xml/provider_paths.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths xmlns:android="http://schemas.android.com/apk/res/android">
-    <external-path name="external_files" path="."/>
+    <files-path name="internal_files" path="."/>
 </paths>


### PR DESCRIPTION
### 🔧 Fix: In-App Update Installation on Android

This patch resolves a critical issue where users would encounter a "There was a problem parsing the package" error when attempting to install a new version of the app via the in-app update feature.

#### What's Changed

*   **Corrected FileProvider Path:** The primary change involves updating the `android/app/src/main/res/xml/provider_paths.xml` file. The configuration was changed from `<external-path>` to `<files-path>`.

#### The Fix: Technical Details

The root cause of the installation error was a mismatch between where the update APK was being stored and which directory the `FileProvider` was configured to share.

-   The update service correctly downloads the APK to the application's **internal** storage (`files-path`).
-   However, the `FileProvider` was incorrectly configured to only grant access to **external** storage (`external-path`).

This change aligns the provider's accessible paths with the actual location of the downloaded APK. By doing so, it grants the Android Package Installer the necessary permissions to read the file, resolving the parsing error and allowing the update to proceed smoothly.

#### Impact on Users

-   Inspectors using the Android application can now successfully download and install new app versions directly from the in-app update dialog without any errors.
-   The update process is now more reliable, ensuring users can easily stay on the latest version.

---

Fixes #99