### PR TITLE
feat: Implement resumable image uploads with submission caching

### DIFF
--- a/lib/providers/submission_data_cache_provider.dart
+++ b/lib/providers/submission_data_cache_provider.dart
@@ -4,19 +4,23 @@ import 'package:form_app/models/form_data.dart'; // Assuming FormData is defined
 class SubmissionDataCache {
   final String? lastSubmittedInspectionId;
   final FormData? lastSubmittedFormData;
+  final List<String> uploadedImagePaths; // New field to store paths of uploaded images
 
   SubmissionDataCache({
     this.lastSubmittedInspectionId,
     this.lastSubmittedFormData,
+    this.uploadedImagePaths = const [], // Initialize as empty list
   });
 
   SubmissionDataCache copyWith({
     String? lastSubmittedInspectionId,
     FormData? lastSubmittedFormData,
+    List<String>? uploadedImagePaths,
   }) {
     return SubmissionDataCache(
       lastSubmittedInspectionId: lastSubmittedInspectionId ?? this.lastSubmittedInspectionId,
       lastSubmittedFormData: lastSubmittedFormData ?? this.lastSubmittedFormData,
+      uploadedImagePaths: uploadedImagePaths ?? this.uploadedImagePaths,
     );
   }
 }
@@ -28,10 +32,17 @@ final submissionDataCacheProvider = StateNotifierProvider<SubmissionDataCacheNot
 class SubmissionDataCacheNotifier extends StateNotifier<SubmissionDataCache> {
   SubmissionDataCacheNotifier() : super(SubmissionDataCache());
 
-  void setCache({String? inspectionId, FormData? formData}) {
+  void setCache({String? inspectionId, FormData? formData, List<String>? uploadedImagePaths}) {
     state = state.copyWith(
       lastSubmittedInspectionId: inspectionId,
       lastSubmittedFormData: formData,
+      uploadedImagePaths: uploadedImagePaths,
+    );
+  }
+
+  void addUploadedImagePaths(List<String> newPaths) {
+    state = state.copyWith(
+      uploadedImagePaths: [...state.uploadedImagePaths, ...newPaths],
     );
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 2.0.7+1
+version: 2.1.0+1
 
 environment:
   sdk: ^3.7.2


### PR DESCRIPTION
# ✨ Resumable Image Uploads & Submission Caching

This pull request introduces a robust submission caching mechanism to prevent duplicate image uploads and allow users to safely resume an interrupted submission. If the network fails or the app is closed during the image upload process, the app will now intelligently continue from where it left off, saving time and data.

---

### 🚀 Key Enhancements

*   **Submission Caching:** The app now locally caches the `inspectionId` received after a successful form data submission, along with a running list of `imagePaths` that have been successfully uploaded for that inspection.

*   **Intelligent Resumption:** Upon re-submitting the same form, the app first checks the cache.
    *   If the form data hasn't changed, it reuses the existing `inspectionId`.
    *   It then filters out any images that have already been uploaded (based on the cached paths) and only uploads the remaining files.

*   **Accurate Progress Tracking:** The submission progress bar now accurately reflects the overall progress, even when resuming. It calculates progress based on the total number of images, including those already uploaded in a previous attempt.

### 🛠️ Technical Implementation

*   **`SubmissionDataCacheProvider`:**
    *   Added a new `uploadedImagePaths` list to the `SubmissionDataCache` state to track successfully uploaded image file paths.
    *   Introduced an `addUploadedImagePaths` method to update the cache after each successful batch upload.

*   **`ApiService`:**
    *   The `uploadImagesInBatches` method now includes an `onBatchUploaded` callback. This callback is invoked after each batch is successfully sent, returning the list of paths that were just uploaded.

*   **`MultiStepFormScreen`:**
    *   The `_submitForm` logic has been refactored to use the new caching system. It now filters the list of images to be uploaded against the `uploadedImagePaths` in the cache, ensuring only new images are sent.

---

Fixes #110