### PR TITLE
fix(pin_input): Obscure text for security

### DIFF
--- a/lib/widgets/pin_input.dart
+++ b/lib/widgets/pin_input.dart
@@ -66,8 +66,9 @@ class _PinInputState extends State<PinInput> {
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: List.generate(widget.pinLength, (index) {
             bool isFilled = _pinControllers[index].text.isNotEmpty;
-            return SizedBox(
+            return Container(
               width: 48,
+              alignment: Alignment.center, // Ensure container centers its content
               child: KeyboardListener(
                 focusNode: FocusNode(), // Necessary for the listener to capture events
                 onKeyEvent: (event) {
@@ -87,17 +88,19 @@ class _PinInputState extends State<PinInput> {
                   keyboardType: TextInputType.number,
                   inputFormatters: [FilteringTextInputFormatter.digitsOnly], // Ensure only numbers can be entered
                   textAlign: TextAlign.center,
+                  textAlignVertical: TextAlignVertical.center, // Add vertical alignment
                   // maxLength: 1, // Remove maxLength to handle logic in onChanged
-                  obscureText: false,
+                  obscureText: true,
                   style: inputTextStyling.copyWith(
                     fontWeight: FontWeight.bold,
                     color: isFilled ? Colors.white : Colors.black,
+                    height: 1.0, // Set line height to prevent vertical offset
                   ),
                   decoration: InputDecoration(
                     filled: isFilled,
                     fillColor: borderColor,
                     counterText: '',
-                    contentPadding: const EdgeInsets.symmetric(vertical: 12.0),
+                    contentPadding: const EdgeInsets.fromLTRB(2.0, 16.0, 0, 16.0), // Slight right nudge
                     isDense: true,
                     enabledBorder: OutlineInputBorder(
                       borderRadius: BorderRadius.circular(24),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 2.3.7+1
+version: 2.3.8+1
 
 environment:
   sdk: ^3.9.0


### PR DESCRIPTION
### 🐛 Bug Fixes

*   **Secure PIN Input:** The `PinInput` widget's text fields now have `obscureText` set to `true`. This masks the entered digits with a character (e.g., '•') to prevent shoulder-surfing and improve security. Minor UI adjustments to padding, alignment, and line height have been implemented to ensure the obscured character is properly centered within each input box.
    *   **Fixes #191**

### 🧹 Maintenance & Chores

*   **Version Bump:** The application version has been incremented to `2.3.8+1` in `pubspec.yaml`.