### PR TITLE
fix(ui): Implement auto-focus on next field in paint thickness page

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -45,18 +45,6 @@ jobs:
           channel: 'stable'
           cache: true
 
-      # Cache pub dependencies for faster subsequent runs
-      - name: Cache pub dependencies
-        if: steps.code_changes.outputs.skip != 'true'
-        uses: actions/cache@v3
-        with:
-          path: |
-            ${{ env.PUB_CACHE }}
-            ~/.pub-cache
-          key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-pub-
-
       # Creates a dummy .env file for CI purposes, providing a base URL for the API.
       - name: Create dummy .env file
         if: steps.code_changes.outputs.skip != 'true'
@@ -162,18 +150,6 @@ jobs:
           flutter-version: '3.38.4'
           channel: 'stable'
           cache: true
-
-      # Cache pub dependencies for faster subsequent runs
-      - name: Cache pub dependencies
-        if: steps.code_changes.outputs.skip != 'true'
-        uses: actions/cache@v3
-        with:
-          path: |
-            ${{ env.PUB_CACHE }}
-            ~/.pub-cache
-          key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-pub-
 
       # Creates a dummy .env file for CI purposes, providing a base URL for the API.
       - name: Create dummy .env file

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,34 +26,6 @@ jobs:
           channel: 'stable'
           cache: true
 
-      # Cache pub dependencies for faster subsequent runs
-      - name: Cache pub dependencies
-        uses: actions/cache@v3
-        with:
-          path: |
-            ${{ env.PUB_CACHE }}
-            ~/.pub-cache
-          key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-pub-
-
-      # Cache Gradle wrapper and dependencies for faster Android builds
-      - name: Cache Gradle wrapper
-        uses: actions/cache@v3
-        with:
-          path: ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-wrapper-
-
-      - name: Cache Gradle dependencies
-        uses: actions/cache@v3
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-caches-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-caches-
-
       # Note: Android NDK caching removed to prevent disk space issues (NDK is ~1-3GB)
       # GitHub runners already have NDK pre-installed, so caching is unnecessary
       # This saves ~7 minutes in cache post-processing time
@@ -71,6 +43,10 @@ jobs:
       # Installs all project dependencies listed in pubspec.yaml.
       - name: Install dependencies
         run: flutter pub get
+
+      # Sets up Gradle and manages Gradle User Home caching.
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
 
       # Extracts the semantic version from the pubspec.yaml file.
       - name: Extract version from pubspec.yaml

--- a/lib/pages/ketebalan_cat_page.dart
+++ b/lib/pages/ketebalan_cat_page.dart
@@ -16,6 +16,31 @@ class KetebalanCatPage extends ConsumerStatefulWidget {
 
 class _KetebalanCatPage extends ConsumerState<KetebalanCatPage>
     with AutomaticKeepAliveClientMixin {
+  late final List<FocusNode> _focusNodes;
+
+  @override
+  void initState() {
+    super.initState();
+    _focusNodes = List<FocusNode>.generate(13, (_) => FocusNode());
+  }
+
+  @override
+  void dispose() {
+    for (final FocusNode node in _focusNodes) {
+      node.dispose();
+    }
+    super.dispose();
+  }
+
+  void _handleFieldSubmitted(int index) {
+    final bool isLastField = index == _focusNodes.length - 1;
+    if (isLastField) {
+      _focusNodes[index].unfocus();
+      return;
+    }
+
+    _focusNodes[index + 1].requestFocus();
+  }
 
   @override
   bool get wantKeepAlive => true;
@@ -59,6 +84,9 @@ class _KetebalanCatPage extends ConsumerState<KetebalanCatPage>
                           ),
                           PaintThicknessInputField(
                             initialValue: formData.catDepanKap,
+                            focusNode: _focusNodes[0],
+                            textInputAction: TextInputAction.next,
+                            onFieldSubmitted: (_) => _handleFieldSubmitted(0),
                             onChanged: (value) {
                               formNotifier.updateCatDepanKap(value);
                             },
@@ -76,7 +104,7 @@ class _KetebalanCatPage extends ConsumerState<KetebalanCatPage>
               ],
             ),
           ),
-    
+
           // Section 2: Belakang
           SliverToBoxAdapter(
             child: Column(
@@ -97,12 +125,8 @@ class _KetebalanCatPage extends ConsumerState<KetebalanCatPage>
                           child: Align(
                             alignment: Alignment.center,
                             child: ConstrainedBox(
-                              constraints: const BoxConstraints(
-                                maxWidth: 300,
-                              ),
-                              child: Image.asset(
-                                'assets/images/belakang.png',
-                              ),
+                              constraints: const BoxConstraints(maxWidth: 300),
+                              child: Image.asset('assets/images/belakang.png'),
                             ),
                           ),
                         ),
@@ -110,6 +134,9 @@ class _KetebalanCatPage extends ConsumerState<KetebalanCatPage>
                           left: 125.0,
                           child: PaintThicknessInputField(
                             initialValue: formData.catBelakangBumper,
+                            focusNode: _focusNodes[1],
+                            textInputAction: TextInputAction.next,
+                            onFieldSubmitted: (_) => _handleFieldSubmitted(1),
                             onChanged: (value) {
                               formNotifier.updateCatBelakangBumper(value);
                             },
@@ -120,6 +147,9 @@ class _KetebalanCatPage extends ConsumerState<KetebalanCatPage>
                           left: 226.0,
                           child: PaintThicknessInputField(
                             initialValue: formData.catBelakangTrunk,
+                            focusNode: _focusNodes[2],
+                            textInputAction: TextInputAction.next,
+                            onFieldSubmitted: (_) => _handleFieldSubmitted(2),
                             onChanged: (value) {
                               formNotifier.updateCatBelakangTrunk(value);
                             },
@@ -133,7 +163,7 @@ class _KetebalanCatPage extends ConsumerState<KetebalanCatPage>
               ],
             ),
           ),
-    
+
           // Section 3: Samping Kanan
           SliverToBoxAdapter(
             child: Column(
@@ -149,28 +179,36 @@ class _KetebalanCatPage extends ConsumerState<KetebalanCatPage>
                         children: [
                           PaintThicknessInputField(
                             initialValue: formData.catKananFenderBelakang,
+                            focusNode: _focusNodes[3],
+                            textInputAction: TextInputAction.next,
+                            onFieldSubmitted: (_) => _handleFieldSubmitted(3),
                             onChanged: (value) {
-                              formNotifier.updateCatKananFenderBelakang(
-                                value,
-                              );
+                              formNotifier.updateCatKananFenderBelakang(value);
                             },
                           ),
                           PaintThicknessInputField(
                             initialValue: formData.catKananPintuBelakang,
+                            focusNode: _focusNodes[4],
+                            textInputAction: TextInputAction.next,
+                            onFieldSubmitted: (_) => _handleFieldSubmitted(4),
                             onChanged: (value) {
-                              formNotifier.updateCatKananPintuBelakang(
-                                value,
-                              );
+                              formNotifier.updateCatKananPintuBelakang(value);
                             },
                           ),
                           PaintThicknessInputField(
                             initialValue: formData.catKananPintuDepan,
+                            focusNode: _focusNodes[5],
+                            textInputAction: TextInputAction.next,
+                            onFieldSubmitted: (_) => _handleFieldSubmitted(5),
                             onChanged: (value) {
                               formNotifier.updateCatKananPintuDepan(value);
                             },
                           ),
                           PaintThicknessInputField(
                             initialValue: formData.catKananFenderDepan,
+                            focusNode: _focusNodes[6],
+                            textInputAction: TextInputAction.next,
+                            onFieldSubmitted: (_) => _handleFieldSubmitted(6),
                             onChanged: (value) {
                               formNotifier.updateCatKananFenderDepan(value);
                             },
@@ -182,6 +220,9 @@ class _KetebalanCatPage extends ConsumerState<KetebalanCatPage>
                         padding: const EdgeInsets.only(left: 30.0),
                         child: PaintThicknessInputField(
                           initialValue: formData.catKananSideSkirt,
+                          focusNode: _focusNodes[7],
+                          textInputAction: TextInputAction.next,
+                          onFieldSubmitted: (_) => _handleFieldSubmitted(7),
                           onChanged: (value) {
                             formNotifier.updateCatKananSideSkirt(value);
                           },
@@ -194,7 +235,7 @@ class _KetebalanCatPage extends ConsumerState<KetebalanCatPage>
               ],
             ),
           ),
-    
+
           // Section 4: Samping Kiri
           SliverToBoxAdapter(
             child: Column(
@@ -210,30 +251,38 @@ class _KetebalanCatPage extends ConsumerState<KetebalanCatPage>
                         children: [
                           PaintThicknessInputField(
                             initialValue: formData.catKiriFenderDepan,
+                            focusNode: _focusNodes[8],
+                            textInputAction: TextInputAction.next,
+                            onFieldSubmitted: (_) => _handleFieldSubmitted(8),
                             onChanged: (value) {
                               formNotifier.updateCatKiriFenderDepan(value);
                             },
                           ),
                           PaintThicknessInputField(
                             initialValue: formData.catKiriPintuDepan,
+                            focusNode: _focusNodes[9],
+                            textInputAction: TextInputAction.next,
+                            onFieldSubmitted: (_) => _handleFieldSubmitted(9),
                             onChanged: (value) {
                               formNotifier.updateCatKiriPintuDepan(value);
                             },
                           ),
                           PaintThicknessInputField(
                             initialValue: formData.catKiriPintuBelakang,
+                            focusNode: _focusNodes[10],
+                            textInputAction: TextInputAction.next,
+                            onFieldSubmitted: (_) => _handleFieldSubmitted(10),
                             onChanged: (value) {
-                              formNotifier.updateCatKiriPintuBelakang(
-                                value,
-                              );
+                              formNotifier.updateCatKiriPintuBelakang(value);
                             },
                           ),
                           PaintThicknessInputField(
                             initialValue: formData.catKiriFenderBelakang,
+                            focusNode: _focusNodes[11],
+                            textInputAction: TextInputAction.next,
+                            onFieldSubmitted: (_) => _handleFieldSubmitted(11),
                             onChanged: (value) {
-                              formNotifier.updateCatKiriFenderBelakang(
-                                value,
-                              );
+                              formNotifier.updateCatKiriFenderBelakang(value);
                             },
                           ),
                         ],
@@ -243,6 +292,9 @@ class _KetebalanCatPage extends ConsumerState<KetebalanCatPage>
                         padding: const EdgeInsets.only(left: 30.0),
                         child: PaintThicknessInputField(
                           initialValue: formData.catKiriSideSkirt,
+                          focusNode: _focusNodes[12],
+                          textInputAction: TextInputAction.done,
+                          onFieldSubmitted: (_) => _handleFieldSubmitted(12),
                           onChanged: (value) {
                             formNotifier.updateCatKiriSideSkirt(value);
                           },

--- a/lib/widgets/paint_thickness_input_field.dart
+++ b/lib/widgets/paint_thickness_input_field.dart
@@ -6,29 +6,38 @@ class PaintThicknessInputField extends StatefulWidget {
   final double width; // Parameter for the width of the text field
   final ValueChanged<String>? onChanged; // Callback for changes
   final String? initialValue; // Add initialValue parameter
+  final FocusNode? focusNode;
+  final ValueChanged<String>? onFieldSubmitted;
+  final TextInputAction? textInputAction;
 
   const PaintThicknessInputField({
     super.key,
     this.width = 50.0, // Default width
     this.onChanged,
     this.initialValue,
+    this.focusNode,
+    this.onFieldSubmitted,
+    this.textInputAction,
   });
 
   @override
-  State<PaintThicknessInputField> createState() => _PaintThicknessInputFieldState();
+  State<PaintThicknessInputField> createState() =>
+      _PaintThicknessInputFieldState();
 }
 
 class _PaintThicknessInputFieldState extends State<PaintThicknessInputField> {
   late TextEditingController _controller;
   late FocusNode _focusNode;
   late ScrollController _scrollController; // Add ScrollController
+  late bool _ownsFocusNode;
 
   @override
   void initState() {
     super.initState();
     // Initialize the controller with the initial value
     _controller = TextEditingController(text: widget.initialValue);
-    _focusNode = FocusNode();
+    _ownsFocusNode = widget.focusNode == null;
+    _focusNode = widget.focusNode ?? FocusNode();
     _focusNode.addListener(_handleFocusChange);
     _scrollController = ScrollController(); // Initialize ScrollController
   }
@@ -36,6 +45,16 @@ class _PaintThicknessInputFieldState extends State<PaintThicknessInputField> {
   @override
   void didUpdateWidget(covariant PaintThicknessInputField oldWidget) {
     super.didUpdateWidget(oldWidget);
+    if (oldWidget.focusNode != widget.focusNode) {
+      _focusNode.removeListener(_handleFocusChange);
+      if (_ownsFocusNode) {
+        _focusNode.dispose();
+      }
+      _ownsFocusNode = widget.focusNode == null;
+      _focusNode = widget.focusNode ?? FocusNode();
+      _focusNode.addListener(_handleFocusChange);
+    }
+
     if (widget.initialValue != oldWidget.initialValue) {
       if (_controller.text != widget.initialValue) {
         WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -47,7 +66,8 @@ class _PaintThicknessInputFieldState extends State<PaintThicknessInputField> {
               _controller.selection = currentSelection;
             } else {
               _controller.selection = TextSelection.fromPosition(
-                  TextPosition(offset: _controller.text.length));
+                TextPosition(offset: _controller.text.length),
+              );
             }
           }
         });
@@ -66,7 +86,9 @@ class _PaintThicknessInputFieldState extends State<PaintThicknessInputField> {
   void dispose() {
     _controller.dispose();
     _focusNode.removeListener(_handleFocusChange);
-    _focusNode.dispose();
+    if (_ownsFocusNode) {
+      _focusNode.dispose();
+    }
     _scrollController.dispose(); // Dispose ScrollController
     super.dispose();
   }
@@ -83,20 +105,36 @@ class _PaintThicknessInputFieldState extends State<PaintThicknessInputField> {
             controller: _controller,
             focusNode: _focusNode, // Assign the FocusNode
             scrollController: _scrollController, // Assign the ScrollController
-            keyboardType: const TextInputType.numberWithOptions(decimal: true), // Allow decimal input
+            keyboardType: const TextInputType.numberWithOptions(
+              decimal: true,
+            ), // Allow decimal input
+            textInputAction: widget.textInputAction,
             inputFormatters: [
-              FilteringTextInputFormatter.allow(RegExp(r'^\d*\.?\d*')), // Allow digits and one decimal point
+              FilteringTextInputFormatter.allow(
+                RegExp(r'^\d*\.?\d*'),
+              ), // Allow digits and one decimal point
             ],
             onChanged: widget.onChanged, // Use the provided onChanged callback
-            style: disabledToggleTextStyle.copyWith(color: labelTextColor), // Use a text style from app_styles
+            onSubmitted: widget.onFieldSubmitted,
+            style: disabledToggleTextStyle.copyWith(
+              color: labelTextColor,
+            ), // Use a text style from app_styles
             decoration: InputDecoration(
-              contentPadding: const EdgeInsets.only(top: 4.0, bottom: 4.0, left: 4.0, right: 4.0), // Adjust padding
+              contentPadding: const EdgeInsets.only(
+                top: 4.0,
+                bottom: 4.0,
+                left: 4.0,
+                right: 4.0,
+              ), // Adjust padding
               isDense: true,
               hintText: '0.00',
               hintStyle: hintTextStyling.copyWith(fontSize: 14.0),
               border: OutlineInputBorder(
                 borderRadius: BorderRadius.circular(6.0),
-                borderSide: const BorderSide(color: borderColor, width: 2), // Use border color from app_styles
+                borderSide: const BorderSide(
+                  color: borderColor,
+                  width: 2,
+                ), // Use border color from app_styles
               ),
               enabledBorder: OutlineInputBorder(
                 borderRadius: BorderRadius.circular(6.0),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 2.3.22+1
+version: 2.3.23+1
 
 environment:
   sdk: ^3.10.3

--- a/test/pages/ketebalan_cat_page_test.dart
+++ b/test/pages/ketebalan_cat_page_test.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:form_app/models/inspector_data.dart';
+import 'package:form_app/pages/ketebalan_cat_page.dart';
+import 'package:form_app/providers/inspector_provider.dart';
+import 'package:form_app/utils/crashlytics_util.dart';
+
+class FakeCrashlyticsUtil implements CrashlyticsUtil {
+  @override
+  void recordError(
+    dynamic exception,
+    StackTrace? stack, {
+    String? reason,
+    bool fatal = false,
+  }) {}
+}
+
+void main() {
+  testWidgets(
+    'paint thickness fields configure next and done keyboard actions',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            crashlyticsUtilProvider.overrideWith(
+              (ref) => FakeCrashlyticsUtil(),
+            ),
+            inspectorProvider.overrideWith(
+              (ref) => Future.value(<Inspector>[]),
+            ),
+          ],
+          child: const MaterialApp(home: Scaffold(body: KetebalanCatPage())),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      final List<TextField> textFields = tester
+          .widgetList<TextField>(find.byType(TextField))
+          .toList();
+
+      expect(textFields.first.textInputAction, TextInputAction.next);
+      expect(textFields[1].textInputAction, TextInputAction.next);
+      expect(textFields.last.textInputAction, TextInputAction.done);
+    },
+  );
+
+  testWidgets('submitting a paint thickness field focuses the next field', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          crashlyticsUtilProvider.overrideWith((ref) => FakeCrashlyticsUtil()),
+          inspectorProvider.overrideWith((ref) => Future.value(<Inspector>[])),
+        ],
+        child: const MaterialApp(home: Scaffold(body: KetebalanCatPage())),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    final Finder editableFields = find.byType(EditableText);
+
+    await tester.tap(find.byType(TextField).first);
+    await tester.pump();
+
+    expect(
+      tester.widget<EditableText>(editableFields.at(0)).focusNode.hasFocus,
+      isTrue,
+    );
+
+    await tester.testTextInput.receiveAction(TextInputAction.next);
+    await tester.pump();
+
+    expect(
+      tester.widget<EditableText>(editableFields.at(1)).focusNode.hasFocus,
+      isTrue,
+    );
+  });
+}


### PR DESCRIPTION
### 🐛 Bug Fixes
*   **Auto-focus for Paint Thickness Input Fields:** Implemented automatic focus shifting to the next input field on the `Ketebalan Cat` page upon submission of the current field. This enhances usability by streamlining data entry, eliminating the need for manual focus shifts and improving keyboard navigation.
    *   **Fixes #263**

### 🛠️ Refactoring & Architectural Changes
*   **External FocusNode Management for PaintThicknessInputField:** The `PaintThicknessInputField` widget has been refactored to optionally accept an external `FocusNode`, `TextInputAction`, and `onFieldSubmitted` callback. This change allows parent widgets, such as `KetebalanCatPage`, to manage the focus state and keyboard action behavior of individual input fields, enabling more complex and coordinated focus navigation patterns.
*   **Introduced FocusNode and Submission Handling in KetebalanCatPage:** The `_KetebalanCatPage` state now manages a list of `FocusNode` objects, one for each paint thickness input field. A new `_handleFieldSubmitted` method is responsible for programmatically shifting focus to the subsequent field or unfocusing the current one if it's the last field, coordinating keyboard `TextInputAction`s across the form.

### 🧹 Maintenance & Chores
*   **Streamlined CI/CD Caching for Flutter and Gradle:** Removed redundant manual caching steps for `pub` dependencies and `Gradle` wrapper/caches across `pr-checks.yml` and `release.yml` workflows. The `release.yml` now utilizes `gradle/actions/setup-gradle@v4`, which provides integrated, intelligent caching for Gradle, simplifying the workflow and preventing potential cache-related issues.
*   **Version Increment:** Updated the application version in `pubspec.yaml` from `2.3.22+1` to `2.3.23+1`.
*   **Added KetebalanCatPage Widget Tests:** New widget tests have been added to verify the correct configuration of `textInputAction` properties (e.g., `next`, `done`) and the functionality of auto-focusing to the next field upon submission within the `KetebalanCatPage`.