### PR TITLE
fix(api): Temporarily force debug base URL for production

### DIFF
--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -25,10 +25,10 @@ class ApiService {
   final CrashlyticsUtil _crashlytics;
 
   String get _baseApiUrl {
-    if (kDebugMode) {
+    // if (kDebugMode) {
       return dotenv.env['API_BASE_URL_DEBUG']!;
-    }
-    return dotenv.env['API_BASE_URL']!;
+    // }
+    // return dotenv.env['API_BASE_URL']!;
   }
 
   String get _inspectionsUrl => '$_baseApiUrl/inspections';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 2.3.5+1
+version: 2.3.6+1
 
 environment:
   sdk: ^3.9.0


### PR DESCRIPTION
### 🐛 Bug Fixes

- Temporarily forced the use of the debug API base URL in all build modes by commenting out the conditional logic. This is a temporary workaround for a production server error. Fixes #196