### PR TITLE
feat(forms): Implement auto-focus shifting and input validation

### DIFF
--- a/lib/pages/data_kendaraan_page.dart
+++ b/lib/pages/data_kendaraan_page.dart
@@ -228,6 +228,8 @@ class _DataKendaraanPageState extends ConsumerState<DataKendaraanPage> with Auto
         'validator': (value) {
           if (widget.formSubmitted.value && (value == null || value.isEmpty)) {
             return 'Plat Nomor belum terisi';
+          } else if (value.length > 15) {
+            return 'Plat Nomor tidak boleh lebih dari 15 karakter';
           }
           return null;
         },

--- a/lib/pages/data_kendaraan_page.dart
+++ b/lib/pages/data_kendaraan_page.dart
@@ -159,6 +159,9 @@ class _DataKendaraanPageState extends ConsumerState<DataKendaraanPage> with Auto
           if (widget.formSubmitted.value && (value == null || value.isEmpty)) {
             return 'Tahun belum terisi';
           }
+          if (value != null && int.tryParse(value) == null) {
+            return 'Tahun harus berupa angka';
+          }
           return null;
         },
       },

--- a/lib/pages/data_kendaraan_page.dart
+++ b/lib/pages/data_kendaraan_page.dart
@@ -23,6 +23,21 @@ class DataKendaraanPage extends ConsumerStatefulWidget {
 
 class _DataKendaraanPageState extends ConsumerState<DataKendaraanPage> with AutomaticKeepAliveClientMixin {
   bool _hasValidatedOnSubmit = false; // Declare the state variable
+  late List<FocusNode> _focusNodes; // Declare a list of FocusNodes
+
+  @override
+  void initState() {
+    super.initState();
+    _focusNodes = List.generate(_buildInputFields(ref.read(formProvider), ref.read(formProvider.notifier)).length, (index) => FocusNode());
+  }
+
+  @override
+  void dispose() {
+    for (var node in _focusNodes) {
+      node.dispose();
+    }
+    super.dispose();
+  }
 
   @override
   bool get wantKeepAlive => true;
@@ -68,6 +83,7 @@ class _DataKendaraanPageState extends ConsumerState<DataKendaraanPage> with Auto
             delegate: SliverChildBuilderDelegate(
               (context, index) {
                 final fieldData = _buildInputFields(formData, formNotifier)[index];
+                final isLastField = index == _buildInputFields(formData, formNotifier).length - 1;
                 if (fieldData['isDateField'] == true) {
                   return Padding(
                     padding: const EdgeInsets.only(bottom: 16.0),
@@ -80,6 +96,15 @@ class _DataKendaraanPageState extends ConsumerState<DataKendaraanPage> with Auto
                           ? '${(fieldData['initialValue'] as DateTime).day.toString().padLeft(2, '0')}/${(fieldData['initialValue'] as DateTime).month.toString().padLeft(2, '0')}/${(fieldData['initialValue'] as DateTime).year}'
                           : null,
                       formSubmitted: widget.formSubmitted.value, // Pass the boolean value
+                      focusNode: _focusNodes[index],
+                      textInputAction: isLastField ? TextInputAction.done : TextInputAction.next,
+                      onFieldSubmitted: (_) {
+                        if (!isLastField) {
+                          _focusNodes[index + 1].requestFocus();
+                        } else {
+                          _focusNodes[index].unfocus(); // Dismiss keyboard on last field
+                        }
+                      },
                     ),
                   );
                 } else {
@@ -96,6 +121,15 @@ class _DataKendaraanPageState extends ConsumerState<DataKendaraanPage> with Auto
                       useThousandsSeparator: fieldData['useThousandsSeparator'] ?? true,
                       suffixText: fieldData['suffixText'],
                       textCapitalization: fieldData['textCapitalization'] ?? TextCapitalization.sentences,
+                      focusNode: _focusNodes[index],
+                      textInputAction: isLastField ? TextInputAction.done : TextInputAction.next,
+                      onFieldSubmitted: (_) {
+                        if (!isLastField) {
+                          _focusNodes[index + 1].requestFocus();
+                        } else {
+                          _focusNodes[index].unfocus(); // Dismiss keyboard on last field
+                        }
+                      },
                     ),
                   );
                 }

--- a/lib/pages/hasil_inspeksi_page.dart
+++ b/lib/pages/hasil_inspeksi_page.dart
@@ -20,10 +20,26 @@ class HasilInspeksiPage extends ConsumerStatefulWidget { // Change to ConsumerSt
   ConsumerState<HasilInspeksiPage> createState() => _HasilInspeksiPageState(); // Change to ConsumerState
 }
 
-class _HasilInspeksiPageState extends ConsumerState<HasilInspeksiPage> with AutomaticKeepAliveClientMixin { // Add mixin
+class _HasilInspeksiPageState extends ConsumerState<HasilInspeksiPage> with AutomaticKeepAliveClientMixin {
+  late List<FocusNode> _focusNodes; // Declare a list of FocusNodes
 
   @override
-  bool get wantKeepAlive => true; // Override wantKeepAlive
+  void initState() {
+    super.initState();
+    // Initialize FocusNodes only for the relevant text fields (Posisi Ban, Merk, Tipe Velg, Ketebalan)
+    _focusNodes = List.generate(4, (index) => FocusNode());
+  }
+
+  @override
+  void dispose() {
+    for (var node in _focusNodes) {
+      node.dispose();
+    }
+    super.dispose();
+  }
+
+  @override
+  bool get wantKeepAlive => true;
 
   @override
   Widget build(BuildContext context) {
@@ -165,6 +181,11 @@ class _HasilInspeksiPageState extends ConsumerState<HasilInspeksiPage> with Auto
                 onChanged: (value) {
                   formNotifier.updatePosisiBan(value);
                 },
+                focusNode: _focusNodes[0],
+                textInputAction: TextInputAction.next,
+                onFieldSubmitted: (_) {
+                  _focusNodes[1].requestFocus();
+                },
               ),
               const SizedBox(height: 16.0),
               LabeledTextField(
@@ -173,6 +194,11 @@ class _HasilInspeksiPageState extends ConsumerState<HasilInspeksiPage> with Auto
                 initialValue: formData.merk,
                 onChanged: (value) {
                   formNotifier.updateMerk(value);
+                },
+                focusNode: _focusNodes[1],
+                textInputAction: TextInputAction.next,
+                onFieldSubmitted: (_) {
+                  _focusNodes[2].requestFocus();
                 },
               ),
               const SizedBox(height: 16.0),
@@ -183,6 +209,11 @@ class _HasilInspeksiPageState extends ConsumerState<HasilInspeksiPage> with Auto
                 onChanged: (value) {
                   formNotifier.updateTipeVelg(value);
                 },
+                focusNode: _focusNodes[2],
+                textInputAction: TextInputAction.next,
+                onFieldSubmitted: (_) {
+                  _focusNodes[3].requestFocus();
+                },
               ),
               const SizedBox(height: 16.0),
               LabeledTextField(
@@ -191,6 +222,11 @@ class _HasilInspeksiPageState extends ConsumerState<HasilInspeksiPage> with Auto
                 initialValue: formData.ketebalan,
                 onChanged: (value) {
                   formNotifier.updateKetebalan(value);
+                },
+                focusNode: _focusNodes[3],
+                textInputAction: TextInputAction.done,
+                onFieldSubmitted: (_) {
+                  _focusNodes[3].unfocus(); // Dismiss keyboard on last field
                 },
               ),
               const SizedBox(height: 16.0), // Spacing before Estimasi Perbaikan section

--- a/lib/widgets/labeled_date_input_field.dart
+++ b/lib/widgets/labeled_date_input_field.dart
@@ -14,6 +14,8 @@ class LabeledDateInputField extends ConsumerStatefulWidget {
   final FocusNode? focusNode;
   final bool formSubmitted;
   final String? initialValue;
+  final ValueChanged<String>? onFieldSubmitted; // New parameter
+  final TextInputAction? textInputAction; // New parameter
 
   const LabeledDateInputField({
     super.key,
@@ -25,6 +27,8 @@ class LabeledDateInputField extends ConsumerStatefulWidget {
     this.focusNode,
     this.formSubmitted = false,
     this.initialValue,
+    this.onFieldSubmitted, // Initialize new parameter
+    this.textInputAction, // Initialize new parameter
   });
 
   @override
@@ -172,6 +176,8 @@ class _LabeledDateInputFieldState extends ConsumerState<LabeledDateInputField> {
           },
           style: inputTextStyling,
           focusNode: widget.focusNode,
+          onFieldSubmitted: widget.onFieldSubmitted, // Pass the new parameter
+          textInputAction: widget.textInputAction, // Pass the new parameter
           decoration: InputDecoration(
             hintText: widget.hintText,
             hintStyle: hintTextStyling,

--- a/lib/widgets/labeled_text_field.dart
+++ b/lib/widgets/labeled_text_field.dart
@@ -18,6 +18,8 @@ class LabeledTextField extends StatefulWidget {
   final String? prefixText;
   final String? suffixText;
   final TextCapitalization textCapitalization;
+  final ValueChanged<String>? onFieldSubmitted; // New parameter
+  final TextInputAction? textInputAction; // New parameter
 
   const LabeledTextField({
     super.key,
@@ -36,6 +38,8 @@ class LabeledTextField extends StatefulWidget {
     this.prefixText,
     this.suffixText,
     this.textCapitalization = TextCapitalization.sentences,
+    this.onFieldSubmitted, // Initialize new parameter
+    this.textInputAction, // Initialize new parameter
   });
 
   @override
@@ -126,6 +130,8 @@ class _LabeledTextFieldState extends State<LabeledTextField> {
           inputFormatters: widget.keyboardType == TextInputType.number && widget.useThousandsSeparator
               ? [ThousandsSeparatorInputFormatter()]
               : null,
+          onFieldSubmitted: widget.onFieldSubmitted, // Pass the new parameter
+          textInputAction: widget.textInputAction, // Pass the new parameter
           decoration: InputDecoration(
             hintText: widget.hintText,
             hintStyle: hintTextStyling,


### PR DESCRIPTION
### ✨ New Functionality

*   Implemented automatic focus shifting between text fields on the `DataKendaraanPage` and `HasilInspeksiPage`. Users can now use the 'next' and 'done' actions on the keyboard to navigate through forms. Fixes #176
*   Added validation to ensure the 'Tahun' (Year) field in `DataKendaraanPage` only accepts numeric input. Fixes #175
*   Added a maximum length validation of 15 characters for the 'Plat Nomor' (Plate Number) field. Fixes #165

### 🛠️ Refactoring & Architectural Changes

*   Added `onFieldSubmitted` and `textInputAction` properties to `LabeledTextField` and `LabeledDateInputField` to enable focus navigation.
*   Introduced `FocusNode` management in `DataKendaraanPage` and `HasilInspeksiPage` to control the input focus lifecycle.