### PR TITLE
ci(release): Add debug API URL to release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,9 +48,12 @@ jobs:
 
       # Creates an .env file with the API base URL for the release build.
       - name: Create .env file for Release Build
-        run: echo "API_BASE_URL=${{ secrets.API_BASE_URL }}" > .env
+        run: |
+          echo "API_BASE_URL=${{ secrets.API_BASE_URL }}" > .env
+          echo "API_BASE_URL_DEBUG=${{ secrets.API_BASE_URL_DEBUG }}" >> .env
         env:
           API_BASE_URL: ${{ secrets.API_BASE_URL }}
+          API_BASE_URL_DEBUG: ${{ secrets.API_BASE_URL_DEBUG }}
 
       # Decode Keystore and Create Properties
       - name: Decode Keystore and Create Properties


### PR DESCRIPTION
### 🧹 Maintenance & Chores
- Inject `API_BASE_URL_DEBUG` into the `.env` file during the release workflow.