### PR TITLE
chore: Bump application version to 2.3.13

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 2.3.12+1
+version: 2.3.13+1
 
 environment:
   sdk: ^3.10.3


### PR DESCRIPTION
### 🧹 Maintenance & Chores
*   **Application Version Increment:** The project's semantic version in `pubspec.yaml` has been updated from `2.3.12+1` to `2.3.13+1`. This version bump reflects the aggregation of recent internal changes and prepares the application for a new release cycle, ensuring proper version tracking for deployment and package management.