### PR TITLE
ci: Enforce version bump before merge

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -31,6 +31,33 @@ jobs:
       # Analyzes the Flutter project for any issues, failing the job if infos are found.
       - name: Analyze project
         run: flutter analyze --fatal-infos # Fails the job if any issues are found
+  
+  version-check:
+    name: Check version bump
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Required to compare with main
+
+      - name: Ensure version bumped
+        run: |
+          # Extract current PR version
+          pr_version=$(grep '^version:' pubspec.yaml | awk '{print $2}')
+
+          # Extract version from main branch
+          main_version=$(git show origin/main:pubspec.yaml | grep '^version:' | awk '{print $2}')
+
+          echo "PR version:   $pr_version"
+          echo "Main version: $main_version"
+
+          if [ "$pr_version" = "$main_version" ]; then
+            echo "❌ Version not bumped! Please update pubspec.yaml before merging."
+            exit 1
+          else
+            echo "✅ Version bumped."
+          fi
 
   # test:
   #   name: Test

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 2.3.1+1
+version: 2.3.2+1
 
 environment:
   sdk: ^3.7.2


### PR DESCRIPTION
### ✨ New Functionality

*   Adds a new `version-check` job to the `pr-checks.yml` workflow.
*   The job compares the `version` in `pubspec.yaml` from the PR branch with the version on the `main` branch.
*   If the versions are identical, the workflow fails, preventing merges without a version bump. Fixes #178