### PR TITLE
ci(workflow): Skip version check for Dependabot PRs

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -35,6 +35,7 @@ jobs:
   version-check:
     name: Check version bump
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
### 🧹 Maintenance & Chores

*   Added an `if` condition to the `version-check` job in the `pr-checks.yml` workflow to prevent it from running on pull requests from `dependabot[bot]`. Fixes #192