### PR TITLE
feat(ci): Enhance intelligent release note generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,12 +177,12 @@ jobs:
           echo "path=$new_path" >> $GITHUB_OUTPUT
           echo "name=$new_name" >> $GITHUB_OUTPUT
 
-      # Renames the debug APK to include version and build number.
+      # Renames the debug APK to include version only (no build number to allow replacement).
       - name: Rename Debug APK
         id: debug_apk_details
         run: |
           original_path="build/app/outputs/flutter-apk/app-debug.apk"
-          new_name="palapa_inspeksi-v${{ steps.pubspec.outputs.full_version }}-debug.apk"
+          new_name="palapa_inspeksi-v${{ steps.pubspec.outputs.semantic_version }}-debug.apk"
           new_path="build/app/outputs/flutter-apk/$new_name"
           mv "$original_path" "$new_path"
           echo "path=$new_path" >> $GITHUB_OUTPUT


### PR DESCRIPTION
### ✨ New Feature

*   **Version Bump Detection:** Implemented a new step in the release workflow to explicitly check if the application version defined in `pubspec.yaml` has been incremented relative to the `main` branch. This introduces a critical differentiator for the release process, allowing the workflow to distinguish between a new code release and other types of merges, such as routine dependency updates or documentation changes.

### 🛠️ Refactoring & Architectural Changes

*   **Conditional Release Body Generation Logic:** The GitHub Release body generation process has been significantly re-architected to operate with more intelligence and adaptability, based on the version bump status and the PR author. This enhancement provides three distinct behaviors for generating release notes:
    *   **New Code Releases (Version Bumped):** When a version bump is detected, indicating a new feature or fix release, the release notes are now fully generated from the body of the associated Pull Request. If a PR cannot be determined, the commit message serves as the primary content. This ensures that new releases accurately document the user-facing changes and technical details provided in the PR.
    *   **Dependabot Updates (No Version Bump):** For Dependabot-initiated PRs that do not involve a version increment, the workflow will now gracefully *append* the dependency update information to any *existing* release body for that tag. This prevents overwriting valuable, manually curated release notes that might exist for "internal" or non-public releases, while still logging essential dependency changes.
    *   **Human PRs (No Version Bump):** For regular Pull Requests submitted by humans that do not include a version bump, the workflow will now preserve the existing release body for the corresponding tag without any modifications. This avoids generating redundant or generic release notes for merges that do not represent a new product version or user-visible change.

### 🧹 Maintenance & Chores

*   **Non-interactive Android SDK License Acceptance:** The step for accepting Android SDK licenses has been updated to execute in a non-interactive mode using `yes | flutter doctor --android-licenses`. This modification prevents the CI/CD job from pausing or failing due to pending license agreements, thus ensuring smoother and more reliable build processes within the workflow.
*   **Simplified Debug APK Naming:** The naming convention for the debug APK has been streamlined. It will now be named `palapa_inspeksi-v<semantic_version>-debug.apk`, removing the build number component. This change aligns the debug APK naming closer to release APKs by focusing on the semantic version, which can simplify continuous deployment scenarios for debug builds where file replacement by version is common.